### PR TITLE
Clean out elasticdl cmd to make help info better organized

### DIFF
--- a/elasticdl/python/elasticdl/client.py
+++ b/elasticdl/python/elasticdl/client.py
@@ -11,7 +11,7 @@ from elasticdl.python.elasticdl.api import evaluate, predict, train
 
 def main():
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers(required=True, dest='cmd')
+    subparsers = parser.add_subparsers(required=True, dest="cmd")
 
     train_parser = subparsers.add_parser(
         "train", help="Submit a ElasticDL distributed training job"

--- a/elasticdl/python/elasticdl/client.py
+++ b/elasticdl/python/elasticdl/client.py
@@ -11,7 +11,8 @@ from elasticdl.python.elasticdl.api import evaluate, predict, train
 
 def main():
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers(required=True, dest="cmd")
+    subparsers = parser.add_subparsers(dest="cmd")
+    subparsers.required = True
 
     train_parser = subparsers.add_parser(
         "train", help="Submit a ElasticDL distributed training job"

--- a/elasticdl/python/elasticdl/client.py
+++ b/elasticdl/python/elasticdl/client.py
@@ -10,30 +10,25 @@ from elasticdl.python.elasticdl.api import evaluate, predict, train
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        usage="""elasticdl <command> [<args>]
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(required=True, dest='cmd')
 
-Below is the list of supported commands:
-train         Submit a ElasticDL distributed training job.
-evaluate      Submit a ElasticDL distributed evaluation job.
-"""
+    train_parser = subparsers.add_parser(
+        "train", help="Submit a ElasticDL distributed training job"
     )
-    subparsers = parser.add_subparsers()
-
-    train_parser = subparsers.add_parser("train", help="elasticdl train -h")
     train_parser.set_defaults(func=train)
     add_common_params(train_parser)
     add_train_params(train_parser)
 
     evaluate_parser = subparsers.add_parser(
-        "evaluate", help="elasticdl evaluate -h"
+        "evaluate", help="Submit a ElasticDL distributed evaluation job"
     )
     evaluate_parser.set_defaults(func=evaluate)
     add_common_params(evaluate_parser)
     add_evaluate_params(evaluate_parser)
 
     predict_parser = subparsers.add_parser(
-        "predict", help="elasticdl predict -h"
+        "predict", help="Submit a ElasticDL distributed prediction job"
     )
     predict_parser.set_defaults(func=predict)
     add_common_params(predict_parser)


### PR DESCRIPTION
An exception will be printed if no subcommand provided. We need better help message here.
```
(elasticdl) ➜  elasticdl git:(develop) elasticdl
Traceback (most recent call last):
  File "/miniconda2/envs/elasticdl/bin/elasticdl", line 11, in <module>
    load_entry_point('elasticdl==0.0.1', 'console_scripts', 'elasticdl')()
  File "/miniconda2/envs/elasticdl/lib/python3.7/site-packages/elasticdl-0.0.1-py3.7.egg/elasticdl/python/elasticdl/client.py", line 44, in main
    args.func(args)
AttributeError: 'Namespace' object has no attribute 'func'
```