### PR TITLE
Remove unnecessary noqa comments

### DIFF
--- a/elasticdl/python/worker/main.py
+++ b/elasticdl/python/worker/main.py
@@ -2,7 +2,7 @@ import argparse
 import grpc
 import logging
 
-from elasticdl.python.worker.worker import Worker  # noqa
+from elasticdl.python.worker.worker import Worker
 from elasticdl.python.common.constants import GRPC
 
 

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -3,8 +3,6 @@ import traceback
 
 import tensorflow as tf
 
-assert tf.executing_eagerly()  # noqa
-
 import recordio
 
 from contextlib import closing


### PR DESCRIPTION
These are no longer neccessary as the import path is shorter and we are using TF 2.0. 

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>