### PR TITLE
Pass None to owner reference if no master pod found

### DIFF
--- a/elasticdl/python/elasticdl/master/k8s_client.py
+++ b/elasticdl/python/elasticdl/master/k8s_client.py
@@ -113,7 +113,20 @@ class Client(object):
             pod
             for pod in pods
             if (pod.metadata.name == "elasticdl-master-" + self._job_name)
-        ][0]
+        ]
+        owner_ref = (
+            [
+                client.V1OwnerReference(
+                    api_version="v1",
+                    block_owner_deletion=True,
+                    kind="Pod",
+                    name=master_pod[0].metadata.name,
+                    uid=master_pod[0].metadata.uid,
+                )
+            ]
+            if len(master_pod) != 0
+            else None
+        )
 
         pod = client.V1Pod(
             spec=spec,
@@ -125,15 +138,7 @@ class Client(object):
                 },
                 # TODO: Add tests for this once we've done refactoring on
                 # k8s client code and the constant strings
-                owner_references=[
-                    client.V1OwnerReference(
-                        api_version="v1",
-                        block_owner_deletion=True,
-                        kind="Pod",
-                        name=master_pod.metadata.name,
-                        uid=master_pod.metadata.uid,
-                    )
-                ],
+                owner_references=owner_ref,
             ),
         )
         return pod


### PR DESCRIPTION
When we run tests that only creates the worker pod, we don't need owner reference so we should pass `None` to `owner_references` in this case.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>