### PR TITLE
Delete k8s_cluster_spec.py

### DIFF
--- a/elasticdl/python/common/k8s_cluster_spec.py
+++ b/elasticdl/python/common/k8s_cluster_spec.py
@@ -1,7 +1,0 @@
-class KubernetesCluster:
-    def with_cluster(self, pod):
-        # By default, don't need to add specific config for pod
-        return pod
-
-
-cluster = KubernetesCluster()


### PR DESCRIPTION
This file is not needed anymore since we now support specifying the path to the cluster spec file. 