### PR TITLE
Move TensorBoard starting logic out of WorkerManager

### DIFF
--- a/elasticdl/python/master/k8s_worker_manager.py
+++ b/elasticdl/python/master/k8s_worker_manager.py
@@ -3,7 +3,6 @@ import threading
 from collections import Counter
 
 from elasticdl.python.common import k8s_client as k8s
-from elasticdl.python.common.k8s_tensorboard_client import TensorBoardClient
 from elasticdl.python.common.log_util import default_logger as logger
 
 
@@ -87,16 +86,6 @@ class WorkerManager(object):
     def start_workers(self):
         for i in range(self._num_workers):
             self._start_worker(self._next_worker_id())
-
-    def start_tensorboard_service(self):
-        tb_client = TensorBoardClient(self._k8s_client)
-        tb_client.create_tensorboard_service()
-        logger.info("Waiting for the URL for TensorBoard service...")
-        tb_url = tb_client.get_tensorboard_url()
-        if tb_url:
-            logger.info("TensorBoard service is available at: %s" % tb_url)
-        else:
-            logger.warning("Unable to get the URL for TensorBoard service")
 
     def _remove_worker(self, worker_id):
         logger.info("Removing worker: %d", worker_id)

--- a/elasticdl/python/master/main.py
+++ b/elasticdl/python/master/main.py
@@ -81,12 +81,6 @@ def main():
         # Start TensorBoard CLI
         tb_service = TensorboardService(args.tensorboard_log_dir, master_ip)
         tb_service.start()
-        # Start TensorBoard k8s Service
-        TensorBoardClient(
-            job_name=args.job_name,
-            image_name=args.worker_image,
-            namespace=args.namespace,
-        ).start_tensorboard_service()
     else:
         tb_service = None
 
@@ -260,7 +254,6 @@ def main():
             str(embedding_service_endpoint),
         ]
 
-        logger.info(">>> master pod envs argument is %s" % args.envs)
         env_dict = parse_envs(args.envs)
         env = []
         for key in env_dict:
@@ -287,6 +280,14 @@ def main():
         logger.info("Launching %d workers", args.num_workers)
         worker_manager.start_workers()
         worker_manager.update_status(WorkerManagerStatus.RUNNING)
+
+    # Start TensorBoard k8s Service if requested
+    if tb_service:
+        TensorBoardClient(
+            job_name=args.job_name,
+            image_name=args.worker_image,
+            namespace=args.namespace,
+        ).start_tensorboard_service()
 
     try:
         while True:

--- a/elasticdl/python/tests/k8s_tensorboard_client_test.py
+++ b/elasticdl/python/tests/k8s_tensorboard_client_test.py
@@ -3,7 +3,6 @@ import random
 import time
 import unittest
 
-from elasticdl.python.common import k8s_client as k8s
 from elasticdl.python.common.k8s_tensorboard_client import TensorBoardClient
 
 
@@ -13,15 +12,14 @@ from elasticdl.python.common.k8s_tensorboard_client import TensorBoardClient
 )
 class K8sTensorBoardClientTest(unittest.TestCase):
     def test_create_tensorboard_service(self):
-        client = k8s.Client(
+        tb_client = TensorBoardClient(
             image_name=None,
             namespace="default",
             job_name="test-job-%d-%d"
             % (int(time.time()), random.randint(1, 101)),
             event_callback=None,
         )
-        tb_client = TensorBoardClient(client)
-        tb_client.create_tensorboard_service(
+        tb_client._create_tensorboard_service(
             port=80, service_type="LoadBalancer"
         )
         time.sleep(1)


### PR DESCRIPTION
Previously `WorkerManager` starts TensorBoard service via `worker_manager.start_tensorboard_service()`. However, TensorBoard is only related to master pod and has nothing to do with other workers. This PR removes the dependency so the logic is clearer in `master.main`.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>