### PR TITLE
modify interface between master and embedding service

### DIFF
--- a/elasticdl/python/common/embedding_service.py
+++ b/elasticdl/python/common/embedding_service.py
@@ -296,7 +296,7 @@ class EmbeddingService(object):
         if (
             keys is None
             or embedding_vectors is None
-            or len(keys) != embedding_vectors.shape[0]
+            or len(keys) != len(embedding_vectors)
         ):
             raise Exception(
                 "keys and embedding_vectors can not be 'None'. "

--- a/elasticdl/python/tests/report_gradients_of_bet_test.py
+++ b/elasticdl/python/tests/report_gradients_of_bet_test.py
@@ -19,28 +19,15 @@ class MockEmbeddingService:
 
     def mock_lookup_embedding(self, **kwargs):
         keys = kwargs["keys"]
-        embeddings = None
+        embeddings = []
         for k in keys:
             layer_name, idx = k.split("-")
             idx = int(idx)
-            if embeddings is None:
-                embeddings = self.mock_embedding_table[layer_name][
-                    idx
-                ].reshape((1, -1))
-            else:
-                embeddings = np.concatenate(
-                    [
-                        embeddings,
-                        self.mock_embedding_table[layer_name][idx].reshape(
-                            (1, -1)
-                        ),
-                    ],
-                    axis=0,
-                )
-        return embeddings
+            embeddings.append(self.mock_embedding_table[layer_name][idx])
+        return embeddings, []
 
     def mock_update_embedding(self, **kwargs):
-        keys, embeddings = kwargs["keys"], kwargs["embeddings"]
+        keys, embeddings = kwargs["keys"], kwargs["embedding_vectors"]
         if embeddings is None:
             return
         for k, emb in zip(keys, embeddings):


### PR DESCRIPTION
Fix #1076.
After this PR, model `deepfm_edl_embedding` in model zoo can run on cluster.