### PR TITLE
Fix record_codec import when building dev docker image

### DIFF
--- a/dockerfile/elasticdl.dev
+++ b/dockerfile/elasticdl.dev
@@ -21,7 +21,7 @@ ENV PYTHONPATH=/
 
 # RecordIO dataset generator
 COPY recordio_ds_gen /recordio_ds_gen  
-COPY record_codec /elasticdl/record_codec
+COPY record_codec /record_codec
 RUN python /recordio_ds_gen/mnist/gen_data.py --codec-type tf_example /data
 RUN python /recordio_ds_gen/cifar10/gen_data.py /data
 

--- a/recordio_ds_gen/mnist/gen_data.py
+++ b/recordio_ds_gen/mnist/gen_data.py
@@ -11,8 +11,8 @@ import sys
 import tensorflow as tf
 import numpy as np
 from recordio import File
-from elasticdl.record_codec.tf_example_codec import TFExampleCodec
-from elasticdl.record_codec.bytes_codec import BytesCodec 
+from record_codec.tf_example_codec import TFExampleCodec
+from record_codec.bytes_codec import BytesCodec
 from tensorflow.python.keras.datasets import mnist, fashion_mnist
 
 


### PR DESCRIPTION
Following dev guide: https://github.com/wangkuiyi/elasticdl/tree/develop/elasticdl
The following error occurred:
```
Step 10/15 : RUN python /recordio_ds_gen/mnist/gen_data.py --codec-type tf_example /data
 ---> Running in 40fc675fd3b4
Traceback (most recent call last):
  File "/recordio_ds_gen/mnist/gen_data.py", line 14, in <module>
    from elasticdl.record_codec.tf_example_codec import TFExampleCodec
ImportError: No module named 'elasticdl'
```
This PR fixes this `ImportError`. 