### PR TITLE
Swamp mnist multi-threading

### DIFF
--- a/experimental/swamp-optimization/mnist/README.md
+++ b/experimental/swamp-optimization/mnist/README.md
@@ -10,4 +10,4 @@ Then type `python mnist.py` in the container.  Or,
 docker run --rm -it -v $PWD:/work -w /work pytorch/pytorch python mnist.py
 ```
 
-NOTE: if you are running the example on macOS, please make sure that you give the Docker engine sufficient amount of memory following [this guide](https://docs.docker.com/docker-for-mac/#advanced), or try to use a small number of trainer threads.  Otehrwise, Docker might kill the process without given any error message.
+NOTE: if you are running the example on macOS, please make sure that you give the Docker engine sufficient amount of memory following [this guide](https://docs.docker.com/docker-for-mac/#advanced), or try to use a small number of trainer threads.  Otherwise, Docker might kill the process without giving any error message.

--- a/experimental/swamp-optimization/mnist/mnist.py
+++ b/experimental/swamp-optimization/mnist/mnist.py
@@ -9,6 +9,7 @@ import sys
 import pickle
 import threading
 import queue
+import gc
 
 
 class Net(nn.Module):
@@ -97,6 +98,7 @@ def ps(up, down):
             score = s
             updates = updates + 1
             print("updated", updates, score)
+        gc.collect()
 
 
 def main():
@@ -120,15 +122,11 @@ def main():
 
     torch.manual_seed(args.seed)
 
-    try:
-        up = queue.Queue()
-        down = queue.Queue()
-        for t in range(4):
-            threading.Thread(target=trainer, args=(args, up, down,)).start()
-        ps(up, down)
-    except:
-        print("Caught it!")
-    print("main done")
+    up = queue.Queue()
+    down = queue.Queue()
+    for t in range(4):
+        threading.Thread(target=trainer, args=(args, up, down,)).start()
+    ps(up, down)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
NOTE: if you are running the example on macOS, please make sure that you give the Docker engine sufficient amount of memory following [this guide](https://docs.docker.com/docker-for-mac/#advanced), or try to use a small number of trainer threads.  Otherwise, Docker might kill the process without giving any error message.


```
WangYis-iMac:~/go/src/github.com/wangkuiyi/elasticflow/experimental/swamp-optimization/mnist (swamp-mnist-dist)*$ docker run --rm -it -v $PWD:/work -w /work pytorch/pytorch python mnist.py
updated 1 tensor(2.2415)
updated 2 tensor(2.2390)
updated 3 tensor(2.1798)
updated 4 tensor(2.1671)
updated 5 tensor(2.0580)
updated 6 tensor(1.9010)
updated 7 tensor(1.7039)
updated 8 tensor(1.6941)
updated 9 tensor(1.2861)
updated 10 tensor(0.9625)
updated 11 tensor(0.7719)
updated 12 tensor(0.7247)
updated 13 tensor(0.6691)
updated 14 tensor(0.5181)
updated 15 tensor(0.4509)
updated 16 tensor(0.4273)
updated 17 tensor(0.3832)
updated 18 tensor(0.3493)
```