### PR TITLE
use model.built to determine if variables are created

### DIFF
--- a/elasticdl/python/elasticdl/master/main.py
+++ b/elasticdl/python/elasticdl/master/main.py
@@ -215,7 +215,7 @@ def main():
         args.minibatch_size,
         optimizer,
         task_q,
-        init_var=model_inst.trainable_variables,
+        init_var=model_inst.trainable_variables if model.built else [],
         init_from_checkpoint=args.init_from_checkpoint,
         checkpoint_service=checkpoint_service,
     )

--- a/elasticdl/python/elasticdl/worker/worker.py
+++ b/elasticdl/python/elasticdl/worker/worker.py
@@ -46,7 +46,7 @@ class Worker(object):
         model_module = load_user_model(model_file)
         self._model = model_module.model
         self._feature_columns = model_module.feature_columns()
-        self._var_created = len(self._model.trainable_variables) > 0
+        self._var_created = self._model.built
         self._input_fn = model_module.input_fn
         self._opt_fn = model_module.optimizer
         self._loss = model_module.loss


### PR DESCRIPTION
Using `len(model.trainable_variables)` is not a reliable way to determine if the variables are created.
For example, the user may define a subclass model, but also use a functional API model as part of it.
`len(model.trainable_variables) ` contains only the variables in the functional API model after model instancing. After a model call, it will contain all the variables in the subclass model.

```
import tensorflow as tf
  
units = 32
timesteps = 10
input_dim = 5

# Define a Functional model
inputs = tf.keras.Input((None, units))
x = tf.keras.layers.GlobalAveragePooling1D()(inputs)
outputs = tf.keras.layers.Dense(1, activation='sigmoid')(x)
functional_model = tf.keras.Model(inputs, outputs)

class CustomRNN(tf.keras.Model):
  def __init__(self):
    super(CustomRNN, self).__init__()
    self.units = units
    self.projection_1 = tf.keras.layers.Dense(units=units, activation='tanh')
    self.projection_2 = tf.keras.layers.Dense(units=units, activation='tanh')
    # Our previously-defined Functional model
    self.classifier = functional_model

  def call(self, inputs):
    outputs = []
    state = tf.zeros(shape=(inputs.shape[0], self.units))
    for t in range(inputs.shape[1]):
      x = inputs[:, t, :]
      h = self.projection_1(x)
      y = h + self.projection_2(state)
      state = y
      outputs.append(y)
    features = tf.stack(outputs, axis=1)
    print(features.shape)
    return self.classifier(features)

model = CustomRNN()

# len(model.trainable_variables) is 2 here

model(tf.zeros((1, timesteps, input_dim)))

# len(model.trainable_variables) is 6 here
```

