### PR TITLE
Only check existence of worker pod in event callback

### DIFF
--- a/elasticdl/python/elasticdl/master/k8s_worker_manager.py
+++ b/elasticdl/python/elasticdl/master/k8s_worker_manager.py
@@ -118,7 +118,10 @@ class WorkerManager(object):
         relaunch = False
         with self._lock:
             worker_id = self._pod_name_to_id.get(pod_name)
-            if worker_id is None:
+            if (
+                worker_id is None
+                and pod_name != self._k8s_client.get_master_pod_name()
+            ):
                 self._logger.error("Unknown worker pod name: %s" % pod_name)
                 return
 


### PR DESCRIPTION
Issue https://github.com/wangkuiyi/elasticdl/issues/579 appears again on the latest code:

`E0624 15:49:41.411780 140557653350144 k8s_worker_manager.py:122] Unknown worker pod name: elasticdl-test-mnist-master`.

It seems like this piece of code was accidentally removed during refactoring so I am fixing it again here.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>