### PR TITLE
scale the learning rate according to the number of workers 

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -26,6 +26,7 @@ class ThreadLauncher(object):
             for i in range(num_ps)
         ]
         for p in ps:
+            p.set_learning_rate_scale(1.0 / num_worker)
             p.start()
 
         # launch master

--- a/python/elasticdl/tflib/ps/ps_test.py
+++ b/python/elasticdl/tflib/ps/ps_test.py
@@ -10,8 +10,9 @@ from timeit import default_timer as timer
 class ParameterServerTestCase(unittest.TestCase):
     def setUp(self):
         def optimizer():
-            return tf.train.GradientDescentOptimizer(0.1) 
-            
+            # return tf.train.GradientDescentOptimizer(0.1)
+            return {"type": tf.train.GradientDescentOptimizer, "learning_rate": 0.1}
+
         self.ps1 = ParameterServer(
             optimizer,
             {

--- a/python/elasticdl/tflib/worker/worker.py
+++ b/python/elasticdl/tflib/worker/worker.py
@@ -20,7 +20,10 @@ class Worker(object):
         self._ps_client = ps_client
         self._work_queue = work_queue
         self._umd = umd
-        self._opt = umd.optimizer()
+        optimizer = umd.optimizer()
+        opt_type = optimizer.pop('type', None)
+        assert(opt_type)
+        self._opt = opt_type(**optimizer)
         self._model_initialized = False
         self._exiting = False
         self._graph = tf.Graph()

--- a/python/elasticdl/tflib/worker/worker_test.py
+++ b/python/elasticdl/tflib/worker/worker_test.py
@@ -56,7 +56,7 @@ class Dummy(object):
 
     @staticmethod
     def optimizer():
-        return tf.train.GradientDescentOptimizer(0.1)
+        return {"type": tf.train.AdamOptimizer, "learning_rate": 0.1}
 
     @staticmethod
     def _create_model_var():

--- a/test/mnist.py
+++ b/test/mnist.py
@@ -31,7 +31,7 @@ class MnistCNN(UserDefinedModule):
 
     @staticmethod
     def optimizer():
-        return tf.train.AdamOptimizer(learning_rate=0.001)
+        return {'type': tf.train.AdamOptimizer, 'learning_rate': 0.01}
 
     @staticmethod
     def accuracy(output, labels):


### PR DESCRIPTION
scale the learning rate according to the number of workers.
This will help the convergence in async-training regardless of worker number.
Also, we may adjust the learning rate scale for various async/sync strategy later.

Change in user defined model.
For optimizer() method, user provides the type of the optimizer (tf.train.XXXOptimizer) and the parameters of the optimizer, including the learning_rate.
In ps, learning_rate is adjusted by  learning_rate_scale, which we may modify at any time.