### PR TITLE
Fix docker run -w argument

### DIFF
--- a/elasticdl/README.md
+++ b/elasticdl/README.md
@@ -31,7 +31,7 @@ Could also start Docker container and run unittests in a single command:
 ```bash
 docker run --rm -u $(id -u):$(id -g) -it \
     -v $HOME/git/elasticdl:/elasticdl \
-    -w /elasticdl/elasticdl \
+    -w /elasticdl \
     elasticdl:dev \
     bash -c "make && python -m unittest -v */*_test.py"
 ```


### PR DESCRIPTION
Currently, the following command
```
docker run --rm -u $(id -u):$(id -g) -it \
    -v $EDL_REPO:/elasticdl \
    -w /elasticdl/elasticdl \
    elasticdl:dev \
    bash -c "make && python -m unittest -v */*_test.py"
```
results in
```
make: *** No targets specified and no makefile found.  Stop.
```
This PR fixes that since the second "elasticdl" is not needed.