### PR TITLE
Fixes #509: Add proto definitions and service for reporting evaluation metrics

### DIFF
--- a/elasticdl/proto/elasticdl.proto
+++ b/elasticdl/proto/elasticdl.proto
@@ -58,7 +58,7 @@ message ReportGradientRequest {
     map<string, Tensor> gradient = 3;
 }
 
-message ReportGradientReply {
+message ReportGradientResponse {
     // If the gradient is accepted.
     bool accepted = 1;
     // Current model version on master.
@@ -73,7 +73,7 @@ message ReportTaskResultRequest {
     string err_message = 2;
 }
 
-message ReportEvaluationMetricsReply {
+message ReportEvaluationMetricsResponse {
     // If the evaluation metric is accepted.
     bool accepted = 1;
     // Current model version on master.
@@ -89,7 +89,7 @@ message ReportEvaluationMetricsRequest {
 service Master {
     rpc GetTask(GetTaskRequest) returns (Task);
     rpc GetModel(GetModelRequest) returns (Model);
-    rpc ReportGradient(ReportGradientRequest) returns (ReportGradientReply);
-    rpc ReportEvaluationMetrics(ReportEvaluationMetricsRequest) returns (ReportEvaluationMetricsReply);
+    rpc ReportGradient(ReportGradientRequest) returns (ReportGradientResponse);
+    rpc ReportEvaluationMetrics(ReportEvaluationMetricsRequest) returns (ReportEvaluationMetricsResponse);
     rpc ReportTaskResult(ReportTaskResultRequest) returns (google.protobuf.Empty);
 }

--- a/elasticdl/python/elasticdl/master/servicer.py
+++ b/elasticdl/python/elasticdl/master/servicer.py
@@ -108,7 +108,7 @@ class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
     def ReportGradient(self, request, _):
         invalid_model_version = self._validate_model_version(request.model_version)
 
-        res = elasticdl_pb2.ReportGradientReply()
+        res = elasticdl_pb2.ReportGradientResponse()
         if invalid_model_version:
             res.accepted = False
             res.model_version = self._version
@@ -156,7 +156,7 @@ class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
     def ReportEvaluationMetrics(self, request, _):
         invalid_model_version = self._validate_model_version(request.model_version)
 
-        res = elasticdl_pb2.ReportEvaluationMetricsReply()
+        res = elasticdl_pb2.ReportEvaluationMetricsResponse()
         if invalid_model_version:
             res.accepted = False
             res.model_version = self._version


### PR DESCRIPTION
This sets up initial proto definitions and service for reporting evaluation metrics, in order to support model evaluation task. Also moved model version validation to an internally reusable function. 

This fixes #509.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>