### PR TITLE
Hide TensorBoard service REST call logs

### DIFF
--- a/elasticdl/python/elasticdl/master/tensorboard_service.py
+++ b/elasticdl/python/elasticdl/master/tensorboard_service.py
@@ -34,7 +34,10 @@ class TensorboardService(object):
 
     def start(self):
         self.tb_process = subprocess.Popen(
-            ["tensorboard --logdir " + self._tensorboard_log_dir], shell=True
+            ["tensorboard --logdir " + self._tensorboard_log_dir],
+            shell=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
         )
 
     def keep_running(self):


### PR DESCRIPTION
Fixes #765. These logs are not useful for users.