### PR TITLE
Also print progress if no error and no "stream" in dict

### DIFF
--- a/elasticdl/python/elasticdl/image_builder.py
+++ b/elasticdl/python/elasticdl/image_builder.py
@@ -147,9 +147,11 @@ def _print_docker_progress(line):
     error = line.get("error", None)
     if error:
         raise RuntimeError("Docker image build: " + error)
-    text = line.get("stream", None)
-    if text:
-        print(text)
+    stream = line.get("stream", None)
+    if stream:
+        print(stream)
+    else:
+        print(line)
 
 
 def _build_docker_image(client, ctx_dir, dockerfile, image_name):


### PR DESCRIPTION
When pushing the image, "stream" is not in the dictionary. So if there's no error, we should just print whatever we obtain:
```
{'status': 'Pushing', 'progressDetail': {'current': 3684864, 'total': 44857306}, 'progress': '[====>                                              ]  3.685MB/44.86MB', 'id': '35ee4446fd21'}
```