### PR TITLE
K8S demo job switches to use elasticdl:ci image

### DIFF
--- a/elasticdl/docker/Dockerfile.dev
+++ b/elasticdl/docker/Dockerfile.dev
@@ -14,7 +14,7 @@ RUN pip install -r /requirements.txt --extra-index-url=${EXTRA_PYPI_INDEX}
 RUN pip install pre-commit --extra-index-url=${EXTRA_PYPI_INDEX}
 
 # Copy the data generation package to /var and run them from there.
-# This assumes that the data generation pacakge is indepenent with the
+# This assumes that the data generation package is independent with the
 # rest part of ElasticDL.  The generated data will be in /data.
 COPY elasticdl/python/data /var/elasticdl/python/data
 COPY elasticdl/python/elasticdl/common /var/elasticdl/python/elasticdl/common

--- a/elasticdl/manifests/examples/elasticdl-demo-k8s.yaml
+++ b/elasticdl/manifests/examples/elasticdl-demo-k8s.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: mnist-demo-container
-    image: elasticdl:dev
+    image: elasticdl:ci
     command: ["/bin/bash"]
     args:
     - -c
@@ -23,7 +23,7 @@ spec:
       --minibatch_size=64
       --num_workers=4
       --checkpoint_steps=10
-      --worker_image=elasticdl:dev
+      --worker_image=elasticdl:ci
       --job_name=test-mnist
       --log_level=INFO
       --image_pull_policy=Always


### PR DESCRIPTION
After refactoring images, the demo job should use the ci one.