### PR TITLE
Quick fix for RecordIO generation on GKE

### DIFF
--- a/elasticdl/python/data/recordio_gen/sample_pyspark_recordio_gen/go-pip-install.sh
+++ b/elasticdl/python/data/recordio_gen/sample_pyspark_recordio_gen/go-pip-install.sh
@@ -83,4 +83,7 @@ source /.bashrc
 easy_install pip
 
 # Install the dependencies we need
-pip install pyrecordio>=0.0.6 Pillow tensorflow
+pip install pyrecordio>=0.0.6 Pillow
+
+# A hacky fix for tensorflow installation
+pip install tensorflow --ignore-installed


### PR DESCRIPTION
When I follow [here](https://github.com/wangkuiyi/elasticdl/blob/develop/elasticdl/python/data/recordio_gen/recordio_data_preparation_tutorial.md#pyspark-job-on-google-cloud), it gives `ERROR: Cannot uninstall 'wrapt'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.` when installing `tensorflow`. This should be because of some changes on GKE side. The reason is https://github.com/pypa/pip/issues/5247#issuecomment-381550610. I fix it by following https://stackoverflow.com/a/50396798/3469564.

Further, we should run the PySpark job on GKE in Conda to avoid the errors caused by the changes on GKE side https://github.com/wangkuiyi/elasticdl/issues/835.