### PR TITLE
Put task drop warning in the correct place

### DIFF
--- a/elasticdl/python/elasticdl/master/servicer.py
+++ b/elasticdl/python/elasticdl/master/servicer.py
@@ -150,7 +150,7 @@ class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
             )
             self._logger.warning(err_msg)
             raise ValueError(err_msg)
-        return request_model_version == self._version:
+        return request_model_version == self._version
 
     def ReportGradient(self, request, _):
         model_version_valid = self._validate_model_version(


### PR DESCRIPTION
`GetModel` will also call `_validate_model_version`, which may generate an incorrect task drop warning.