### PR TITLE
Add logging config for client code

### DIFF
--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -6,7 +6,6 @@ from elasticdl.python.elasticdl.image_builder import (
     build_and_push_docker_image,
 )
 
-
 logging.basicConfig(
     format="%(asctime)s %(name)s %(levelname)-8s "
     "[%(filename)s:%(lineno)d] %(message)s"

--- a/elasticdl/python/elasticdl/image_builder.py
+++ b/elasticdl/python/elasticdl/image_builder.py
@@ -8,7 +8,6 @@ import docker
 
 from elasticdl.python.common.file_helper import copy_if_not_exists
 
-
 logging.basicConfig(
     format="%(asctime)s %(name)s %(levelname)-8s "
     "[%(filename)s:%(lineno)d] %(message)s"


### PR DESCRIPTION
After https://github.com/wangkuiyi/elasticdl/pull/981, users won't be able to see any log from client code if the log level is not specified as INFO when submitting the job. This is just a temporary solution. We will need a centralized log config later (see https://github.com/wangkuiyi/elasticdl/issues/990).

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>