### PR TITLE
add training argument in model.call to support non-trainable weights update

### DIFF
--- a/elasticdl/examples/mnist/mnist.py
+++ b/elasticdl/examples/mnist/mnist.py
@@ -25,13 +25,14 @@ class MnistModel(tf.keras.Model):
         self._flatten = tf.keras.layers.Flatten()
         self._dense = tf.keras.layers.Dense(10)
 
-    def call(self, inputs):
+    def call(self, inputs, training=False):
         x = self._reshape(inputs)
         x = self._conv1(x)
         x = self._conv2(x)
-        x = self._batch_norm(x)
+        x = self._batch_norm(x, training=training)
         x = self._maxpooling(x)
-        x = self._dropout(x)
+        if training:
+            x = self._dropout(x, training=training)
         x = self._flatten(x)
         x = self._dense(x)
         return x

--- a/elasticdl/worker/worker.py
+++ b/elasticdl/worker/worker.py
@@ -114,7 +114,7 @@ class Worker(object):
                                     inputs.append(batch_input_data[input_name])
                                 if len(inputs) == 1:
                                     inputs = inputs[0]
-                                outputs = self._model.call(inputs)
+                                outputs = self._model.call(inputs, training=True)
                                 loss = self._model.loss(outputs, batch_input_data)
 
                                 # TODO:  Add regularization loss if any,
@@ -164,7 +164,7 @@ class Worker(object):
                                 inputs.append(data[input_name])
                             if len(inputs) == 1:
                                 inputs = inputs[0]
-                            outputs = self._model.call(inputs)
+                            outputs = self._model.call(inputs, training=True)
                             loss = self._model.loss(outputs, data)
 
                             # Add regularization loss if any.

--- a/elasticdl/worker/worker_test.py
+++ b/elasticdl/worker/worker_test.py
@@ -21,7 +21,7 @@ class TestModel(tf.keras.Model):
         super(TestModel, self).__init__(name='test_model')
         self.dense = tf.keras.layers.Dense(1)
 
-    def call(self, inputs):
+    def call(self, inputs, training=False):
         return self.dense(inputs)
 
     @staticmethod


### PR DESCRIPTION
Add training argument in model.call to support non-trainable weight update.
Non-trainable weights exist in certain layers such as BatchNorm, RNN, etc.

fix #295 