### PR TITLE
Remove unused python path

### DIFF
--- a/elasticdl/docker/Dockerfile
+++ b/elasticdl/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN pip install pytest --extra-index-url=${EXTRA_PYPI_INDEX}
 # Install RecordIO 
 RUN pip install 'pyrecordio>=0.0.6' --extra-index-url=${EXTRA_PYPI_INDEX}
 
-ENV PYTHONPATH=/:/elasticdl/python/
+ENV PYTHONPATH=/
 
 WORKDIR /
 COPY elasticdl /elasticdl


### PR DESCRIPTION
After making elasticdl root dir as a package, the path /elasticdl/python/ doesn't need to be in PYTHONPATH anymore.