### PR TITLE
Add redis environment to elasticdl's image

### DIFF
--- a/elasticdl/docker/Dockerfile
+++ b/elasticdl/docker/Dockerfile
@@ -6,8 +6,13 @@ FROM ${BASE_IMAGE}
 COPY elasticdl/docker/bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
 
-RUN apt-get update && apt-get install -y unzip curl git
+RUN apt-get update && apt-get install -y unzip curl git software-properties-common
 
+# install redis 5.0.5
+RUN add-apt-repository ppa:chris-lea/redis-server -y \
+    && apt-get update \
+    && apt-get install -y redis-server
+    
 COPY elasticdl/requirements.txt /requirements.txt
 ARG EXTRA_PYPI_INDEX
 RUN pip install -r /requirements.txt --extra-index-url=${EXTRA_PYPI_INDEX}

--- a/elasticdl/docker/Dockerfile.dev
+++ b/elasticdl/docker/Dockerfile.dev
@@ -6,8 +6,13 @@ FROM ${BASE_IMAGE}
 COPY elasticdl/docker/bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
 
-RUN apt-get update && apt-get install -y unzip curl git
+RUN apt-get update && apt-get install -y unzip curl git software-properties-common
 
+# install redis 5.0.5
+RUN add-apt-repository ppa:chris-lea/redis-server -y \
+    && apt-get update \
+    && apt-get install -y redis-server
+		
 COPY elasticdl/requirements.txt /requirements.txt
 ARG EXTRA_PYPI_INDEX
 RUN pip install -r /requirements.txt --extra-index-url=${EXTRA_PYPI_INDEX}

--- a/elasticdl/requirements.txt
+++ b/elasticdl/requirements.txt
@@ -6,3 +6,4 @@ pytest-cov
 pyrecordio>=0.0.6
 Pillow
 odps
+redis-py-cluster


### PR DESCRIPTION
Basis of #1036 .
Master and workers need access redis-cluster, it requires redis environment.