### PR TITLE
control evaluation cpu usage.

### DIFF
--- a/experimental/swamp-optimization/mnist/eval.py
+++ b/experimental/swamp-optimization/mnist/eval.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+import os
+import sys
 import argparse
 import torch
 from torchvision import datasets, transforms
@@ -8,7 +10,8 @@ import shutil
 from network import Net
 import torch.nn.functional as F
 import multiprocessing
-from multiprocessing import Pool
+from multiprocessing import Process, Queue
+import queue
 from common import prepare_data_loader
 from common import bool_parser
 
@@ -36,8 +39,7 @@ def _validate(data_loader, model, max_batch, batch_size):
 def _evaluate(job_root_dir, max_validate_batch, validate_batch_size, concurrency):
     # Prepare data source
     validation_ds = prepare_data_loader(False, validate_batch_size, False)
-
-    validation_works = []
+    validation_jobs = Queue()
 
     # Evaluate all the jobs under job_root_dir.
     for parent, dirs, _ in os.walk(job_root_dir):
@@ -68,39 +70,57 @@ def _evaluate(job_root_dir, max_validate_batch, validate_batch_size, concurrency
                                 'timestamp': meta[-1],
                                 'msg': msg_info
                             }
-                            validation_works.append(work_params)
+                            validation_jobs.put(work_params)
     # Start validation
     start_time = time.time()
-    pool = Pool(processes=concurrency)
-    pool.map(_single_validate, validation_works)
-    pool.close()
-    pool.join()
+    job_procs = []
+    for _ in range(concurrency):
+        job = _SingleValidationJob(validation_jobs) 
+        job_proc = Process(target=job.validate)
+        job_proc.start()
+        job_procs.append(job_proc)
+
+    for proc in job_procs:
+        proc.join()
+
     end_time = time.time()
     total_cost = int(end_time - start_time)
     print('validation metrics total cost {} seconds'.format(total_cost))
 
 
-def _single_validate(param_dict):
-    print(param_dict['msg'])
-    model = torch.load(param_dict['job_dir'] + '/model.pkl')
-    model.load_state_dict(torch.load(
-        '{}/{}'.format(param_dict['pkl_dir'], param_dict['param_file'])))
-    loss, accuracy = _validate(
-        param_dict['validation_ds'], model, param_dict['max_batch'], param_dict['batch_size'])
-    eval_filename = param_dict['pkl_dir'] + '/' + \
-        param_dict['param_file'].split('.')[0] + '.eval'
-    if os.path.exists(eval_filename):
-        os.remove(eval_filename)
-    with open(eval_filename, 'w') as eval_f:
-        eval_f.write(
-            '{}_{}_{}'.format(
-                loss, accuracy, int(
-                    param_dict['timestamp'])))
+class _SingleValidationJob(object):
+    def __init__(self, job_queue):
+        self._model = Net() 
+        self._job_queue = job_queue 
 
+    def validate(self):
+        while True:
+            try:
+                param_dict = self._job_queue.get_nowait()
+            except queue.Empty:
+                break 
+            print(param_dict['msg'])
+            #model = torch.load(param_dict['job_dir'] + '/model.pkl')
+            self._model.load_state_dict(torch.load(
+                '{}/{}'.format(param_dict['pkl_dir'], param_dict['param_file'])))
+
+            loss, accuracy = _validate(
+                param_dict['validation_ds'], self._model, param_dict['max_batch'], param_dict['batch_size'])
+            eval_filename = param_dict['pkl_dir'] + '/' + \
+                param_dict['param_file'].split('.')[0] + '.eval'
+
+            if os.path.exists(eval_filename):
+                os.remove(eval_filename)
+            with open(eval_filename, 'w') as eval_f:
+                eval_f.write(
+                    '{}_{}_{}'.format(
+                        loss, accuracy, int(
+                            param_dict['timestamp'])))
 
 def _prepare():
     args = _parse_args()
     torch.manual_seed(args.seed)
+    os.system('export OMP_NUM_THREADS=1')
     return args
 
 
@@ -122,9 +142,10 @@ def _parse_args():
         type=int,
         default=64,
         help='batch size for evaluate model logged by train.py')
-    parser.add_argument('--eval-max-batch', type=int, default=5,
+    parser.add_argument('--eval-max-batch', type=int, default=sys.maxsize,
                         help='max batch for evaluate model logged by train.py')
-    parser.add_argument('--eval-concurrency', type=int, default=2,
+    parser.add_argument('--eval-concurrency', type=int, 
+                        default=int(multiprocessing.cpu_count()/2),
                         help='process concurrency for evaluation')
     return parser.parse_args()
 


### PR DESCRIPTION
1. 每个evaluation进程使用固定的Net Model加载model params，避免每个evaluation job创建一个Net，以节省资源提高速度。
2. 将单个pytorch process中线程池大小调整为1，从而可以精确的控制evaluation阶段的cpu使用量。
3. 在eval.py中默认配置采用全量evaluation数据集。