### PR TITLE
use cmd os.putenv to change env var in python

### DIFF
--- a/experimental/swamp-optimization/mnist/eval.py
+++ b/experimental/swamp-optimization/mnist/eval.py
@@ -122,7 +122,7 @@ class _SingleValidationJob(object):
 def _prepare():
     args = _parse_args()
     torch.manual_seed(args.seed)
-    os.system('export OMP_NUM_THREADS=1')
+    os.putenv('OMP_NUM_THREADS', '1')
     return args
 
 


### PR DESCRIPTION
the original command os.system('export OMP_NUM_THREADS=1') looks invalid in python, instead using os.putenv('OMP_NUM_THREADS', '1') works correctly to control pytorch thread pool size.