### PR TITLE
Remove unnecessary tf.executing_eagerly() check

### DIFF
--- a/elasticdl/python/master/servicer.py
+++ b/elasticdl/python/master/servicer.py
@@ -12,8 +12,6 @@ from elasticdl.python.common.ndarray import (
     tensor_to_ndarray,
 )
 
-assert tf.executing_eagerly()
-
 
 class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
     """Master service implementation"""


### PR DESCRIPTION
TF 2.0 doesn't need this check since eager mode is the default.