### PR TITLE
Not delete worker pods when job finishes

### DIFF
--- a/elasticdl/python/elasticdl/master/main.py
+++ b/elasticdl/python/elasticdl/master/main.py
@@ -184,10 +184,6 @@ def main():
     except KeyboardInterrupt:
         logger.warning("Server stopping")
 
-    if args.num_worker:
-        # TODO: worker_manager.remove_workers supports synchronized call
-        worker_manager.remove_workers()
-
     server.stop(0)
 
 


### PR DESCRIPTION
When entire training finishes, we should keep workers there (with COMPLETE status). Thus, users still can fetch and check all logs.