### PR TITLE
Remove unused embedding_vectors local variable

### DIFF
--- a/elasticdl/python/common/embedding_service.py
+++ b/elasticdl/python/common/embedding_service.py
@@ -256,7 +256,6 @@ class EmbeddingService(object):
             for ip, port_list in embedding_service_endpoint.items()
             for port in port_list
         ]
-        embedding_vectors = []
         embedding_service = RedisCluster(
             startup_nodes=startup_nodes, decode_responses=False
         ).pipeline()


### PR DESCRIPTION
This local variable is initialized via `embedding_vectors = embedding_service.execute()` so this line is unnecessary.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>