### PR TITLE
Check for required functions in model definition files

### DIFF
--- a/elasticdl/python/tests/model_helper_test.py
+++ b/elasticdl/python/tests/model_helper_test.py
@@ -58,6 +58,16 @@ class ModelHelperTest(unittest.TestCase):
             _get_spec_value("test_module.unknown_model", _model_zoo_path, {})
             is None
         )
+        self.assertRaisesRegex(
+            Exception,
+            "Missing required spec key unknown_model "
+            "in the module: test_module.unknown_model",
+            _get_spec_value,
+            "test_module.unknown_model",
+            _model_zoo_path,
+            {},
+            True,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #805. Here we assume all of them are required except for optional prediction outputs processing. There are more work required if we want to treat them differently for different phases but that's not in demand now (it's better if users can define all of them at once so they can perform different tasks).

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>