### PR TITLE
Fix docker build issue with 404 not found

### DIFF
--- a/elasticdl/docker/Dockerfile
+++ b/elasticdl/docker/Dockerfile
@@ -1,8 +1,7 @@
 ARG BASE_IMAGE=tensorflow/tensorflow:1.13.1-py3
 FROM ${BASE_IMAGE}
 
-RUN apt-get update
-RUN apt-get install -y unzip curl git
+RUN apt-get update && apt-get install -y unzip curl git
 
 ARG EXTRA_PYPI_INDEX
 


### PR DESCRIPTION
To fix the issue of:
```
Err:36 http://security.ubuntu.com/ubuntu xenial-security/main amd64 libcurl3-gnutls amd64 7.47.0-1ubuntu2.12
  404  Not Found [IP: 91.189.88.152 80]
Get:37 http://archive.ubuntu.com/ubuntu xenial/main amd64 libedit2 amd64 3.1-20150325-1ubuntu2 [76.5 kB]
Get:38 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libsasl2-modules amd64 2.1.26.dfsg1-14ubuntu0.1 [47.5 kB]
Get:39 http://archive.ubuntu.com/ubuntu xenial/main amd64 libxmuu1 amd64 2:1.1.2-2 [9674 B]
Get:40 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 openssh-client amd64 1:7.2p2-4ubuntu2.8 [590 kB]
Err:36 http://security.ubuntu.com/ubuntu xenial-security/main amd64 libcurl3-gnutls amd64 7.47.0-1ubuntu2.12
  404  Not Found [IP: 91.189.88.152 80]
```

This would happen when a new package needs to be installed by apt-get. More details in 
 https://stackoverflow.com/questions/37706635/in-docker-apt-get-install-fails-with-failed-to-fetch-http-archive-ubuntu-com