### PR TITLE
 Check if the Redis cluster started successfully

### DIFF
--- a/elasticdl/python/common/constants.py
+++ b/elasticdl/python/common/constants.py
@@ -32,4 +32,4 @@ class Mode(object):
 
 
 class Redis(object):
-    RETRY_COMMAND_TIMES = 10
+    MAX_COMMAND_RETRY_TIMES = 10

--- a/elasticdl/python/common/embedding_service.py
+++ b/elasticdl/python/common/embedding_service.py
@@ -201,7 +201,12 @@ class EmbeddingService(object):
 
     def _run_shell_command(self, command):
         retry_times = 0
-        while retry_times < Redis.RETRY_COMMAND_TIMES:
+        while retry_times <= Redis.MAX_COMMAND_RETRY_TIMES:
+            if retry_times:
+                logger.warning(
+                    'Command: "%s" failed to run, retry times: %d .'
+                    % (command, retry_times)
+                )
             redis_process = subprocess.Popen(
                 [command],
                 shell=True,


### PR DESCRIPTION
Fix #1069 .
I use `subprocess.Popen()` to start the Redis cluster. Now, I check the `returncode` of command, if `returncode` is not zero, try to start the Redis cluster again.