### PR TITLE
make validate_max_batch arg robust

### DIFF
--- a/experimental/swamp-optimization/mnist/mnist.py
+++ b/experimental/swamp-optimization/mnist/mnist.py
@@ -248,7 +248,7 @@ class PS(object):
                     total += len(batch_y)
                 else:
                     break
-        loss_val = eval_loss / max_batch
+        loss_val = eval_loss / total * self._args.validate_batch_size
         accuracy = float(correct) / total
         return loss_val, accuracy
 


### PR DESCRIPTION
This will result in correct loss when the user sets valiate_max_batch larger than the number of batches in the test data.