### PR TITLE
Update instruction on data image and fix data path in examples

### DIFF
--- a/elasticdl/README.md
+++ b/elasticdl/README.md
@@ -2,7 +2,7 @@
 
 ## The Development Docker Image
 
-Development Docker image contains ElasticDL system code and processed demo data in RecordIO format. We first build the demo data image. This only need to be built once.
+Development Docker image contains ElasticDL system code and processed demo data in RecordIO format. We first build the demo data image. This only needs to be built once.
 
 ```bash
 docker build \
@@ -27,17 +27,7 @@ docker build \
     --build-arg BASE_IMAGE=tensorflow/tensorflow:2.0.0b0-gpu-py3 .
 ```
 
-If you are running the examples in the repo, the datasets need to be generated when building the image, which
-could be achieved by adding `GEN_DATA=yes` to the build arg like the following:
-
-```bash
-docker build \
-    --build-arg GEN_DATA=yes \
-    -t elasticdl:dev \
-    -f elasticdl/docker/Dockerfile .
-```
-
-When having difficulties downloading from the main PYPI site, you could pass an extra PYPI index url to `docker build`, such as:
+When having difficulties downloading from the main PyPI site, you could pass an extra PyPI index url to `docker build`, such as:
 
 ```bash
 docker build \

--- a/elasticdl/manifests/examples/elasticdl-demo-k8s.yaml
+++ b/elasticdl/manifests/examples/elasticdl-demo-k8s.yaml
@@ -15,8 +15,8 @@ spec:
     - >
       python -m elasticdl.python.elasticdl.master.main
       --model_file=/elasticdl/python/examples/mnist_functional_api.py
-      --training_data_dir=/elasticdl/python/data/mnist/train
-      --evaluation_data_dir=/elasticdl/python/data/mnist/test
+      --training_data_dir=/data/mnist/train
+      --evaluation_data_dir=/data/mnist/test
       --codec_type=tf_example
       --records_per_task=100
       --num_epochs=1

--- a/elasticdl/manifests/examples/elasticdl-demo-minikube.yaml
+++ b/elasticdl/manifests/examples/elasticdl-demo-minikube.yaml
@@ -15,8 +15,8 @@ spec:
     - >
       python -m elasticdl.python.elasticdl.master.main
       --model_file=/elasticdl/python/examples/mnist_functional_api.py
-      --training_data_dir=/elasticdl/python/data/mnist/train
-      --evaluation_data_dir=/elasticdl/python/data/mnist/test
+      --training_data_dir=/data/mnist/train
+      --evaluation_data_dir=/data/mnist/test
       --codec_type=tf_example
       --records_per_task=100
       --num_epochs=1


### PR DESCRIPTION
The dataset paths in the image are changed in https://github.com/wangkuiyi/elasticdl/pull/619 so we are updating the paths in example manifests. Also removing the mentions of `GEN_DATA` in the instruction that's no longer needed.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>