### PR TITLE
Add manifest example yaml for Minikube

### DIFF
--- a/elasticdl/README.md
+++ b/elasticdl/README.md
@@ -137,11 +137,16 @@ This will train MNIST data with a model defined in [model_zoo/mnist_functional_a
 
 ### Test with Kubernetes
 
-We can also test ElasticDL job in a Kubernetes cluster using the previously built [image](#the-development-docker-image).
+We can also test ElasticDL job in a Kubernetes cluster using the previously built [image](#development-docker-image).
 
 First make sure the built image has been pushed to a docker registry, and then run the following command to launch the job. 
 ```bash
 kubectl apply -f manifests/examples/elasticdl-demo-k8s.yaml
+```
+
+For running demo job in Minikube, please make sure run `eval $(minikube docker-env)` first, and then build images.
+```bash
+kubectl apply -f manifests/examples/elasticdl-demo-minikube.yaml
 ```
 
 If you find permission error in the main pod log, e.g., `"pods is forbidden: User \"system:serviceaccount:default:default\" cannot create resource \"pods\""`, you need to grant pod-related permissions for the default user.

--- a/elasticdl/manifests/examples/elasticdl-demo-minikube.yaml
+++ b/elasticdl/manifests/examples/elasticdl-demo-minikube.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: elasticdl-test-mnist-master
+  labels:
+    app: elasticdl
+    elasticdl-job-name: test-mnist
+    elasticdl-replica-type: master
+    elasticdl-replica-index: "0"
+spec:
+  containers:
+  - name: mnist-demo-container
+    image: elasticdl:ci
+    command: ["/bin/bash"]
+    args:
+    - -c
+    - >
+      python -m elasticdl.python.master.main
+      --model_zoo=model_zoo
+      --model_def=mnist_functional_api.mnist_functional_api.custom_model
+      --training_data_dir=/data/mnist/train
+      --evaluation_data_dir=/data/mnist/test
+      --records_per_task=100
+      --num_epochs=2
+      --grads_to_wait=10
+      --minibatch_size=64
+      --num_workers=2
+      --checkpoint_steps=10
+      --evaluation_steps=15
+      --worker_image=elasticdl:ci
+      --job_name=test-mnist
+      --log_level=INFO
+      --image_pull_policy=Never
+    imagePullPolicy: Never
+    env:
+      - name: MY_POD_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+  restartPolicy: Never


### PR DESCRIPTION
When running in Minikube, users need to update the ImagePullPolicy to Never. For better user experience, just create a demo yaml for Minikube, and users don't need to update ImagePullPolicy themselves. 