### PR TITLE
Move TensorBoard log in main() to outside of the while loop

### DIFF
--- a/elasticdl/python/master/main.py
+++ b/elasticdl/python/master/main.py
@@ -241,7 +241,7 @@ def main():
     # Keep TensorBoard running when all the tasks are finished
     if tb_service:
         logger.info(
-            "All tasks finished. " "Keeping TensorBoard service running..."
+            "All tasks finished. Keeping TensorBoard service running..."
         )
         while True:
             if tb_service.is_active():


### PR DESCRIPTION
Currently the log is in the while loop so it will be printed everytime when we check TensorBoard's status, for example:
```
I0719 17:01:39.528261 139896949020480 main.py:246] All tasks finished. Keeping TensorBoard service running...
I0719 17:01:49.538619 139896949020480 main.py:246] All tasks finished. Keeping TensorBoard service running...
I0719 17:01:59.548961 139896949020480 main.py:246] All tasks finished. Keeping TensorBoard service running...
I0719 17:02:09.559306 139896949020480 main.py:246] All tasks finished. Keeping TensorBoard service running...
```