### PR TITLE
Optimize and move owner reference code to reusable functions

### DIFF
--- a/elasticdl/python/elasticdl/common/k8s_client.py
+++ b/elasticdl/python/elasticdl/common/k8s_client.py
@@ -68,8 +68,7 @@ class Client(object):
     def _get_master_pod(self):
         try:
             return self._v1.read_namespaced_pod(
-                name=self.get_master_pod_name(),
-                namespace=self._ns,
+                name=self.get_master_pod_name(), namespace=self._ns
             )
         except client.api_client.ApiException as e:
             self._logger.warning("Exception when reading master pod: %s\n" % e)


### PR DESCRIPTION
These functions can be reused later for creating owner reference between master pod and TensorBoard service (part of https://github.com/wangkuiyi/elasticdl/issues/746).
Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>