### PR TITLE
Move resource limits/requests logic to `Client._create_pod()`

### DIFF
--- a/elasticdl/python/common/k8s_client.py
+++ b/elasticdl/python/common/k8s_client.py
@@ -121,13 +121,20 @@ class Client(object):
 
     def _create_pod(self, **kargs):
         # Container
+        pod_resource_requests = kargs["resource_requests"]
+        pod_resource_limits = kargs["resource_limits"]
+        pod_resource_limits = (
+            pod_resource_limits
+            if pod_resource_limits
+            else pod_resource_requests
+        )
         container = client.V1Container(
             name=kargs["pod_name"],
             image=kargs["image_name"],
             command=kargs["command"],
             resources=client.V1ResourceRequirements(
-                requests=parse_resource(kargs["resource_requests"]),
-                limits=parse_resource(kargs["resource_limits"]),
+                requests=parse_resource(pod_resource_requests),
+                limits=parse_resource(pod_resource_limits),
             ),
             args=kargs["container_args"],
             image_pull_policy=kargs["image_pull_policy"],

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -79,12 +79,6 @@ def train(args):
     container_args.extend(["--restart_policy", args.restart_policy])
     container_args.extend(["--volume", args.volume])
 
-    args.master_resource_limit = (
-        args.master_resource_limit
-        if args.master_resource_limit
-        else args.master_resource_request
-    )
-
     _submit_job(image_name, args, container_args)
     # TODO: print dashboard url after launching the master pod
 
@@ -136,12 +130,6 @@ def evaluate(args):
     container_args.extend(["--image_pull_policy", args.image_pull_policy])
     container_args.extend(["--restart_policy", args.restart_policy])
     container_args.extend(["--volume", args.volume])
-
-    args.master_resource_limit = (
-        args.master_resource_limit
-        if args.master_resource_limit
-        else args.master_resource_request
-    )
 
     _submit_job(image_name, args, container_args)
 

--- a/elasticdl/python/master/main.py
+++ b/elasticdl/python/master/main.py
@@ -195,12 +195,6 @@ def main():
             args.model_class,
         ]
 
-        args.worker_resource_limit = (
-            args.worker_resource_limit
-            if args.worker_resource_limit
-            else args.worker_resource_request
-        )
-
         worker_manager = WorkerManager(
             task_d,
             job_name=args.job_name,


### PR DESCRIPTION
Currently the same code exists in multiple places. This PR moves the logic to `Client._create_pod()`. 

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>