### PR TITLE
Disable debug mode in client_test.sh

### DIFF
--- a/elasticdl/scripts/client_test.sh
+++ b/elasticdl/scripts/client_test.sh
@@ -1,5 +1,3 @@
-set -x
-
 elasticdl train \
   --image_base=elasticdl:ci \
   --model_zoo=model_zoo \


### PR DESCRIPTION
The current log is pretty verbose since debug mode is enabled in `client_test.sh` via `-x`, e.g. 
```
+echo 'Master: Running, Worker0: Succeeded, Worker1: Succeeded. Continue checking...'
2069Master: Running, Worker0: Succeeded, Worker1: Succeeded. Continue checking...
2070+sleep 10
2071+grep 'Cpu(s)'
2072+top -bn1
2073+sed 's/.*, *\([0-9.]*\)%* id.*/\1/'
2074+awk '{print 100 - $1"%"}'
207563.5%
2076+for i in '{1..200}'
2077++get_pod_status elasticdl-test-mnist-master
2078+++kubectl get pod elasticdl-test-mnist-master -o 'jsonpath={.status.phase}'
2079++local pod_status=Succeeded
2080++echo Succeeded
2081+MASTER_POD_STATUS=Succeeded
2082++get_pod_status elasticdl-test-mnist-worker-0
2083+++kubectl get pod elasticdl-test-mnist-worker-0 -o 'jsonpath={.status.phase}'
2084++local pod_status=Succeeded
2085++echo Succeeded
```
See detailed log [here](https://travis-ci.com/wangkuiyi/elasticdl/jobs/223908848#L2068-L2083). 

This is unnecessary so I am removing the `-x` option.