### PR TITLE
bugfix for python queue concurrently call

### DIFF
--- a/experimental/swamp-optimization/mnist/eval.py
+++ b/experimental/swamp-optimization/mnist/eval.py
@@ -100,6 +100,7 @@ class _SingleValidationJob(object):
             try:
                 param_dict = self._job_queue.get_nowait()
             except queue.Empty:
+                # workaround for a python queue concurrency bug that the queue may be not empty here.
                 if self._job_queue.qsize() == 0:
                     break
                 else:


### PR DESCRIPTION
多进程并发调用python queue的get_nowait方法时，遇到部分进程抛出queue.Empty的exception，但同时queue.qsize()>0的情况，导致evaluation job进程意外退出。