### PR TITLE
Delete lock in  `GetModel` and `_update_model`

### DIFF
--- a/elasticdl/python/master/servicer.py
+++ b/elasticdl/python/master/servicer.py
@@ -175,8 +175,10 @@ class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
 
     def _update_model(self):
         if not self._use_async and not self._lock.locked():
+            # TODO (chengfu.wcy) `self._lock.locked` may be removed
+            # according to  changes in `ReportGradient` in async mode.
             raise RuntimeError(
-                "Lock must be acquired when updating " "the model in sync mode"
+                "Lock must be acquired when updating the model in sync mode"
             )
         grad_var = []
 

--- a/elasticdl/python/master/servicer.py
+++ b/elasticdl/python/master/servicer.py
@@ -175,7 +175,9 @@ class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
 
     def _update_model(self):
         if not self._use_async and not self._lock.locked():
-            raise RuntimeError("In sync mode, lock is not acquired")
+            raise RuntimeError(
+                "Lock must be acquired when updating " "the model in sync mode"
+            )
         grad_var = []
 
         # (grad, var) pairs excluding keras Embedding layer and

--- a/elasticdl/python/master/servicer.py
+++ b/elasticdl/python/master/servicer.py
@@ -174,8 +174,7 @@ class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
             )
 
     def _update_model(self):
-        if (not self._use_async and
-                not self._lock.locked()):
+        if not self._use_async and not self._lock.locked():
             raise RuntimeError("In sync mode, lock is not acquired")
         grad_var = []
 


### PR DESCRIPTION
The lock in `GetModel` function can clearly removed. But there is also a lock in
+ `_update_model` from `ReportGradient`
+ `_update_model_version`

They depend on the lock from their parent's function.