### PR TITLE
revise design doc

### DIFF
--- a/elasticdl/doc/embedding_layer_design.md
+++ b/elasticdl/doc/embedding_layer_design.md
@@ -23,7 +23,6 @@ An embedding layer defines an embedding table *E*. For an input containing a lis
 class EdlEmbedding(tf.keras.layers.Layer):
     def __init__(self,
                  embedding_dim,
-                 name,
                  embedding_initializer="uniform",
                  )
 ```


### PR DESCRIPTION
Revise design doc. 

* Worker will create embedding vector itself rather than asking master to create. Use `set_if_not_exists` to avoid conflict between workers.
* call `optimizer.apply_gradient` only once.
* remove `name` argument in `EdlEmbedding`'s constructor. 