### PR TITLE
Fix "model" not defined error

### DIFF
--- a/elasticdl/python/elasticdl/master/main.py
+++ b/elasticdl/python/elasticdl/master/main.py
@@ -215,7 +215,7 @@ def main():
         args.minibatch_size,
         optimizer,
         task_q,
-        init_var=model_inst.trainable_variables if model.built else [],
+        init_var=model_inst.trainable_variables if model_inst.built else [],
         init_from_checkpoint=args.init_from_checkpoint,
         checkpoint_service=checkpoint_service,
     )


### PR DESCRIPTION
Caught by integration test that's being added in https://github.com/wangkuiyi/elasticdl/pull/690. 
Detailed error log: https://travis-ci.com/wangkuiyi/elasticdl/jobs/208942217

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/elasticdl/python/elasticdl/master/main.py", line 292, in <module>
    main()
  File "/elasticdl/python/elasticdl/master/main.py", line 218, in main
    init_var=model_inst.trainable_variables if model.built else [],
NameError: name 'model' is not defined
```