### PR TITLE
Add missing eval shards in tests

### DIFF
--- a/elasticdl/python/tests/k8s_worker_manager_test.py
+++ b/elasticdl/python/tests/k8s_worker_manager_test.py
@@ -17,7 +17,7 @@ class WorkerManagerTest(unittest.TestCase):
         "No Kubernetes cluster available",
     )
     def testCreateDeleteWorkerPod(self):
-        task_q = _TaskQueue({"f": 10}, 1, 1)
+        task_q = _TaskQueue({"f": 10}, {}, 1, 1)
         task_q.recover_tasks = MagicMock()
         worker_manager = WorkerManager(
             task_q,
@@ -58,7 +58,7 @@ class WorkerManagerTest(unittest.TestCase):
         Start a pod running a python program destined to fail with restart_policy="Never"
         to test failed_worker_count
         """
-        task_q = _TaskQueue({"f": 10}, 1, 1)
+        task_q = _TaskQueue({"f": 10}, {}, 1, 1)
         task_q.recover_tasks = MagicMock()
         worker_manager = WorkerManager(
             task_q,
@@ -95,7 +95,7 @@ class WorkerManagerTest(unittest.TestCase):
         "No Kubernetes cluster available",
     )
     def testRelaunchWorkerPod(self):
-        task_q = _TaskQueue({"f": 10}, 1, 1)
+        task_q = _TaskQueue({"f": 10}, {}, 1, 1)
         worker_manager = WorkerManager(
             task_q,
             job_name="test-relaunch-worker-pod",


### PR DESCRIPTION
These tests are not being checked since we only run tests with `K8S_TESTS=False` on Travis.