### PR TITLE
Change pod to pod_priority for consistency

### DIFF
--- a/elasticdl/python/common/k8s_client.py
+++ b/elasticdl/python/common/k8s_client.py
@@ -190,7 +190,7 @@ class Client(object):
             resource_requests=kargs["resource_requests"],
             resource_limits=kargs["resource_limits"],
             container_args=kargs["args"],
-            pod_priority=kargs["priority"],
+            pod_priority=kargs["pod_priority"],
             image_pull_policy=kargs["image_pull_policy"],
             restart_policy=kargs["restart_policy"],
             volume_name=kargs["volume_name"],

--- a/elasticdl/python/master/k8s_worker_manager.py
+++ b/elasticdl/python/master/k8s_worker_manager.py
@@ -68,7 +68,7 @@ class WorkerManager(object):
                 worker_id=worker_id,
                 resource_requests=self._resource_requests,
                 resource_limits=self._resource_limits,
-                priority=self._pod_priority,
+                pod_priority=self._pod_priority,
                 mount_path=self._mount_path,
                 volume_name=self._volume_name,
                 image_pull_policy=self._image_pull_policy,

--- a/elasticdl/python/tests/k8s_client_test.py
+++ b/elasticdl/python/tests/k8s_client_test.py
@@ -42,7 +42,7 @@ class K8sClientTest(unittest.TestCase):
                 resource_requests=resource,
                 resource_limits=resource,
                 command=["echo"],
-                priority=None,
+                pod_priority=None,
                 args=None,
                 mount_path=None,
                 volume_name=None,


### PR DESCRIPTION
In `kargs` of `create_master()`, this is `pod_priority` instead of `priority`. This PR makes it consistent with other mentions of pod priority.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>