### PR TITLE
Turn on black check on precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,9 @@
 repos:
-#-   repo: https://github.com/ambv/black
-#    rev: 19.3b0
-#    hooks:
-#    - id: black
-#      args: [--line-length=79]
-#-   repo: git://github.com/doublify/pre-commit-isort
-#    rev: v4.3.0
-#    hooks:
-#    -   id: isort
+-   repo: https://github.com/ambv/black
+    rev: 19.3b0
+    hooks:
+    - id: black
+      args: [--line-length=79]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:


### PR DESCRIPTION
This would be useful for standardizing the code formatting. 

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>