### PR TITLE
Add default gpu resource name and validation

### DIFF
--- a/elasticdl/python/elasticdl/common/k8s_utils.py
+++ b/elasticdl/python/elasticdl/common/k8s_utils.py
@@ -5,7 +5,7 @@ _ALLOWED_RESOURCE_TYPES = ["memory", "disk", "ephemeral-storage", "cpu", "gpu"]
 # Any domain name is (syntactically) valid if it's a dot-separated list of
 # identifiers, each no longer than 63 characters, and made up of letters,
 # digits and dashes (no underscores).
-_GPU_VENDOR_REGEX_STR = "^[a-zA-Z\d-]{,63}(\.[a-zA-Z\d-]{,63})*/gpu$"
+_GPU_VENDOR_REGEX_STR = r"^[a-zA-Z\d-]{,63}(\.[a-zA-Z\d-]{,63})*/gpu$"
 
 
 def _is_numeric(n):

--- a/elasticdl/python/tests/k8s_utils_test.py
+++ b/elasticdl/python/tests/k8s_utils_test.py
@@ -69,7 +69,8 @@ class K8SUtilsTest(unittest.TestCase):
             parse_resource,
             "cpu=2,memory=32Mi,disk=64Mi,gpu=0.1",
         )
-        # When gpu resource name has a valid vendor name, parse_resource works as expected
+        # When gpu resource name has a valid vendor name,
+        # parse_resource works as expected
         self.assertEqual(
             {
                 "cpu": "0.1",
@@ -79,14 +80,16 @@ class K8SUtilsTest(unittest.TestCase):
             },
             parse_resource("cpu=0.1,memory=32Mi,disk=64Mi,amd.com/gpu=1"),
         )
-        # When gpu resource name does not have a valid vendor name, raise an error
+        # When gpu resource name does not have a valid vendor name,
+        # raise an error
         self.assertRaisesRegex(
             ValueError,
             "gpu resource name does not have a valid vendor name: blah-gpu",
             parse_resource,
             "cpu=2,memory=32Mi,disk=64Mi,blah-gpu=1",
         )
-        # When gpu resource name does not have a valid vendor name, raise an error
+        # When gpu resource name does not have a valid vendor name,
+        # raise an error
         self.assertRaisesRegex(
             ValueError,
             "gpu resource name does not have a valid vendor name: @#/gpu",


### PR DESCRIPTION
This fixes #711, which includes:

* Adding "nvidia.com/gpu" as the default GPU resource name.
* Validate for user-provided GPU resource name based on an established pattern.



Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>