### PR TITLE
Rename model_def to model_zoo

### DIFF
--- a/elasticdl/README.md
+++ b/elasticdl/README.md
@@ -95,7 +95,7 @@ In a terminal, start master to distribute mnist training tasks.
 ```
 docker run --net=host --rm -it elasticdl:dev \
     bash -c "python -m elasticdl.python.master.main \
-          --model_def=elasticdl/python/examples/mnist_functional_api \
+          --model_zoo=elasticdl/python/examples/mnist_functional_api \
           --job_name=test \
           --training_data_dir=/data/mnist/train \
           --evaluation_data_dir=/data/mnist/test \
@@ -113,7 +113,7 @@ In another terminal, start a worker
 docker run --net=host --rm -it elasticdl:dev \
     bash -c "python -m elasticdl.python.worker.main \
           --worker_id=1 \
-          --model_def=elasticdl/python/examples/mnist_functional_api \
+          --model_zoo=elasticdl/python/examples/mnist_functional_api \
           --master_addr=localhost:50001 \
           --log_level=INFO"
 ```

--- a/elasticdl/doc/elastic_scheduling.md
+++ b/elasticdl/doc/elastic_scheduling.md
@@ -65,7 +65,7 @@ Use the command below to submit your first ElasticDL job on GKE:
 ```
 python -m elasticdl.python.elasticdl.client train \
     --job_name=hello-world \
-    --model_def=elasticdl/python/examples/mnist_subclass \
+    --model_zoo=elasticdl/python/examples/mnist_subclass \
     --training_data_dir=${MNIST_DATA_DIR}/train \
     --evaluation_data_dir=${MNIST_DATA_DIR}/test \
     --num_epochs=1 \
@@ -103,7 +103,7 @@ Same as the first example, submit a job on GKE using the command below:
 ```
 python -m elasticdl.python.elasticdl.client train \
     --job_name=fault-tolerance \
-    --model_def=elasticdl/python/examples/mnist_subclass \
+    --model_zoo=elasticdl/python/examples/mnist_subclass \
     --training_data_dir=${MNIST_DATA_DIR}/train \
     --evaluation_data_dir=${MNIST_DATA_DIR}/test \
     --num_epochs=1 \
@@ -163,7 +163,7 @@ For more about PriorityClass, please check out [Pod Priority and Preemption](htt
 ```
 python -m elasticdl.python.elasticdl.client train \
     --job_name=low-prio-job \
-    --model_def=elasticdl/python/examples/mnist_subclass \
+    --model_zoo=elasticdl/python/examples/mnist_subclass \
     --training_data_dir=${MNIST_DATA_DIR}/train \
     --evaluation_data_dir=${MNIST_DATA_DIR}/test \
     --master_pod_priority=high-priority \
@@ -194,7 +194,7 @@ kubectl get pods -l elasticdl_job_name=low-prio-job
 ```
 python -m elasticdl.python.elasticdl.client train \
     --job_name=high-prio-job \
-    --model_def=elasticdl/python/examples/mnist_subclass \
+    --model_zoo=elasticdl/python/examples/mnist_subclass \
     --training_data_dir=${MNIST_DATA_DIR}/train \
     --evaluation_data_dir=${MNIST_DATA_DIR}/test \
     --master_pod_priority=high-priority \

--- a/elasticdl/manifests/examples/elasticdl-demo-k8s.yaml
+++ b/elasticdl/manifests/examples/elasticdl-demo-k8s.yaml
@@ -14,7 +14,7 @@ spec:
     - -c
     - >
       python -m elasticdl.python.master.main
-      --model_def=/elasticdl/python/examples/mnist_functional_api
+      --model_zoo=/elasticdl/python/examples/mnist_functional_api
       --training_data_dir=/data/mnist/train
       --evaluation_data_dir=/data/mnist/test
       --records_per_task=100

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -1,6 +1,6 @@
 def add_common_params(parser):
     parser.add_argument(
-        "--model_def",
+        "--model_zoo",
         help="The directory that contains user-defined model files "
         "or a specific model file",
         required=True,

--- a/elasticdl/python/common/model_helper.py
+++ b/elasticdl/python/common/model_helper.py
@@ -51,5 +51,5 @@ def load_from_checkpoint_file(file_name):
     return pb_model
 
 
-def get_model_file(model_def):
-    return os.path.join(model_def, os.path.basename(model_def) + ".py")
+def get_model_file(model_zoo):
+    return os.path.join(model_zoo, os.path.basename(model_zoo) + ".py")

--- a/elasticdl/python/elasticdl/README.md
+++ b/elasticdl/python/elasticdl/README.md
@@ -43,7 +43,7 @@ Submit training job:
 
 ```bash
 python -m elasticdl.python.elasticdl.client train \
-    --model_def=elasticdl/python/examples/mnist_subclass \
+    --model_zoo=elasticdl/python/examples/mnist_subclass \
     --image_base=elasticdl:ci \
     --training_data_dir=/data/mnist/train \
     --evaluation_data_dir=/data/mnist/test \
@@ -75,7 +75,7 @@ ElasticDL provides an easy way for users to specify their pods requirements.
 python -m elasticdl.python.elasticdl.client train \
     --job_name=test \
     --image_name=gcr.io/elasticdl/mnist:dev \
-    --model_def=elasticdl/python/examples/mnist_subclass \
+    --model_zoo=elasticdl/python/examples/mnist_subclass \
     --cluster_spec=<path_to_cluster_specification_file> \
     --training_data_dir=/data/mnist_nfs/mnist/train \
     --evaluation_data_dir=/data/mnist_nfs/mnist/test \

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -8,7 +8,7 @@ from elasticdl.python.elasticdl.image_builder import (
 
 def train(args):
     image_name = build_and_push_docker_image(
-        model_zoo=args.model_def,
+        model_zoo=args.model_zoo,
         base_image=args.image_base,
         docker_image_prefix=args.docker_image_prefix,
         extra_pypi=args.extra_pypi_index,
@@ -21,8 +21,8 @@ def train(args):
         args.job_name,
         "--worker_image",
         image_name,
-        "--model_def",
-        _model_def_in_docker(args.model_def),
+        "--model_zoo",
+        _model_zoo_in_docker(args.model_zoo),
         "--cluster_spec",
         _cluster_spec_def_in_docker(args.cluster_spec),
         "--num_workers",
@@ -82,7 +82,7 @@ def train(args):
 
 def evaluate(args):
     image_name = build_and_push_docker_image(
-        model_zoo=args.model_def,
+        model_zoo=args.model_zoo,
         base_image=args.image_base,
         docker_image_prefix=args.docker_image_prefix,
         extra_pypi=args.extra_pypi_index,
@@ -95,8 +95,8 @@ def evaluate(args):
         args.job_name,
         "--worker_image",
         image_name,
-        "--model_def",
-        _model_def_in_docker(args.model_def),
+        "--model_zoo",
+        _model_zoo_in_docker(args.model_zoo),
         "--cluster_spec",
         _cluster_spec_def_in_docker(args.cluster_spec),
         "--num_workers",
@@ -155,9 +155,9 @@ def _submit_job(image_name, client_args, container_args):
     )
 
 
-def _model_def_in_docker(model_def):
+def _model_zoo_in_docker(model_zoo):
     MODEL_ROOT_PATH = "/model_zoo"
-    return os.path.join(MODEL_ROOT_PATH, os.path.basename(model_def))
+    return os.path.join(MODEL_ROOT_PATH, os.path.basename(model_zoo))
 
 
 def _cluster_spec_def_in_docker(cluster_spec):

--- a/elasticdl/python/master/main.py
+++ b/elasticdl/python/master/main.py
@@ -94,7 +94,7 @@ def main():
         args.records_per_task,
         args.num_epochs,
     )
-    model_module = load_module(get_model_file(args.model_def)).__dict__
+    model_module = load_module(get_model_file(args.model_zoo)).__dict__
     model_inst = load_model_from_module(
         args.model_class, model_module, args.model_params
     )
@@ -177,8 +177,8 @@ def main():
         worker_args = [
             "-m",
             "elasticdl.python.worker.main",
-            "--model_def",
-            args.model_def,
+            "--model_zoo",
+            args.model_zoo,
             "--master_addr",
             master_addr,
             "--log_level",

--- a/elasticdl/python/tests/example_test.py
+++ b/elasticdl/python/tests/example_test.py
@@ -84,7 +84,7 @@ def create_imagenet_recordio_file(size, shape):
 class ExampleTest(unittest.TestCase):
     def distributed_train_and_evaluate(
         self,
-        model_def,
+        model_zoo,
         image_shape,
         model_class,
         model_params="",
@@ -95,7 +95,7 @@ class ExampleTest(unittest.TestCase):
         Run distributed training and evaluation with a local master.
         grpc calls are mocked by local master call.
         """
-        module_file = _get_model_info(get_model_file(model_def))
+        module_file = _get_model_info(get_model_file(model_zoo))
 
         worker = Worker(
             1,

--- a/elasticdl/python/worker/main.py
+++ b/elasticdl/python/worker/main.py
@@ -15,7 +15,7 @@ def _parse_args():
     )
     parser.add_argument("--master_addr", help="Master ip:port", required=True)
     parser.add_argument(
-        "--model_def",
+        "--model_zoo",
         help="The directory that contains user-defined model files "
         "or a specific model file",
         required=True,
@@ -93,7 +93,7 @@ def main():
     logger.info("Starting worker %d", args.worker_id)
     worker = Worker(
         args.worker_id,
-        get_model_file(args.model_def),
+        get_model_file(args.model_zoo),
         channel=channel,
         input_fn=args.input_fn,
         loss=args.loss,

--- a/elasticdl/scripts/client_test.sh
+++ b/elasticdl/scripts/client_test.sh
@@ -2,7 +2,7 @@ set -x
 
 elasticdl train \
   --image_base=elasticdl:ci \
-  --model_def=elasticdl/python/examples/mnist_functional_api \
+  --model_zoo=elasticdl/python/examples/mnist_functional_api \
   --training_data_dir=/data/mnist/train \
   --evaluation_data_dir=/data/mnist/test \
   --num_epochs=2 \


### PR DESCRIPTION
This is part of https://github.com/wangkuiyi/elasticdl/issues/926, which only renames `model_def` to `model_zoo`.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>