### PR TITLE
Remove unnecessary args in create_master()

### DIFF
--- a/elasticdl/python/client/client.py
+++ b/elasticdl/python/client/client.py
@@ -241,8 +241,6 @@ def _submit(image_name, model_file, job_name, args, argv):
         job_name=job_name,
         event_callback=None,
     ).create_master(
-        job_name=job_name,
-        image_name=image_name,
         resource_requests=args.master_resource_request,
         resource_limits=args.master_resource_limit,
         pod_priority=args.master_pod_priority,

--- a/elasticdl/python/common/k8s_client.py
+++ b/elasticdl/python/common/k8s_client.py
@@ -41,7 +41,7 @@ class Client(object):
         self.namespace = namespace
         self.job_name = job_name
         self._logger = logging.getLogger(__name__)
-        self._image = image_name
+        self._image_name = image_name
         self._event_cb = event_callback
         if self._event_cb:
             threading.Thread(
@@ -160,9 +160,9 @@ class Client(object):
             )
         ]
         pod = self._create_pod(
-            pod_name="elasticdl-" + kargs["job_name"] + "-master",
-            job_name=kargs["job_name"],
-            image_name=kargs["image_name"],
+            pod_name=self.get_master_pod_name(),
+            job_name=self.job_name,
+            image_name=self._image_name,
             command=["python"],
             resource_requests=parse(kargs["resource_requests"]),
             resource_limits=parse(kargs["resource_limits"]),
@@ -185,7 +185,7 @@ class Client(object):
         pod = self._create_pod(
             pod_name=self.get_worker_pod_name(kargs["worker_id"]),
             job_name=self.job_name,
-            image_name=self._image,
+            image_name=self._image_name,
             command=kargs["command"],
             resource_requests=kargs["resource_requests"],
             resource_limits=kargs["resource_limits"],


### PR DESCRIPTION
These are already available in `Client` object as member variables so it's unnecessary to pass them again in `create_master()`.
Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>