### PR TITLE
Update pre-commit-hooks to use an newer version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.3.0
+    rev: v2.2.3
     hooks:
     -   id: flake8
 -   repo: git://github.com/skorokithakis/pre-commit-mypy


### PR DESCRIPTION
There have been many good fixes since v1.3.0. It's better to switch to the latest version: v2.2.3.