### PR TITLE
Retrain the minibatch when gradients are not accepted

### DIFF
--- a/elasticdl/worker/worker_test.py
+++ b/elasticdl/worker/worker_test.py
@@ -105,7 +105,7 @@ class WorkerTest(unittest.TestCase):
             return master.GetModel(req, None)
 
         def mock_ReportGradient(req):
-            if master._version > 2 and master._version < 20:
+            if master._version > 2 and master._version < 80:
                 # For testing of retrain when gradient not accepted.
                 # Increase master version so the gradient will not be accepted.
                 master._version += 1


### PR DESCRIPTION
Retrain the minibatch if its gradients are not accepted by the master due to old model version.
Fail the task if the number of continuous retrain exceeds a threshold.

fix #290 