### PR TITLE
No need to print master pod status after launching

### DIFF
--- a/elasticdl/python/common/k8s_client.py
+++ b/elasticdl/python/common/k8s_client.py
@@ -242,8 +242,8 @@ class Client(object):
         # Add replica type and index
         pod.metadata.labels[ELASTICDL_REPLICA_TYPE_KEY] = "master"
         pod.metadata.labels[ELASTICDL_REPLICA_INDEX_KEY] = "0"
-        resp = self.client.create_namespaced_pod(self.namespace, pod)
-        logger.info("Master launched. status='%s'" % str(resp.status))
+        self.client.create_namespaced_pod(self.namespace, pod)
+        logger.info("Master launched.")
 
     def _create_worker_pod(self, pod_name, type_key, **kargs):
         # Find that master pod that will be used as the owner reference


### PR DESCRIPTION
Currently, when submitting a job, the last lines of logs look like:
```
[2019-09-03 14:10:24,172] [INFO] [k8s_client.py:246:create_master] Master launched. status='{'conditions': None,
 'container_statuses': None,
 'host_ip': None,
 'init_container_statuses': None,
 'message': None,
 'nominated_node_name': None,
 'phase': 'Pending',
 'pod_ip': None,
 'qos_class': 'Guaranteed',
 'reason': None,
 'start_time': None}'
[2019-09-03 14:10:24,173] [INFO] [api.py:217:_submit_job] ElasticDL job test-mnist-wy was successfully submitted. The master pod is: elasticdl-test-mnist-wy-master.
```
We don't need to log `status` here, as it doesn't contain any useful information here.