### PR TITLE
Rename outputs to predictions in loss function

### DIFF
--- a/elasticdl/python/tests/test_module.py
+++ b/elasticdl/python/tests/test_module.py
@@ -9,8 +9,8 @@ outputs = Dense(1)(inputs)
 model = Model(inputs, outputs)
 
 
-def loss(outputs, labels):
-    return tf.reduce_mean(tf.square(outputs - labels)) 
+def loss(predictions, labels):
+    return tf.reduce_mean(tf.square(predictions - labels)) 
 
 
 def feature_columns():


### PR DESCRIPTION
To avoid shadowing name `outputs` already defined in outer scope as part of the model definition: `outputs = Dense(1)(inputs)`. 