### PR TITLE
Check TensorFlow installation during image building

### DIFF
--- a/elasticdl/README.md
+++ b/elasticdl/README.md
@@ -19,6 +19,8 @@ docker build \
     --build-arg BASE_IMAGE=tensorflow/tensorflow:2.0.0b1-gpu-py3 .
 ```
 
+Note that since ElasticDL depends on TensorFlow, the base image must have TensorFlow installed.
+
 When having difficulties downloading from the main PyPI site, you could pass an extra PyPI index url to `docker build`, such as:
 
 ```bash

--- a/model_zoo/requirements.txt
+++ b/model_zoo/requirements.txt
@@ -1,3 +1,2 @@
 numpy
-tensorflow
 Pillow


### PR DESCRIPTION
If `tensorflow-gpu` is installed in base image, the `tensorflow` entry will install tensorflow again which overwrites the version. Here we are removing this entry and instead we add a check in image building to make sure base image contains tensorflow installation. 

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>