### PR TITLE
worker methods to support grpc calls

### DIFF
--- a/elasticdl/worker/worker_test.py
+++ b/elasticdl/worker/worker_test.py
@@ -121,8 +121,8 @@ class WorkerTest(unittest.TestCase):
                                 16,
                                 get_optimizer(),
                                 task_q)
-        for n in worker._name_var_dict:
-            master._set_model_var(n, worker._name_var_dict[n].numpy())
+        for var in worker._keras_model.variables:
+            master._set_model_var(Worker.replaced_name(var.name), var.numpy())
 
         with mock.patch.object(worker._stub, 'GetTask', mock_GetTask),                   \
                 mock.patch.object(worker._stub, 'GetModel', mock_GetModel),              \


### PR DESCRIPTION
# Implementation
Implement the methods related to grpc calls in Worker:
- get_task
- get_model
- report_task_result
- report_gradient

# Testing
In testing, create a local master, and mock the grpc calls by stub to the corresponding master calls.

# Issues
In `MasterServicer._set_model_var`, it calls `tf.Variable()`.  `tf.Variable()` will fail if there exists ':' in variable name. Thus, replace ':' with '-' to workaround it.

fix #235 #236 