### PR TITLE
add crossover probability for model average with pulled model

### DIFF
--- a/experimental/swamp-optimization/mnist/mnist.py
+++ b/experimental/swamp-optimization/mnist/mnist.py
@@ -144,7 +144,12 @@ class Trainer(object):
 
     def _pull_model(self):
         trained_model = self._trained_model_wrapper.value
-        self._model.load_state_dict(trained_model.model_state)
+        if random.random() < self._args.crossover_probability:
+            s_dict = self._model.state_dict()
+            for k in trained_model.model_state:
+                s_dict[k] = (s_dict[k] + trained_model.model_state[k]) / 2
+        else:
+            self._model.load_state_dict(trained_model.model_state)
         self._score = trained_model.loss
         self._pulled_losses.append(self._score.data.item())
         self._pull_timestamps.append(self._timestamps())
@@ -306,6 +311,8 @@ def parse_args():
         help='how many batches to wait before logging training status')
     parser.add_argument('--pull-probability', type=float, default=0,
                         help='the probability of trainer pulling from ps')
+    parser.add_argument('--crossover-probability', type=float, default=0,
+                        help='the probability of crossover op for model pulling')
     parser.add_argument('--trainer-number', type=int, default=1,
                         help='the total number of trainer to launch')
     return parser.parse_args()


### PR DESCRIPTION
fix #112 

See https://github.com/wangkuiyi/elasticdl/issues/112#issuecomment-449851100  for detail.

Doing model average with the pulled model is better than replace the trainer's model with the pulled model.