### PR TITLE
Format labels for launched master/workers

### DIFF
--- a/elasticdl/manifests/examples/elasticdl-demo-k8s.yaml
+++ b/elasticdl/manifests/examples/elasticdl-demo-k8s.yaml
@@ -1,7 +1,10 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test-mnist
+  name: elasticdl-master-test-mnist
+  labels:
+    app: elasticdl
+    elasticdl_job_name: test-mnist
 spec:
   containers:
   - name: mnist-demo-container
@@ -21,7 +24,7 @@ spec:
       --minibatch_size=64
       --num_worker=2
       --worker_image=elasticdl:dev
-      --job_name=edl-train
+      --job_name=test-mnist
     imagePullPolicy: IfNotPresent
     env:
       - name: MY_POD_IP

--- a/elasticdl/manifests/examples/elasticdl-demo-minikube.yaml
+++ b/elasticdl/manifests/examples/elasticdl-demo-minikube.yaml
@@ -1,7 +1,10 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test-mnist
+  name: elasticdl-master-test-mnist
+  labels:
+    app: elasticdl
+    elasticdl_job_name: test-mnist
 spec:
   containers:
   - name: mnist-demo-container
@@ -23,7 +26,7 @@ spec:
       --worker_image=elasticdl:dev
       --worker_cpu_request=100m
       --worker_memory_request=100Mi
-      --job_name=edl-train
+      --job_name=test-mnist
     imagePullPolicy: Never
     env:
       - name: MY_POD_IP

--- a/elasticdl/python/data/recordio_gen/cifar10/show_data.py
+++ b/elasticdl/python/data/recordio_gen/cifar10/show_data.py
@@ -12,7 +12,7 @@ from data.codec import BytesCodec
 def main(argv):
     print(argv)
     parser = argparse.ArgumentParser(
-        description="Show same data from CIFAR10 recordio"
+        description="Show some data from CIFAR10 recordio"
     )
     parser.add_argument("file", help="RecordIo file to read")
     parser.add_argument(

--- a/elasticdl/python/data/recordio_gen/mnist/show_data.py
+++ b/elasticdl/python/data/recordio_gen/mnist/show_data.py
@@ -11,7 +11,7 @@ tf.enable_eager_execution()
 def main(argv):
     print(argv)
     parser = argparse.ArgumentParser(
-        description="Show same data from mnist recordio"
+        description="Show some data from mnist recordio"
     )
     parser.add_argument("file", help="RecordIo file to read")
     parser.add_argument(

--- a/elasticdl/python/elasticdl/client/client.py
+++ b/elasticdl/python/elasticdl/client/client.py
@@ -51,7 +51,8 @@ kind: Pod
 metadata:
   name: "elasticdl-master-{job_name}"
   labels:
-    purpose: test-command
+    app: elasticdl
+    elasticdl_job_name: {job_name}
 spec:
   containers:
   - name: "elasticdl-master-{job_name}"
@@ -175,7 +176,7 @@ def main():
     args, argv = parser.parse_known_args()
     _validate_params(args)
 
-    job_name = args.job_name + "-" + str(int(round(time.time() * 1000)))
+    job_name = args.job_name
     image_name = args.image_base + '_' + job_name 
     _build_docker_image(args.model_file, image_name, image_base=args.image_base,
         repository=args.repository)

--- a/elasticdl/python/elasticdl/master/k8s.py
+++ b/elasticdl/python/elasticdl/master/k8s.py
@@ -44,7 +44,7 @@ class Client(object):
         stream = watch.Watch().stream(
             self._v1.list_namespaced_pod,
             self._ns,
-            label_selector="elasticdl=" + self._job_name,
+            label_selector = "elasticdl_job_name=" + self._job_name,
         )
         for event in stream:
             self._event_cb(event)
@@ -87,10 +87,13 @@ class Client(object):
             spec.priority_class_name = pod_priority
 
         pod = client.V1Pod(
-            spec=spec,
-            metadata=client.V1ObjectMeta(
-                name=self.get_pod_name(worker_id),
-                labels={"elasticdl": self._job_name},
+            spec = spec,
+            metadata = client.V1ObjectMeta(
+                name = self.get_pod_name(worker_id),
+                labels = {
+                    "app": "elasticdl",
+                    "elasticdl_job_name": self._job_name
+                },
             ),
         )
         return pod


### PR DESCRIPTION
Directly use user-typed job_name, instead of attaching a random number, to make sure users can use `kubectl get pods -l {job_name}` to list all master/workers for his/her submitted job.

