### PR TITLE
Log only when TensorBoard service is requested

### DIFF
--- a/elasticdl/python/elasticdl/master/main.py
+++ b/elasticdl/python/elasticdl/master/main.py
@@ -332,7 +332,9 @@ def main():
 
     # Keep TensorBoard running when all the tasks are finished
     if tb_service:
-        logger.info("All tasks finished. Keeping TensorBoard service running...")
+        logger.info(
+            "All tasks finished. Keeping TensorBoard service running..."
+        )
         tb_service.keep_running()
 
 


### PR DESCRIPTION
Currently we are seeing the log: `I0624 15:35:29.098400 139852246968128 main.py:334] All tasks finished. Keeping TensorBoard service running...` even when TensorBoard service is not requested.