### PR TITLE
Small fix for data generation on GKE

### DIFF
--- a/elasticdl/python/data/recordio_gen/recordio_data_preparation_tutorial.md
+++ b/elasticdl/python/data/recordio_gen/recordio_data_preparation_tutorial.md
@@ -108,7 +108,7 @@ gcloud dataproc jobs submit pyspark \
     elasticdl/python/data/recordio_gen/sample_pyspark_recordio_gen/spark_gen_recordio.py \
     --cluster=$CLUSTER_NAME --region=global --py-files=elasticdl.zip \
     --files=elasticdl/python/examples/mnist_functional_api/mnist_functional_api.py \
-    -- --training_data_dir=/filestore_mnt/$TRAINING_DATA_DIR \
+    -- --training_data_tar_file=/filestore_mnt/$TAR_FILE \
     --output_dir=/filestore_mnt --model_file=$MODEL_FILE --records_per_file=200
 ```
 

--- a/elasticdl/python/data/recordio_gen/sample_pyspark_recordio_gen/go-pip-install.sh
+++ b/elasticdl/python/data/recordio_gen/sample_pyspark_recordio_gen/go-pip-install.sh
@@ -86,4 +86,7 @@ easy_install pip
 pip install pyrecordio>=0.0.6 Pillow
 
 # A hacky fix for tensorflow installation
-pip install tensorflow --ignore-installed
+rm -rf /opt/conda/default/lib/python3.6/site-packages/wrapt*
+
+# Install tensorflow
+pip install tensorflow


### PR DESCRIPTION
1. Update the data generation tutorial

2. Fix initialization script: the fix of https://github.com/wangkuiyi/elasticdl/pull/836 causes another error `ImportError: Something is wrong with the numpy installation. While importing we detected an older version of numpy in ['/opt/conda/default/lib/python3.6/site-packages/numpy']. One method of fixing this is to repeatedly uninstall numpy until none is found, then reinstall this version.`. This diff fixed the error in https://github.com/wangkuiyi/elasticdl/pull/836 with an alternative way.