### PR TITLE
CI must not rely on external Docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,13 @@ jobs:
     - stage: precommit
       name: "Pre-commit Check"
       script:
+        - docker build -t elasticdl:data -f elasticdl/docker/Dockerfile.data .
         - docker build -t elasticdl:dev -f elasticdl/docker/Dockerfile.dev .
         - docker run --rm -it -v $PWD:/work -w /work elasticdl:dev bash -c "pre-commit run --files $(find elasticdl/python -name '*.py' -print0 | tr '\0' ' ')"
     - stage: unittest
       name: "Unit Tests"
       script:
+        - docker build -t elasticdl:data -f elasticdl/docker/Dockerfile.data .        
         - docker build -t elasticdl:dev -f elasticdl/docker/Dockerfile.dev .
         - docker run --rm -it -v $PWD:/work -w /work elasticdl:dev bash -c "make -f elasticdl/Makefile && K8S_TESTS=False pytest elasticdl/python/tests"
     - stage: integrationtest
@@ -49,6 +51,7 @@ jobs:
         - sudo minikube start --vm-driver=none --kubernetes-version=v$K8S_VERSION --cpus 2 --memory 6144
         - "sudo chown -R travis: /home/travis/.minikube/"
         - kubectl cluster-info
+        - docker build -t elasticdl:data -f elasticdl/docker/Dockerfile.data .        
         - docker build -t elasticdl:dev -f elasticdl/docker/Dockerfile.dev .
         - docker build -t elasticdl:ci -f elasticdl/docker/Dockerfile.ci .
         # Run unit tests related to k8s

--- a/elasticdl/docker/Dockerfile.dev
+++ b/elasticdl/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM sqlflow/elasticdl:data
+FROM elasticdl:data
 
 RUN apt-get update && apt-get install -y unzip curl git
 


### PR DESCRIPTION
We used to convert MNIST and CIFA datasets into RecordIO format when building Docker image `elasticdl:data`, which takes a long time. So I configured DockerHub.com to build `sqlflow/elasticdl:data` automatically from the develop branch and make CI reuses the pre-built image.  However, this might cause inconsistent behaviors in CI. 

After the merge of https://github.com/wangkuiyi/elasticdl/pull/737, which builds only MNIST but not CIFAR and takes much less time, I think it is the right time to remove the dependency to external Docker images from our CI.