### PR TITLE
Fix elasticdl_job_name in tensorboard service

### DIFF
--- a/elasticdl/manifests/examples/elasticdl-demo-k8s-tensorboard-service.yaml
+++ b/elasticdl/manifests/examples/elasticdl-demo-k8s-tensorboard-service.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    elasticdl_job_name: test-mnist-with-tb
+    elasticdl_job_name: test-mnist
   name: tensorboard
 spec:
   ports:
   - port: 80
     targetPort: 6006
   selector:
-    elasticdl_job_name: test-mnist-with-tb
+    elasticdl_job_name: test-mnist
   type: LoadBalancer


### PR DESCRIPTION
This is used in conjunction with `elasticdl-demo-k8s.yaml` so job name should be consistent.