### PR TITLE
Add model_zoo for elasticdl:ci image

### DIFF
--- a/elasticdl/docker/Dockerfile.ci
+++ b/elasticdl/docker/Dockerfile.ci
@@ -4,5 +4,6 @@ WORKDIR /
 ENV PYTHONPATH=/
 COPY elasticdl /elasticdl
 COPY setup.py setup.py
+COPY model_zoo /model_zoo
 RUN make -f elasticdl/Makefile
 RUN python setup.py install


### PR DESCRIPTION
The model_zoo should be included in elasticdl:ci image, as elasticdl:ci is supposed to be a runnable demo image.