### PR TITLE
Fix flaky recordio conversion test

### DIFF
--- a/elasticdl/python/tests/odps_recordio_conversion_utils_test.py
+++ b/elasticdl/python/tests/odps_recordio_conversion_utils_test.py
@@ -94,7 +94,7 @@ class TestODPSRecordIOConversionUtils(unittest.TestCase):
                 records_iter, features_list, output_dir, records_per_shard=1
             )
             self.assertEqual(
-                os.listdir(output_dir), ["data-00000", "data-00001"]
+                sorted(os.listdir(output_dir)), ["data-00000", "data-00001"]
             )
 
         # Each batch contains multiple items


### PR DESCRIPTION
Sometimes the test is failing because we are comparing the unsorted list with the sorted list. This PR sorts the resulting list first before comparing it with the expected result.
```
E           AssertionError: Lists differ: ['data-00001', 'data-00000'] != ['data-00000', 'data-00001']
E
E           First differing element 0:
E           'data-00001'
E           'data-00000'
E
E           - ['data-00001', 'data-00000']
E           + ['data-00000', 'data-00001']

elasticdl/python/tests/odps_recordio_conversion_utils_test.py:97: AssertionError
```
