### PR TITLE
Use requirements.txt to populate install_requires field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
 setup(
-    name="ElasticDL",
+    name="elasticdl",
     version="0.0.1",
     description="A Kubernetes-naitve Elastic Deep Learning Framework",
     author="Ant Financial",


### PR DESCRIPTION
This is helpful for pip to determine the dependencies of `elasticdl` Python package. We can just automatically populate it from `requirements.txt`.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>