### PR TITLE
Misc optimizations on Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
-language: python
+dist: xenial
+language: minimal
+
+services:
+  - docker
 
 script:
   - set -e


### PR DESCRIPTION
Speed up Travis CI build via:
* Switch to use "minimal" distribution instead of Python
* Start `docker` service since this is all we need for now