### PR TITLE
rename func according to PEP8

### DIFF
--- a/elasticdl/master/servicer.py
+++ b/elasticdl/master/servicer.py
@@ -4,7 +4,7 @@ import numpy as np
 import tensorflow as tf
 from proto import master_pb2
 from proto import master_pb2_grpc
-from util.converter import NdarrayToTensor, TensorToNdarray
+from util.ndarray import ndarray_to_tensor, tensor_to_ndarray
 
 
 class MasterServicer(master_pb2_grpc.MasterServicer):
@@ -49,7 +49,7 @@ class MasterServicer(master_pb2_grpc.MasterServicer):
         with self._lock:
             res.version = self._version
             for k, v in self._model.items():
-                res.param[k].CopyFrom(NdarrayToTensor(v.numpy()))
+                res.param[k].CopyFrom(ndarray_to_tensor(v.numpy()))
         return res
 
     def ReportTaskResult(self, request, context):
@@ -86,7 +86,7 @@ class MasterServicer(master_pb2_grpc.MasterServicer):
                     raise ValueError(
                         "Gradient key: %s is not part of model", k
                     )
-                arr = TensorToNdarray(v)
+                arr = tensor_to_ndarray(v)
                 if arr.shape != self._model[k].numpy().shape:
                     raise ValueError(
                         "Gradient key: %s has incompatible dimension", k

--- a/elasticdl/master/servicer_test.py
+++ b/elasticdl/master/servicer_test.py
@@ -8,7 +8,7 @@ tf.enable_eager_execution()
 from google.protobuf import empty_pb2
 
 from proto import master_pb2
-from util.converter import TensorToNdarray, NdarrayToTensor
+from util.ndarray import ndarray_to_tensor, tensor_to_ndarray
 from .servicer import MasterServicer
 
 
@@ -37,7 +37,7 @@ class ServicerTest(unittest.TestCase):
         self.assertEqual(0, model.version)
         self.assertEqual(["x"], list(model.param.keys()))
         np.testing.assert_array_equal(
-            np.array([1.0, 1.0]), TensorToNdarray(model.param["x"])
+            np.array([1.0, 1.0]), tensor_to_ndarray(model.param["x"])
         )
 
         # increase master's model version, now should get version 1
@@ -48,10 +48,10 @@ class ServicerTest(unittest.TestCase):
         self.assertEqual(1, model.version)
         self.assertEqual(["x", "y"], list(model.param.keys()))
         np.testing.assert_array_equal(
-            np.array([2.0, 2.0]), TensorToNdarray(model.param["x"])
+            np.array([2.0, 2.0]), tensor_to_ndarray(model.param["x"])
         )
         np.testing.assert_array_equal(
-            np.array([12.0, 13.0]), TensorToNdarray(model.param["y"])
+            np.array([12.0, 13.0]), tensor_to_ndarray(model.param["y"])
         )
 
         # try to get version 2, it should raise exception.
@@ -63,10 +63,10 @@ class ServicerTest(unittest.TestCase):
             """ Make a ReportTaskResultRequest compatible with model"""
             req = master_pb2.ReportTaskResultRequest()
             req.gradient["x"].CopyFrom(
-                NdarrayToTensor(np.array([0.1], dtype=np.float32))
+                ndarray_to_tensor(np.array([0.1], dtype=np.float32))
             )
             req.gradient["y"].CopyFrom(
-                NdarrayToTensor(np.array([0.1, 0.2], dtype=np.float32))
+                ndarray_to_tensor(np.array([0.1, 0.2], dtype=np.float32))
             )
             req.model_version = 1
             return req
@@ -98,14 +98,14 @@ class ServicerTest(unittest.TestCase):
         # Report a unknown gradient, should raise.
         req = makeGrad()
         req.gradient["z"].CopyFrom(
-            NdarrayToTensor(np.array([0.1], dtype=np.float32))
+            ndarray_to_tensor(np.array([0.1], dtype=np.float32))
         )
         self.assertRaises(ValueError, master.ReportTaskResult, req, None)
 
         # Report an incompatible gradient, should raise.
         req = makeGrad()
         req.gradient["y"].CopyFrom(
-            NdarrayToTensor(np.array([0.1], dtype=np.float32))
+            ndarray_to_tensor(np.array([0.1], dtype=np.float32))
         )
         self.assertRaises(ValueError, master.ReportTaskResult, req, None)
 

--- a/elasticdl/util/ndarray.py
+++ b/elasticdl/util/ndarray.py
@@ -2,7 +2,7 @@ import numpy as np
 from proto import master_pb2
 
 
-def TensorToNdarray(tensor_pb):
+def tensor_to_ndarray(tensor_pb):
     """
     Create an ndarray from Tensor proto message. Note: upon return, the input
     tensor message is reset and underlying buffer passed to the returned
@@ -30,7 +30,7 @@ def TensorToNdarray(tensor_pb):
     return arr
 
 
-def NdarrayToTensor(arr):
+def ndarray_to_tensor(arr):
     """Convert ndarray to Tensor PB"""
 
     if arr.dtype != np.float32:

--- a/elasticdl/util/ndarray_test.py
+++ b/elasticdl/util/ndarray_test.py
@@ -2,55 +2,55 @@ import numpy as np
 import unittest
 
 from proto import master_pb2
-from .converter import NdarrayToTensor, TensorToNdarray
+from .ndarray import ndarray_to_tensor, tensor_to_ndarray
 
 
 class ConverterTest(unittest.TestCase):
-    def testNdarrayToTensor(self):
+    def test_ndarray_to_tensor(self):
         # Wrong type, should raise
         arr = np.array([1, 2, 3, 4])
-        self.assertRaises(ValueError, NdarrayToTensor, arr)
+        self.assertRaises(ValueError, ndarray_to_tensor, arr)
 
         # Empty array
         arr = np.array([], dtype=np.float32)
-        t = NdarrayToTensor(arr)
+        t = ndarray_to_tensor(arr)
         self.assertEqual([0], t.dim)
         self.assertEqual(0, len(t.content))
 
         # Pathological case, one of the dimensions is 0.
         arr = np.ndarray(shape=[2, 0, 1, 9], dtype=np.float32)
-        t = NdarrayToTensor(arr)
+        t = ndarray_to_tensor(arr)
         self.assertEqual([2, 0, 1, 9], t.dim)
         self.assertEqual(0, len(t.content))
 
         # 1-D array
         arr = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
-        t = NdarrayToTensor(arr)
+        t = ndarray_to_tensor(arr)
         self.assertEqual([4], t.dim)
         self.assertEqual(4 * 4, len(t.content))
 
         # 4-D random array
         arr = np.ndarray(shape=[2, 1, 3, 4], dtype=np.float32)
-        t = NdarrayToTensor(arr)
+        t = ndarray_to_tensor(arr)
         self.assertEqual([2, 1, 3, 4], t.dim)
         self.assertEqual(4 * 2 * 1 * 3 * 4, len(t.content))
 
-    def testTensorToNdarray(self):
+    def testtensor_to_ndarray(self):
         t = master_pb2.Tensor()
         # No dim defined, should raise.
-        self.assertRaises(ValueError, TensorToNdarray, t)
+        self.assertRaises(ValueError, tensor_to_ndarray, t)
 
         # Empty array, should be ok.
         t.dim.append(0)
         t.content = b""
-        arr = TensorToNdarray(t)
+        arr = tensor_to_ndarray(t)
         np.testing.assert_array_equal(np.array([], dtype=np.float32), arr)
 
         # Pathological case, one of the dimensions is 0.
         del t.dim[:]
         t.dim.extend([2, 0, 1, 9])
         t.content = b""
-        arr = TensorToNdarray(t)
+        arr = tensor_to_ndarray(t)
         np.testing.assert_array_equal(
             np.ndarray(shape=[2, 0, 1, 9], dtype=np.float32), arr
         )
@@ -60,18 +60,18 @@ class ConverterTest(unittest.TestCase):
         # Wrong content size, should raise
         del t.dim[:]
         t.dim.extend([11])
-        self.assertRaises(ValueError, TensorToNdarray, t)
+        self.assertRaises(ValueError, tensor_to_ndarray, t)
 
         # Compatible dimensions, should be ok.
         for m in (1, 2, 3, 4, 6, 12):
             del t.dim[:]
             t.content = b"\0" * (4 * 12)
             t.dim.extend([m, 12 // m])
-            arr = TensorToNdarray(t)
+            arr = tensor_to_ndarray(t)
 
     def testRoundTrip(self):
         def verify(a):
-            b = TensorToNdarray(NdarrayToTensor(a))
+            b = tensor_to_ndarray(ndarray_to_tensor(a))
             np.testing.assert_array_equal(a, b)
 
         # 1-D array

--- a/elasticdl/worker/worker_test.py
+++ b/elasticdl/worker/worker_test.py
@@ -29,25 +29,24 @@ class TestModel(object):
         x1 = tf.keras.layers.Dense(1)(input1)
         self._model = tf.keras.models.Model(input1, x1)
 
-    def GetKerasModel(self):
+    def get_keras_model(self):
         return self._model
 
-    def Output(self, data):
+    def output(self, data):
         return self._model.call(data['x'])
 
-    def Loss(self, output, data):
+    def loss(self, output, data):
         return tf.reduce_mean(tf.square(output - data['y']))
 
 
 class WorkerTest(unittest.TestCase):
-    def testLocalTrain(self):
+    def test_local_train(self):
         tf.enable_eager_execution()
         worker = Worker(TestModel, input_fn, get_optimizer)
         batch_size = 32
         epoch = 2
-        worker.LocalTrain(batch_size, epoch)
         try:
-            worker.LocalTrain(batch_size, epoch)
+            worker.local_train(batch_size, epoch)
             res = True
         except Exception as ex:
             print(ex)


### PR DESCRIPTION
1. change func names according to PEP8
2. rename converter.py ndarray.py
3. some minor fix in worker.py