### PR TITLE
Use temp directory when launching redis tests

### DIFF
--- a/elasticdl/python/tests/embedding_service_test.py
+++ b/elasticdl/python/tests/embedding_service_test.py
@@ -66,12 +66,10 @@ class EmbeddingServiceTest(unittest.TestCase):
             EmbeddingService.update_embedding(
                 keys, origin_data, embedding_endpoint
             )
-            lookup_data, unknown_keys_index = (
-                EmbeddingService.lookup_embedding(
-                    keys, embedding_endpoint, parse_type=np.float32
-                )
+            lookup_data, unknown_keys_idx = EmbeddingService.lookup_embedding(
+                keys, embedding_endpoint, parse_type=np.float32
             )
-            self.assertTrue(len(unknown_keys_index) == 0)
+            self.assertTrue(len(unknown_keys_idx) == 0)
             output_length = len(keys)
             lookup_data = np.concatenate(lookup_data, axis=0)
             lookup_data = lookup_data.reshape((output_length, -1))
@@ -83,10 +81,8 @@ class EmbeddingServiceTest(unittest.TestCase):
             EmbeddingService.update_embedding(
                 keys, origin_data_2, embedding_endpoint, set_if_not_exist=True
             )
-            lookup_data, unknown_keys_index = (
-                EmbeddingService.lookup_embedding(
-                    keys, embedding_endpoint, parse_type=np.float32
-                )
+            lookup_data, unknown_keys_idx = EmbeddingService.lookup_embedding(
+                keys, embedding_endpoint, parse_type=np.float32
             )
             lookup_data = np.concatenate(lookup_data, axis=0)
             lookup_data = lookup_data.reshape((output_length, -1))
@@ -95,14 +91,10 @@ class EmbeddingServiceTest(unittest.TestCase):
 
             # Test non-exist keys
             keys_do_not_exist = ["test_no_exist_%d" % i for i in range(10)]
-            lookup_data, unknown_keys_index = (
-                EmbeddingService.lookup_embedding(
-                    keys_do_not_exist,
-                    embedding_endpoint,
-                    parse_type=np.float32
-                )
+            lookup_data, unknown_keys_idx = EmbeddingService.lookup_embedding(
+                keys_do_not_exist, embedding_endpoint, parse_type=np.float32
             )
-            self.assertTrue(len(unknown_keys_index) == 10)
+            self.assertTrue(len(unknown_keys_idx) == 10)
             self.assertTrue(len(lookup_data) == 10)
             # Close
             self.assertTrue(embedding_service.stop_embedding_service())


### PR DESCRIPTION
Better to use temp directory when we launch redis cluster in the unittests.