### PR TITLE
Add default None for event callback in k8s client

### DIFF
--- a/elasticdl/python/common/k8s_client.py
+++ b/elasticdl/python/common/k8s_client.py
@@ -28,7 +28,7 @@ class Client(object):
         image_name,
         namespace,
         job_name,
-        event_callback,
+        event_callback=None,
         cluster_spec=""
     ):
         """


### PR DESCRIPTION
`TensorBoardClient`'s constructor has `**kwargs` passed to `k8s.Client`. If `event_callback` does not have a default, this becomes a required keyword arg for `TensorBoardClient`'s constructor which will throw error if it's not specified.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>