### PR TITLE
Revise Embedding layer to not depend on worker

### DIFF
--- a/elasticdl/python/elasticdl/layers/embedding.py
+++ b/elasticdl/python/elasticdl/layers/embedding.py
@@ -45,7 +45,7 @@ class Embedding(tf.keras.layers.Layer):
         self.input_length = input_length
         self.combiner = combiner
         self.tape = None
-        self.worker = None
+        self.lookup_func = None
         self.bet_ids_pair = []
 
     @tf_utils.shape_type_conversion
@@ -87,7 +87,7 @@ class Embedding(tf.keras.layers.Layer):
         return "-".join(map(str, name_list))
 
     def lookup_embedding(self, unique_ids):
-        batch_embedding = self.worker.lookup_embedding(
+        batch_embedding = self.lookup_func(
             unique_ids.numpy(),
             self._name,
             self.embedding_initializer,
@@ -161,10 +161,19 @@ class Embedding(tf.keras.layers.Layer):
 
     def reset(self):
         self.bet_ids_pair = []
-        self.tape = None
 
     def set_tape(self, tape):
         self.tape = tape
 
-    def set_worker(self, worker):
-        self.worker = worker
+    def set_lookup_func(self, lookup_func):
+        """
+        lookup_func args
+          ids: id list to lookup
+          layer_name: layer name
+          initializer: intializer method name for unkown embeddings
+          output_dim: the embedding vector dimension
+        return:
+          embeddings corresponding to the ids, in numpy ndarray type
+          with a shape of (len(ids), output_dim)
+        """
+        self.lookup_func = lookup_func

--- a/elasticdl/python/tests/layer_test.py
+++ b/elasticdl/python/tests/layer_test.py
@@ -84,7 +84,7 @@ def create_embedding_layer(
         mask_zero=mask_zero,
     )
     worker = mock_worker(embedding_size, output_dim)
-    layer.set_worker(worker)
+    layer.set_lookup_func(worker.lookup_embedding)
     return layer
 
 


### PR DESCRIPTION
fix #1090 

1. elasticdl.layers.Embedding only need a function to support lookup embedding vectors, not a worker.

2. The worker can use a persistent tape, and set it to Embedding layers only once, instead of set it in every minibatch training.
