### PR TITLE
Remove unsupported types

### DIFF
--- a/elasticdl/data/tf_example_codec.py
+++ b/elasticdl/data/tf_example_codec.py
@@ -1,53 +1,48 @@
-from enum import Enum 
+from enum import Enum
 import tensorflow as tf
 
-class TFExampleCodec(object):
 
+class TFExampleCodec(object):
     def __init__(self, feature_schema):
-        self._f_schema = feature_schema
         self._f_desc = {}
-        self._f_name2type = dict(feature_schema) 
-        for f_name, f_type, in self._f_name2type.items():
-            category = _type_category(f_type)
-            if category == _TypeCategory.STR:
-                self._f_desc[f_name] = tf.FixedLenFeature([], tf.string, default_value='')
-            elif category == _TypeCategory.FLOAT:
-                self._f_desc[f_name] = tf.FixedLenFeature([], f_type, default_value=0.0)
-            elif category == _TypeCategory.INT:
-                self._f_desc[f_name] = tf.FixedLenFeature([], f_type, default_value=0)
+        self._f_name2type = dict(feature_schema)
+        for f_name, f_type in self._f_name2type.items():
+            if f_type == tf.string:
+                self._f_desc[f_name] = tf.FixedLenFeature(
+                    [], tf.string, default_value=""
+                )
+            elif f_type in (tf.int64, tf.float32):
+                self._f_desc[f_name] = tf.FixedLenFeature(
+                    [], f_type, default_value=f_type.as_numpy_dtype(0)
+                )
             else:
-                raise ValueError("not supported tensorflow data type.")
+                raise ValueError(
+                    "not supported tensorflow data type: " + f_type
+                )
 
     def encode(self, example):
         f_dict = {}
         for f_name, f_value in example:
             f_type = self._f_name2type[f_name]
             if f_type == tf.string:
-                f_dict[f_name] = tf.train.Feature(bytes_list=tf.train.BytesList(value=[f_value]))
-            elif f_type in (tf.float32, tf.float64):
-                f_dict[f_name] = tf.train.Feature(float_list=tf.train.FloatList(value=[f_value]))
-            elif f_type in (tf.bool, tf.int32, tf.uint32, tf.int64, tf.uint64):
-                f_dict[f_name] = tf.train.Feature(int64_list=tf.train.Int64List(value=[f_value]))
+                f_dict[f_name] = tf.train.Feature(
+                    bytes_list=tf.train.BytesList(value=[f_value])
+                )
+            elif f_type == tf.float32:
+                f_dict[f_name] = tf.train.Feature(
+                    float_list=tf.train.FloatList(value=[f_value])
+                )
+            elif f_type == tf.int64:
+                f_dict[f_name] = tf.train.Feature(
+                    int64_list=tf.train.Int64List(value=[f_value])
+                )
             else:
-                raise ValueError("not supported tensorflow data type.")
+                raise ValueError(
+                    "not supported tensorflow data type: " + f_type
+                )
 
         example = tf.train.Example(features=tf.train.Features(feature=f_dict))
         return example.SerializeToString()
 
     def decode(self, raw):
         return tf.parse_single_example(raw, self._f_desc)
-
-class _TypeCategory(Enum):
-    STR = 1
-    INT = 2
-    FLOAT =3
-
-def _type_category(f_type):
-    if f_type == tf.string:
-        return _TypeCategory.STR 
-    elif f_type.is_floating:
-        return _TypeCategory.FLOAT
-    elif f_type == tf.bool or f_type.is_integer:
-        return _TypeCategory.INT
-    else:
-        return None

--- a/elasticdl/data/tf_example_codec_test.py
+++ b/elasticdl/data/tf_example_codec_test.py
@@ -3,15 +3,20 @@ import tempfile
 import os
 import tensorflow as tf
 import numpy as np
-from coded_recordio import File
-from tf_example_codec import TFExampleCodec
+from .coded_recordio import File
+from .tf_example_codec import TFExampleCodec
+
 
 class TestTFExampleCodec(unittest.TestCase):
     """ Test tf_example_codec.py
     """
 
     def test_encode_and_decode(self):
-        feature_schema = [("f0", tf.string), ("f1", tf.float32), ("label", tf.int64)]
+        feature_schema = [
+            ("f0", tf.string),
+            ("f1", tf.float32),
+            ("label", tf.int64),
+        ]
         example_1 = [("f0", b"abc"), ("f1", 100.1), ("label", 1)]
         example_2 = [("f0", b"def"), ("f1", 200.1), ("label", 2)]
         example_3 = [("f0", b"ghi"), ("f1", 300.1), ("label", 3)]
@@ -32,12 +37,15 @@ class TestTFExampleCodec(unittest.TestCase):
                 for idx in range(coded_r.count()):
                     exp = coded_r.get(idx)
                     expected_exp = examples[idx]
-                    f_0, f_1, label = session.run([exp["f0"], exp["f1"], exp["label"]])
+                    f_0, f_1, label = session.run(
+                        [exp["f0"], exp["f1"], exp["label"]]
+                    )
                     self.assertEqual(f_0, expected_exp[0][1])
                     self.assertEqual(f_1, np.float32(expected_exp[1][1]))
                     self.assertEqual(label, np.int64(expected_exp[2][1]))
 
         os.remove(tmp_file.name)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Since decoding only supports tf.float32, tf.int64 and tf.string. We should only support these 3 types in encoding as well.
ref #287 