### PR TITLE
Add utility functions to parse row to tf.Example

### DIFF
--- a/elasticdl/python/common/odps_recordio_converter.py
+++ b/elasticdl/python/common/odps_recordio_converter.py
@@ -1,0 +1,65 @@
+from collections import namedtuple
+
+import numpy as np
+import tensorflow as tf
+
+
+def _find_features_indices(
+    features_list, int_features, float_features, bytes_features
+):
+    """Finds the indices for different types of features."""
+    FeatureIndices = namedtuple(
+        "FeatureIndices",
+        ["int_features", "float_features", "bytes_features"],
+        verbose=False,
+    )
+    int_features_indices = [features_list.index(key) for key in int_features]
+    float_features_indices = [
+        features_list.index(key) for key in float_features
+    ]
+    bytes_features_indices = [
+        features_list.index(key) for key in bytes_features
+    ]
+    return FeatureIndices(
+        int_features_indices, float_features_indices, bytes_features_indices
+    )
+
+
+def _parse_row_to_example(record, features_list, feature_indices):
+    """
+    Parses one row (a flat list or one-dimensional numpy array)
+    to a TensorFlow Example.
+    """
+    if isinstance(record, list):
+        record = np.array(record, dtype=object)
+
+    example = tf.train.Example()
+    # Note: these cannot be constructed dynamically since
+    # we cannot assign a value to an embedded message
+    # field in protobuf
+    for feature_ind in feature_indices.int_features:
+        example.features.feature[
+            features_list[feature_ind]
+        ].int64_list.value.append(
+            int(_maybe_encode_unicode_string(record[feature_ind]) or 0)
+        )
+    for feature_ind in feature_indices.float_features:
+        example.features.feature[
+            features_list[feature_ind]
+        ].float_list.value.append(
+            float(_maybe_encode_unicode_string(record[feature_ind]) or 0.0)
+        )
+    for feature_ind in feature_indices.bytes_features:
+        example.features.feature[
+            features_list[feature_ind]
+        ].bytes_list.value.append(
+            _maybe_encode_unicode_string(record[feature_ind])
+        )
+    return example
+
+
+def _maybe_encode_unicode_string(record):
+    """Encodes unicode strings if needed."""
+    if isinstance(record, str):
+        record = bytes(record, "utf-8").strip()
+    return record

--- a/elasticdl/python/tests/odps_recordio_converter_test.py
+++ b/elasticdl/python/tests/odps_recordio_converter_test.py
@@ -1,0 +1,85 @@
+import inspect
+import unittest
+
+import numpy as np
+
+from elasticdl.python.common.odps_recordio_converter import (
+    _find_features_indices,
+    _maybe_encode_unicode_string,
+    _parse_row_to_example,
+)
+
+
+class TestODPSRecordIOConverter(unittest.TestCase):
+
+    row1 = [61, 5.65, "Cash"]
+    row2 = [50, 1.2, "Credit Card"]
+    float_features = ["float_col"]
+    bytes_features = ["bytes_col"]
+    int_features = ["int_col"]
+    features_list = ["int_col", "float_col", "bytes_col"]
+    feature_indices = _find_features_indices(
+        features_list, int_features, float_features, bytes_features
+    )
+
+    def test_parse_row_to_example(self):
+        expected = inspect.cleandoc(
+            """features {
+      feature {
+        key: "bytes_col"
+        value {
+          bytes_list {
+            value: "Cash"
+          }
+        }
+      }
+      feature {
+        key: "float_col"
+        value {
+          float_list {
+            value: 5.650000095367432
+          }
+        }
+      }
+      feature {
+        key: "int_col"
+        value {
+          int64_list {
+            value: 61
+          }
+        }
+      }
+    }
+    """
+        )
+
+        result = _parse_row_to_example(
+            np.array(self.row1, dtype=object),
+            self.features_list,
+            self.feature_indices,
+        )
+        self.assertEqual(str(result), expected + "\n")
+
+        result = _parse_row_to_example(
+            self.row1, self.features_list, self.feature_indices
+        )
+        self.assertEqual(str(result), expected + "\n")
+
+    def test_parse_row_to_example_unicode_mapping(self):
+        self.assertEqual(
+            _maybe_encode_unicode_string(u"some_unicode_string"),
+            b"some_unicode_string",
+        )
+        self.assertEqual(
+            _maybe_encode_unicode_string("some_string"), b"some_string"
+        )
+
+        _parse_row_to_example(
+            np.array([u"40", u"2.5", "Chinese中文"], dtype=object),
+            self.features_list,
+            self.feature_indices,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part of https://github.com/wangkuiyi/elasticdl/issues/945. This PR adds some utility functions to parse rows to tf.Example based on each feature's type. 

More work is needed for ODPS -> RecordIO conversion, such as figuring out the schema mapping between tf.Example and ODPS. 

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>