### PR TITLE
Refactor code for loading model spec

### DIFF
--- a/elasticdl/python/common/model_helper.py
+++ b/elasticdl/python/common/model_helper.py
@@ -1,6 +1,11 @@
 import importlib.util
 import os
 
+from elasticdl.python.common.log_util import default_logger as logger
+from elasticdl.python.worker.prediction_outputs_processor import (
+    BasePredictionOutputsProcessor,
+)
+
 
 def load_module(module_file):
     spec = importlib.util.spec_from_file_location(module_file, module_file)
@@ -9,20 +14,11 @@ def load_module(module_file):
     return module
 
 
-# TODO: More validation around the following two functions
-def _get_model_def_name(model_def):
-    return model_def.split(".")[-1]
-
-
-def _get_model_def_file_path(model_def):
-    return "/".join(model_def.split(".")[:-1]) + ".py"
-
-
 # TODO: Discuss whether we need to support default model
 # function/class names such as `custom_model()`
 # or `CustomModel()`
 def load_model_from_module(model_def, model_module, model_params):
-    model_def_name = _get_model_def_name(model_def)
+    model_def_name = model_def.split(".")[-1]
     if model_def_name in model_module:
         custom_model_name = model_def_name
     else:
@@ -41,8 +37,87 @@ def load_model_from_module(model_def, model_module, model_params):
         return model_module[custom_model_name]()
 
 
-def get_model_file(model_zoo, model_def):
-    return os.path.join(model_zoo, _get_model_def_file_path(model_def))
+def get_module_file_path(model_zoo, spec_key):
+    """Get the path to module file from model zoo and the spec string.
+
+    For example, if `model_zoo = "model_zoo"` and
+    `spec_key = "test_module.custom_model"`, the function returns
+    "model_zoo/test_module.py".
+    """
+    return os.path.join(model_zoo, "/".join(spec_key.split(".")[:-1]) + ".py")
+
+
+def _get_spec_value(spec_key, model_zoo, default_module):
+    """Get the value to the given spec key.
+
+    Notes:
+
+    * If the dot-splitted spec key (e.g. "test_module.custom_model"
+      is splitted into "test_module" and "custom_model") is of length 1
+      (e.g. `spec_key` is "custom_model"), return the value in the
+      specified `default_module`.
+    * If the spec key does not exist in the module, return `None`.
+    """
+    spec_key_items = spec_key.split(".")
+    spec_key_base = spec_key_items[-1]
+    if len(spec_key_items) == 1:
+        spec_key_module = default_module
+    else:
+        spec_key_module = load_module(
+            get_module_file_path(model_zoo, spec_key)
+        ).__dict__
+    return (
+        spec_key_module[spec_key_base]
+        if spec_key_base in spec_key_module
+        else None
+    )
+
+
+def get_model_spec(
+    model_zoo,
+    model_def,
+    model_params,
+    dataset_fn,
+    loss,
+    optimizer,
+    eval_metrics_fn,
+    prediction_outputs_processor,
+):
+    """Get the model spec items in a tuple.
+
+    The model spec tuple contains the following items in order:
+
+    * The model object instantiated with parameters specified
+      in `model_params`,
+    * The `dataset_fn`,
+    * The `loss`,
+    * The `optimizer`,
+    * The `eval_metrics_fn`,
+    * The `prediction_outputs_processor`. Note that it will print
+      warning if it's not inherited from `BasePredictionOutputsProcessor`.
+    """
+    model_def_module_file = get_module_file_path(model_zoo, model_def)
+    default_module = load_module(model_def_module_file).__dict__
+    model = load_model_from_module(model_def, default_module, model_params)
+    prediction_outputs_processor = _get_spec_value(
+        prediction_outputs_processor, model_zoo, default_module
+    )
+    if prediction_outputs_processor and not isinstance(
+        prediction_outputs_processor, BasePredictionOutputsProcessor
+    ):
+        logger.warning(
+            "prediction_outputs_processor is not "
+            "inherited from BasePredictionOutputsProcessor. "
+            "Prediction outputs may not be processed correctly."
+        )
+    return (
+        model,
+        _get_spec_value(dataset_fn, model_zoo, default_module),
+        _get_spec_value(loss, model_zoo, default_module),
+        _get_spec_value(optimizer, model_zoo, default_module),
+        _get_spec_value(eval_metrics_fn, model_zoo, default_module),
+        prediction_outputs_processor,
+    )
 
 
 def save_checkpoint_to_file(pb_model, file_name):

--- a/elasticdl/python/master/main.py
+++ b/elasticdl/python/master/main.py
@@ -18,7 +18,7 @@ from elasticdl.python.common.embedding_service import EmbeddingService
 from elasticdl.python.common.log_util import get_logger
 from elasticdl.python.common.model_helper import (
     find_layer,
-    get_model_file,
+    get_module_file_path,
     load_model_from_module,
     load_module,
 )
@@ -99,7 +99,7 @@ def main():
         args.num_epochs,
     )
     model_module = load_module(
-        get_model_file(args.model_zoo, args.model_def)
+        get_module_file_path(args.model_zoo, args.model_def)
     ).__dict__
     model_inst = load_model_from_module(
         args.model_def, model_module, args.model_params

--- a/elasticdl/python/tests/checkpoint_test.py
+++ b/elasticdl/python/tests/checkpoint_test.py
@@ -9,16 +9,18 @@ import tensorflow as tf
 
 from elasticdl.proto import elasticdl_pb2
 from elasticdl.python.common.constants import JobType
-from elasticdl.python.common.model_helper import get_model_file, load_module
+from elasticdl.python.common.model_helper import (
+    get_module_file_path,
+    load_module,
+)
 from elasticdl.python.master.checkpoint_service import CheckpointService
 from elasticdl.python.master.servicer import MasterServicer
 from elasticdl.python.master.task_dispatcher import _TaskDispatcher
 from elasticdl.python.tests.in_process_master import InProcessMaster
 from elasticdl.python.worker.worker import Worker
 
-_model_file = get_model_file(
-    os.path.dirname(os.path.realpath(__file__)), "test_module.custom_model"
-)
+_model_zoo_path = os.path.dirname(os.path.realpath(__file__))
+_model_file = get_module_file_path(_model_zoo_path, "test_module.custom_model")
 m = load_module(_model_file).__dict__
 
 
@@ -96,7 +98,7 @@ class CheckpointTest(unittest.TestCase):
                 1,
                 JobType.TRAINING_ONLY,
                 batch_size,
-                _model_file,
+                _model_zoo_path,
                 model_def="test_module.custom_model",
                 channel=None,
             )

--- a/elasticdl/python/tests/example_test.py
+++ b/elasticdl/python/tests/example_test.py
@@ -9,7 +9,6 @@ import tensorflow as tf
 
 from elasticdl.proto import elasticdl_pb2
 from elasticdl.python.common.constants import JobType
-from elasticdl.python.common.model_helper import get_model_file
 from elasticdl.python.master.checkpoint_service import CheckpointService
 from elasticdl.python.master.evaluation_service import EvaluationService
 from elasticdl.python.master.servicer import MasterServicer
@@ -17,11 +16,9 @@ from elasticdl.python.master.task_dispatcher import _TaskDispatcher
 from elasticdl.python.tests.in_process_master import InProcessMaster
 from elasticdl.python.worker.worker import Worker
 
-
-def _get_model_zoo_path():
-    return os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "../../../model_zoo"
-    )
+_model_zoo_path = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "../../../model_zoo"
+)
 
 
 def create_recordio_file(size, shape):
@@ -112,8 +109,6 @@ class ExampleTest(unittest.TestCase):
         Run distributed training and evaluation with a local master.
         grpc calls are mocked by local master call.
         """
-        module_file = get_model_file(_get_model_zoo_path(), model_def)
-
         job_type = (
             JobType.TRAINING_ONLY if training else JobType.EVALUATION_ONLY
         )
@@ -122,7 +117,7 @@ class ExampleTest(unittest.TestCase):
             1,
             job_type,
             batch_size,
-            module_file,
+            _model_zoo_path,
             model_def=model_def,
             model_params=model_params,
             channel=None,

--- a/elasticdl/python/tests/indices_slices_gradient_test.py
+++ b/elasticdl/python/tests/indices_slices_gradient_test.py
@@ -5,15 +5,11 @@ import numpy as np
 import tensorflow as tf
 
 from elasticdl.python.common.constants import JobType
-from elasticdl.python.common.model_helper import get_model_file, load_module
 from elasticdl.python.master.servicer import MasterServicer
 from elasticdl.python.tests.in_process_master import InProcessMaster
 from elasticdl.python.worker.worker import Worker
 
-_model_file = get_model_file(
-    os.path.dirname(os.path.realpath(__file__)), "test_module.custom_model"
-)
-m = load_module(_model_file).__dict__
+_model_zoo_path = os.path.dirname(os.path.realpath(__file__))
 
 
 def custom_model():
@@ -48,7 +44,7 @@ class IndexedSlicesTest(unittest.TestCase):
             1,
             JobType.TRAINING_ONLY,
             2,
-            _model_file,
+            _model_zoo_path,
             model_def="test_module.custom_model",
             channel=None,
         )

--- a/elasticdl/python/tests/layer_test.py
+++ b/elasticdl/python/tests/layer_test.py
@@ -6,7 +6,7 @@ import tensorflow as tf
 
 from elasticdl.python.common.model_helper import (
     find_layer,
-    get_model_file,
+    get_module_file_path,
     load_model_from_module,
     load_module,
 )
@@ -20,7 +20,7 @@ def _get_model_zoo_path():
 
 
 def _create_model_instance(model_def):
-    module_file = get_model_file(_get_model_zoo_path(), model_def)
+    module_file = get_module_file_path(_get_model_zoo_path(), model_def)
     model_module = load_module(module_file).__dict__
     return load_model_from_module(model_def, model_module, None)
 

--- a/elasticdl/python/tests/model_helper_test.py
+++ b/elasticdl/python/tests/model_helper_test.py
@@ -1,0 +1,64 @@
+import os
+import unittest
+
+from elasticdl.python.common.model_helper import (
+    _get_spec_value,
+    get_model_spec,
+    get_module_file_path,
+)
+
+_model_zoo_path = os.path.dirname(os.path.realpath(__file__))
+
+
+class ModelHelperTest(unittest.TestCase):
+    def test_get_model_spec(self):
+        (
+            model,
+            dataset_fn,
+            loss,
+            optimizer,
+            eval_metrics_fn,
+            prediction_outputs_processor,
+        ) = get_model_spec(
+            model_zoo=_model_zoo_path,
+            model_def="test_module.custom_model",
+            dataset_fn="dataset_fn",
+            loss="loss",
+            optimizer="optimizer",
+            eval_metrics_fn="eval_metrics_fn",
+            model_params="",
+            prediction_outputs_processor="PredictionOutputsProcessor",
+        )
+
+        self.assertTrue(model is not None)
+        self.assertTrue(dataset_fn is not None)
+        self.assertTrue(loss is not None)
+        self.assertTrue(optimizer is not None)
+        self.assertTrue(eval_metrics_fn is not None)
+        self.assertTrue(prediction_outputs_processor is not None)
+
+    def test_get_module_file_path(self):
+        self.assertEqual(
+            get_module_file_path(_model_zoo_path, "test_module.custom_model"),
+            os.path.join(_model_zoo_path, "test_module.py"),
+        )
+
+    def test_get_spec_value(self):
+        self.assertTrue(
+            _get_spec_value(
+                "custom_model", _model_zoo_path, {"custom_model": 1}
+            )
+            is not None
+        )
+        self.assertTrue(
+            _get_spec_value("test_module.custom_model", _model_zoo_path, {})
+            is not None
+        )
+        self.assertTrue(
+            _get_spec_value("test_module.unknown_model", _model_zoo_path, {})
+            is None
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/elasticdl/python/tests/report_gradients_of_bet_test.py
+++ b/elasticdl/python/tests/report_gradients_of_bet_test.py
@@ -7,10 +7,11 @@ import tensorflow as tf
 
 from elasticdl.python.common.constants import JobType
 from elasticdl.python.common.embedding_service import EmbeddingService
-from elasticdl.python.common.model_helper import get_model_file, load_module
 from elasticdl.python.master.servicer import MasterServicer
 from elasticdl.python.tests.in_process_master import InProcessMaster
 from elasticdl.python.worker.worker import Worker
+
+_model_zoo_path = os.path.dirname(os.path.realpath(__file__))
 
 
 class MockEmbeddingService:
@@ -34,12 +35,6 @@ class MockEmbeddingService:
             layer_name, idx = k.split("-")
             idx = int(idx)
             self.mock_embedding_table[layer_name][idx] = emb
-
-
-_model_file = get_model_file(
-    os.path.dirname(os.path.realpath(__file__)), "test_module.custom_model"
-)
-m = load_module(_model_file).__dict__
 
 
 def custom_model():
@@ -87,7 +82,7 @@ class ReportBETGradientTest(unittest.TestCase):
             1,
             JobType.TRAINING_ONLY,
             2,
-            _model_file,
+            _model_zoo_path,
             model_def="test_module.custom_model",
             channel=None,
         )

--- a/elasticdl/python/tests/test_module.py
+++ b/elasticdl/python/tests/test_module.py
@@ -2,6 +2,10 @@ import tensorflow as tf
 from tensorflow.keras import Model
 from tensorflow.keras.layers import Dense, Input
 
+from elasticdl.python.worker.prediction_outputs_processor import (
+    BasePredictionOutputsProcessor,
+)
+
 
 def custom_model():
     inputs = Input(shape=(1, 1), name="x")
@@ -32,3 +36,11 @@ def optimizer(lr=0.1):
 
 def eval_metrics_fn(predictions, labels):
     return {"mse": tf.reduce_mean(tf.square(predictions - labels))}
+
+
+class PredictionOutputsProcessor(BasePredictionOutputsProcessor):
+    def __init__(self):
+        pass
+
+    def process(self, predictions, worker_id):
+        pass

--- a/elasticdl/python/tests/worker_test.py
+++ b/elasticdl/python/tests/worker_test.py
@@ -11,12 +11,13 @@ import tensorflow as tf
 from elasticdl.proto import elasticdl_pb2
 from elasticdl.python.common.constants import JobType
 from elasticdl.python.common.embedding_service import EmbeddingService
-from elasticdl.python.common.model_helper import get_model_file, load_module
 from elasticdl.python.master.evaluation_service import EvaluationService
 from elasticdl.python.master.servicer import MasterServicer
 from elasticdl.python.master.task_dispatcher import _TaskDispatcher
 from elasticdl.python.tests.in_process_master import InProcessMaster
 from elasticdl.python.worker.worker import Worker
+
+_model_zoo_path = os.path.dirname(os.path.realpath(__file__))
 
 
 class MockEmbeddingService:
@@ -43,16 +44,6 @@ class MockEmbeddingService:
             return
         for k, emb in zip(keys, embeddings):
             self.mock_embedding_table[k] = emb
-
-
-_model_file = get_model_file(
-    os.path.dirname(os.path.realpath(__file__)), "test_module.custom_model"
-)
-_embedding_model_file = get_model_file(
-    os.path.dirname(os.path.realpath(__file__)),
-    "embedding_test_module.CustomModel",
-)
-m = load_module(_model_file).__dict__
 
 
 def create_recordio_file(size):
@@ -102,7 +93,7 @@ class WorkerTest(unittest.TestCase):
             1,
             job_type,
             batch_size,
-            _model_file,
+            _model_zoo_path,
             model_def="test_module.custom_model",
             channel=None,
         )
@@ -162,7 +153,7 @@ class WorkerTest(unittest.TestCase):
             1,
             JobType.TRAINING_ONLY,
             32,
-            _embedding_model_file,
+            _model_zoo_path,
             model_def="embedding_test_module.CustomModel",
             channel=None,
         )
@@ -189,7 +180,7 @@ class WorkerTest(unittest.TestCase):
             1,
             JobType.TRAINING_ONLY,
             32,
-            _embedding_model_file,
+            _model_zoo_path,
             model_def="embedding_test_module.CustomModel",
             channel=None,
         )

--- a/elasticdl/python/worker/main.py
+++ b/elasticdl/python/worker/main.py
@@ -4,7 +4,6 @@ import grpc
 
 from elasticdl.python.common import log_util
 from elasticdl.python.common.constants import GRPC
-from elasticdl.python.common.model_helper import get_model_file
 from elasticdl.python.worker.worker import Worker
 
 
@@ -104,7 +103,7 @@ def main():
         args.worker_id,
         args.job_type,
         args.minibatch_size,
-        get_model_file(args.model_zoo, args.model_def),
+        args.model_zoo,
         channel=channel,
         embedding_service_endpoint=eval(args.embedding_service_endpoint),
         dataset_fn=args.dataset_fn,


### PR DESCRIPTION
* Support specifying `loss`, `optimizer`, etc. from different import paths. Prior to this PR, we could only load all of the pieces from the same model definition file.
* Refactored relevant code into testable functions, added tests, and documentation.
* `Worker` now calls `get_model_spec()` to load necessary pieces from the model definition file.