### PR TITLE
Remove unnecessary log for namespace name

### DIFF
--- a/elasticdl/python/elasticdl/common/k8s_client.py
+++ b/elasticdl/python/elasticdl/common/k8s_client.py
@@ -48,7 +48,6 @@ class Client(object):
             ).start()
 
     def _watch(self):
-        self._logger.info(self._ns)
         stream = watch.Watch().stream(
             self._v1.list_namespaced_pod,
             self._ns,


### PR DESCRIPTION
This piece of information seems unnecessary.
```
I0620 14:20:16.568042 140664264189696 k8s_client.py:51] default
```