### PR TITLE
add pulled model version control in trainer

### DIFF
--- a/experimental/swamp-optimization/mnist/train.py
+++ b/experimental/swamp-optimization/mnist/train.py
@@ -69,6 +69,7 @@ class Trainer(object):
         self._loss_fn = nn.CrossEntropyLoss()
         self._gpu_id = gpu_id
         self._gpu_device = None
+        self._last_pull_model_version = -1
 
     def train(self):
         os.environ['CUDA_VISIBLE_DEVICES'] = str(self._gpu_id)
@@ -123,6 +124,11 @@ class Trainer(object):
 
     def _pull_model(self):
         trained_model = self._trained_model_wrapper.value
+
+        if self._last_pull_model_version >= trained_model.version:
+            return
+
+        self._last_pull_model_version = trained_model.version
         coefficient = random.random()
         s_dict = self._model.state_dict()
         for k in trained_model.model_state:


### PR DESCRIPTION
在trainer的pull_model逻辑中添加了pulled model version check，避免和自己之前push to coordinator的model进行average。
从如下实验结果可以看出，通过避免了model regression，accuracy的fluctuation得到了缓解。
![screenshot from 2019-01-10 17-02-58](https://user-images.githubusercontent.com/5202350/50958126-f073a100-14fa-11e9-83ec-a93a1485b0b0.png)
![screenshot from 2019-01-10 17-03-30](https://user-images.githubusercontent.com/5202350/50958131-f36e9180-14fa-11e9-90a2-1271a9d35315.png)
