### PR TITLE
Relax evaluation metrics shape

### DIFF
--- a/elasticdl/python/elasticdl/master/evaluation_service.py
+++ b/elasticdl/python/elasticdl/master/evaluation_service.py
@@ -39,12 +39,11 @@ class _EvaluationJob(object):
             )
             return False
         for k, v in evaluation_metrics.items():
-            if v.dim:
-                self._completed_minibatches += 1
-                if k in self._evaluation_metrics:
-                    self._evaluation_metrics[k] += tensor_to_ndarray(v)
-                else:
-                    self._evaluation_metrics[k] = np.copy(tensor_to_ndarray(v))
+            if k in self._evaluation_metrics:
+                self._evaluation_metrics[k] += tensor_to_ndarray(v)
+            else:
+                self._evaluation_metrics[k] = np.copy(tensor_to_ndarray(v))
+        self._completed_minibatches += 1
         return True
 
     def get_evaluation_summary(self):

--- a/elasticdl/python/elasticdl/worker/worker.py
+++ b/elasticdl/python/elasticdl/worker/worker.py
@@ -123,10 +123,9 @@ class Worker(object):
         req = elasticdl_pb2.ReportEvaluationMetricsRequest()
         for k, v in evaluation_metrics.items():
             v_np = v.numpy()
-            if v_np.size != 1:
-                raise Exception(
-                    "Only metric result of length 1 is " "supported currently"
-                )
+            # If scalar, convert to numpy 1D array with size 1
+            if not v_np.shape:
+                v_np = v_np.reshape(1)
             req.evaluation_metrics[k].CopyFrom(ndarray_to_tensor(v_np))
         req.model_version = self._model_version
         res = self._stub.ReportEvaluationMetrics(req)


### PR DESCRIPTION
1. Metrics can be any shape/size.

2. For scalar metrics, convert to 1D array in `report_evaluation_metrics` to support tensor/ndarray based operations.

3. Fix `_completed_minibatches` computation logic.

Tested with MNIST model.
