### PR TITLE
Support tf.function when model has ElasticDL embedding layer

### DIFF
--- a/elasticdl/python/common/model_helper.py
+++ b/elasticdl/python/common/model_helper.py
@@ -160,7 +160,7 @@ def get_non_embedding_trainable_vars(model, embedding_layers):
     """
     embedding_items = []
     for layer in embedding_layers:
-        embedding_items.extend([bet for bet, _ in layer.bet_ids_pair])
+        embedding_items.extend(layer.trainable_variables)
     return [
         var for var in model.trainable_variables if var not in embedding_items
     ]

--- a/elasticdl/python/elasticdl/layers/embedding.py
+++ b/elasticdl/python/elasticdl/layers/embedding.py
@@ -57,19 +57,17 @@ class Embedding(tf.keras.layers.Layer):
         # BET's shape and ids' shape in `self._bet_ids_pair_graph` have `None`
         # dimension. This is because they have different shapes in different
         # iterations.
-        # `tf.Variable` requires initial value if shape has `None` dimension
-        bet_initial_value = tf.zeros((1, self.output_dim))
-        ids_initial_value = tf.zeros((1, 1), dtype=tf.int64)
+        # `tf.Variable` requires initial value if shape has `None` dimension.
         self._bet_ids_pair_graph = [
             (
                 tf.Variable(
-                    bet_initial_value,
+                    initial_value=tf.zeros((1, self.output_dim)),
                     shape=tf.TensorShape((None, self.output_dim)),
                     dtype=tf.float32,
                     trainable=True,
                 ),
                 tf.Variable(
-                    ids_initial_value,
+                    initial_value=tf.zeros((1, 1), dtype=tf.int64),
                     shape=tf.TensorShape(None),
                     dtype=tf.int64,
                     trainable=False,
@@ -185,7 +183,7 @@ class Embedding(tf.keras.layers.Layer):
                 self._bet_ids_pair_eagerly.append((batch_embedding, flat_ids))
                 batch_embedding = self._bet_ids_pair_eagerly[-1][0]
             else:
-                # In graph mode, assigning tensor to trainable variables is
+                # In graph mode, assigning tensors to trainable variables is
                 # allowed and tape can record the gradients of trainable
                 # variables automatically.
                 self._bet_ids_pair_graph[0][0].assign(batch_embedding)
@@ -221,7 +219,7 @@ class Embedding(tf.keras.layers.Layer):
                 )
                 batch_embedding = self._bet_ids_pair_eagerly[-1][0]
             else:
-                # In graph mode, assigning tensor to trainable variables is
+                # In graph mode, assigning tensors to trainable variables is
                 # allowed and tape can record the gradients of trainable
                 # variables automatically.
                 self._bet_ids_pair_graph[0][0].assign(batch_embedding)

--- a/elasticdl/python/elasticdl/layers/embedding.py
+++ b/elasticdl/python/elasticdl/layers/embedding.py
@@ -1,12 +1,14 @@
 import collections
+
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.keras.utils import tf_utils
 
 from elasticdl.python.master.embedding_service import EmbeddingService
 
-
-EmbeddingAndIds = collections.namedtuple('EmbeddingAndIds', ['batch_embedding', 'batch_ids'])
+EmbeddingAndIds = collections.namedtuple(
+    "EmbeddingAndIds", ["batch_embedding", "batch_ids"]
+)
 
 
 class Embedding(tf.keras.layers.Layer):
@@ -58,19 +60,19 @@ class Embedding(tf.keras.layers.Layer):
 
         self._embedding_and_ids_eagerly = []
 
-        # BET's shape and ids' shape in `self._embedding_and_ids_graph` have `None`
-        # dimension. This is because they have different shapes in different
-        # iterations.
+        # BET's shape and ids' shape in `self._embedding_and_ids_graph` have
+        # `None` dimension. This is because they have different shapes in
+        # different iterations.
         # `tf.Variable` requires initial value if shape has `None` dimension.
         self._embedding_and_ids_graph = [
             EmbeddingAndIds(
-                batch_embedding = tf.Variable(
+                batch_embedding=tf.Variable(
                     initial_value=tf.zeros((1, self.output_dim)),
                     shape=tf.TensorShape((None, self.output_dim)),
                     dtype=tf.float32,
                     trainable=True,
                 ),
-                batch_ids = tf.Variable(
+                batch_ids=tf.Variable(
                     initial_value=tf.zeros((1, 1), dtype=tf.int64),
                     shape=tf.TensorShape(None),
                     dtype=tf.int64,
@@ -198,9 +200,7 @@ class Embedding(tf.keras.layers.Layer):
         )
         # TODO: use tf.cond rather than python if statement
         if self.tape:
-            batch_embedding = (
-                self._record_gradients(batch_embedding, flat_ids)
-            )
+            batch_embedding = self._record_gradients(batch_embedding, flat_ids)
 
         outputs = tf.gather(batch_embedding, idx)
         # tf.reshape does not support shape with None. Replace None with -1.

--- a/elasticdl/python/tests/example_test.py
+++ b/elasticdl/python/tests/example_test.py
@@ -124,6 +124,7 @@ class ExampleTest(unittest.TestCase):
         )
 
         if dataset == "imagenet":
+            batch_size = 8
             shards = {create_imagenet_recordio_file(8, feature_shape): 8}
         elif dataset == "frappe":
             shards = {create_frappe_recordio_file(16, feature_shape, 5383): 16}

--- a/elasticdl/python/tests/example_test.py
+++ b/elasticdl/python/tests/example_test.py
@@ -124,7 +124,7 @@ class ExampleTest(unittest.TestCase):
         )
 
         if dataset == "imagenet":
-            shards = {create_imagenet_recordio_file(16, feature_shape): 16}
+            shards = {create_imagenet_recordio_file(8, feature_shape): 8}
         elif dataset == "frappe":
             shards = {create_frappe_recordio_file(16, feature_shape, 5383): 16}
         else:

--- a/elasticdl/python/tests/layer_test.py
+++ b/elasticdl/python/tests/layer_test.py
@@ -252,14 +252,14 @@ class EmbeddingLayerTest(unittest.TestCase):
                     layer.set_tape(tape)
                     output = module_call(layer, inputs)
                     output = output * multiply_tensor
-                bet = layer.bet_ids_pair[0].batch_embedding
+                bet = layer.embedding_and_ids[0].batch_embedding
                 grads = tape.gradient(output, bet)
                 self.assertTrue(
                     (grads.values.numpy() == multiply_values).all()
                 )
                 self.assertTrue(
                     (
-                        layer.bet_ids_pair[0].batch_ids.numpy()
+                        layer.embedding_and_ids[0].batch_ids.numpy()
                         == inputs.numpy().reshape(-1)
                     ).all()
                 )
@@ -273,10 +273,10 @@ class EmbeddingLayerTest(unittest.TestCase):
             layer.set_tape(tape)
             for inputs in inputs_list:
                 _ = layer.call(inputs)
-            self.assertTrue(len(layer.bet_ids_pair) == len(inputs_list))
+            self.assertTrue(len(layer.embedding_and_ids) == len(inputs_list))
             for i, correct_ids in enumerate(correct_ids_list):
                 self.assertTrue(
-                    (layer.bet_ids_pair[i].batch_ids.numpy() == correct_ids).all()
+                    (layer.embedding_and_ids[i].batch_ids.numpy() == correct_ids).all()
                 )
 
     def test_embedding_layer_gradient_with_sparse_inputs(self):
@@ -325,7 +325,7 @@ class EmbeddingLayerTest(unittest.TestCase):
                     layer.set_tape(tape)
                     output = module_call(layer, inputs)
                     output = output * multiply_tensor
-                bet = layer.bet_ids_pair[0].batch_embedding
+                bet = layer.embedding_and_ids[0].batch_embedding
                 grads = tape.gradient(output, bet)
                 grads = grads.numpy()
                 place = 8 if combiner == "sum" else 5
@@ -333,7 +333,7 @@ class EmbeddingLayerTest(unittest.TestCase):
                     self.assertAlmostEqual(grads[n][0], v, place)
                 self.assertTrue(
                     (
-                        layer.bet_ids_pair[0].batch_ids.numpy()
+                        layer.embedding_and_ids[0].batch_ids.numpy()
                         - np.array([1, 3, 2, 0, 6])
                         < 0.00001
                     ).all()
@@ -352,10 +352,10 @@ class EmbeddingLayerTest(unittest.TestCase):
                 layer.set_tape(tape)
                 _ = layer.call(inputs)
                 _ = layer.call(inputs)
-                self.assertTrue(len(layer.bet_ids_pair) == 2)
+                self.assertTrue(len(layer.embedding_and_ids) == 2)
                 for i in range(2):
                     self.assertTrue(
-                        (layer.bet_ids_pair[i].batch_ids.numpy() == correct_ids).all()
+                        (layer.embedding_and_ids[i].batch_ids.numpy() == correct_ids).all()
                     )
 
 

--- a/elasticdl/python/tests/layer_test.py
+++ b/elasticdl/python/tests/layer_test.py
@@ -276,7 +276,10 @@ class EmbeddingLayerTest(unittest.TestCase):
             self.assertTrue(len(layer.embedding_and_ids) == len(inputs_list))
             for i, correct_ids in enumerate(correct_ids_list):
                 self.assertTrue(
-                    (layer.embedding_and_ids[i].batch_ids.numpy() == correct_ids).all()
+                    (
+                        layer.embedding_and_ids[i].batch_ids.numpy()
+                        == correct_ids
+                    ).all()
                 )
 
     def test_embedding_layer_gradient_with_sparse_inputs(self):
@@ -355,7 +358,10 @@ class EmbeddingLayerTest(unittest.TestCase):
                 self.assertTrue(len(layer.embedding_and_ids) == 2)
                 for i in range(2):
                     self.assertTrue(
-                        (layer.embedding_and_ids[i].batch_ids.numpy() == correct_ids).all()
+                        (
+                            layer.embedding_and_ids[i].batch_ids.numpy()
+                            == correct_ids
+                        ).all()
                     )
 
 

--- a/elasticdl/python/tests/layer_test.py
+++ b/elasticdl/python/tests/layer_test.py
@@ -252,14 +252,14 @@ class EmbeddingLayerTest(unittest.TestCase):
                     layer.set_tape(tape)
                     output = module_call(layer, inputs)
                     output = output * multiply_tensor
-                bet = layer.bet_ids_pair[0][0]
+                bet = layer.bet_ids_pair[0].batch_embedding
                 grads = tape.gradient(output, bet)
                 self.assertTrue(
                     (grads.values.numpy() == multiply_values).all()
                 )
                 self.assertTrue(
                     (
-                        layer.bet_ids_pair[0][1].numpy()
+                        layer.bet_ids_pair[0].batch_ids.numpy()
                         == inputs.numpy().reshape(-1)
                     ).all()
                 )
@@ -276,7 +276,7 @@ class EmbeddingLayerTest(unittest.TestCase):
             self.assertTrue(len(layer.bet_ids_pair) == len(inputs_list))
             for i, correct_ids in enumerate(correct_ids_list):
                 self.assertTrue(
-                    (layer.bet_ids_pair[i][1].numpy() == correct_ids).all()
+                    (layer.bet_ids_pair[i].batch_ids.numpy() == correct_ids).all()
                 )
 
     def test_embedding_layer_gradient_with_sparse_inputs(self):
@@ -325,7 +325,7 @@ class EmbeddingLayerTest(unittest.TestCase):
                     layer.set_tape(tape)
                     output = module_call(layer, inputs)
                     output = output * multiply_tensor
-                bet = layer.bet_ids_pair[0][0]
+                bet = layer.bet_ids_pair[0].batch_embedding
                 grads = tape.gradient(output, bet)
                 grads = grads.numpy()
                 place = 8 if combiner == "sum" else 5
@@ -333,7 +333,7 @@ class EmbeddingLayerTest(unittest.TestCase):
                     self.assertAlmostEqual(grads[n][0], v, place)
                 self.assertTrue(
                     (
-                        layer.bet_ids_pair[0][1].numpy()
+                        layer.bet_ids_pair[0].batch_ids.numpy()
                         - np.array([1, 3, 2, 0, 6])
                         < 0.00001
                     ).all()
@@ -355,7 +355,7 @@ class EmbeddingLayerTest(unittest.TestCase):
                 self.assertTrue(len(layer.bet_ids_pair) == 2)
                 for i in range(2):
                     self.assertTrue(
-                        (layer.bet_ids_pair[i][1].numpy() == correct_ids).all()
+                        (layer.bet_ids_pair[i].batch_ids.numpy() == correct_ids).all()
                     )
 
 

--- a/elasticdl/python/tests/layer_test.py
+++ b/elasticdl/python/tests/layer_test.py
@@ -115,7 +115,9 @@ def get_correct_values_for_sparse_test(indices, values, dense_shape, combiner):
 
 
 class EmbeddingLayerTest(unittest.TestCase):
-    def _run_forward_pass_and_compare(self, call_fns, correct_values, output_dim):
+    def _run_forward_pass_and_compare(
+        self, call_fns, correct_values, output_dim
+    ):
         for call_fn in call_fns:
             values = call_fn()
             values = values.numpy().reshape(-1, output_dim)
@@ -133,10 +135,12 @@ class EmbeddingLayerTest(unittest.TestCase):
 
         ids = [0, 1, 3, 8, 3, 2, 3]
         call_fns = [lambda: layer.call(ids), lambda: module_call(layer, ids)]
-        correct_values = np.array([
-            np.array([idx] * output_dim, dtype=np.float32) for idx in ids
-        ])
-        self._run_forward_pass_and_compare(call_fns, correct_values, output_dim)
+        correct_values = np.array(
+            [np.array([idx] * output_dim, dtype=np.float32) for idx in ids]
+        )
+        self._run_forward_pass_and_compare(
+            call_fns, correct_values, output_dim
+        )
 
         # Keras model without/with input_layer
         model_without_input_layer = tf.keras.models.Sequential([layer])
@@ -152,7 +156,9 @@ class EmbeddingLayerTest(unittest.TestCase):
                 lambda: model.call(inputs),
                 lambda: module_call(model, inputs),
             ]
-            self._run_forward_pass_and_compare(call_fns, correct_values, output_dim)
+            self._run_forward_pass_and_compare(
+                call_fns, correct_values, output_dim
+            )
 
     def test_embedding_layer_with_input_length(self):
         output_dim = 8
@@ -164,10 +170,15 @@ class EmbeddingLayerTest(unittest.TestCase):
         ids = [[0, 1, 3, 8], [5, 3, 2, 3]]
         flatten_ids = ids[0] + ids[1]
         call_fns = [lambda: layer.call(ids), lambda: module_call(layer, ids)]
-        correct_values = np.array([
-            np.array([idx] * output_dim, dtype=np.float32) for idx in flatten_ids
-        ])
-        self._run_forward_pass_and_compare(call_fns, correct_values, output_dim)
+        correct_values = np.array(
+            [
+                np.array([idx] * output_dim, dtype=np.float32)
+                for idx in flatten_ids
+            ]
+        )
+        self._run_forward_pass_and_compare(
+            call_fns, correct_values, output_dim
+        )
 
     def test_embedding_layer_with_sparse_input(self):
         output_dim = 8
@@ -191,9 +202,12 @@ class EmbeddingLayerTest(unittest.TestCase):
             correct_value_single_line = get_correct_values_for_sparse_test(
                 indices, values, dense_shape, combiner
             )
-            correct_values = np.array([
-                np.array([idx] * output_dim, dtype=np.float32) for idx in correct_value_single_line
-            ])
+            correct_values = np.array(
+                [
+                    np.array([idx] * output_dim, dtype=np.float32)
+                    for idx in correct_value_single_line
+                ]
+            )
             self._run_forward_pass_and_compare(
                 call_fns, correct_values, output_dim
             )
@@ -335,7 +349,8 @@ class EmbeddingLayerTest(unittest.TestCase):
                         np.absolute(
                             layer.embedding_and_ids[0].batch_ids.numpy()
                             - np.array([1, 3, 2, 0, 6])
-                        ) < 0.00001
+                        )
+                        < 0.00001
                     ).all()
                 )
                 layer.reset()

--- a/elasticdl/python/tests/layer_test.py
+++ b/elasticdl/python/tests/layer_test.py
@@ -115,6 +115,13 @@ def get_correct_values_for_sparse_test(indices, values, dense_shape, combiner):
 
 
 class EmbeddingLayerTest(unittest.TestCase):
+    def _run_forward_pass_and_compare(self, call_fns, correct_values, output_dim):
+        for call_fn in call_fns:
+            values = call_fn()
+            values = values.numpy().reshape(-1, output_dim)
+            for v, correct_v in zip(values, correct_values):
+                self.assertTrue((np.absolute(v - correct_v) < 0.00001).all())
+
     def test_embedding_layer(self):
         output_dim = 8
         embedding_size = 16
@@ -126,12 +133,10 @@ class EmbeddingLayerTest(unittest.TestCase):
 
         ids = [0, 1, 3, 8, 3, 2, 3]
         call_fns = [lambda: layer.call(ids), lambda: module_call(layer, ids)]
-        for call_fn in call_fns:
-            values = call_fn()
-            values = values.numpy()
-            for index, idx in enumerate(ids):
-                correct_value = np.array([idx] * output_dim, dtype=np.float32)
-                self.assertTrue((values[index] == correct_value).all())
+        correct_values = np.array([
+            np.array([idx] * output_dim, dtype=np.float32) for idx in ids
+        ])
+        self._run_forward_pass_and_compare(call_fns, correct_values, output_dim)
 
         # Keras model without/with input_layer
         model_without_input_layer = tf.keras.models.Sequential([layer])
@@ -142,19 +147,12 @@ class EmbeddingLayerTest(unittest.TestCase):
         )
         models = [model_without_input_layer, model_with_input_layer]
         for model in models:
-            inputs = tf.constant([ids, ids])
+            inputs = tf.constant([ids])
             call_fns = [
                 lambda: model.call(inputs),
                 lambda: module_call(model, inputs),
             ]
-            for call_fn in call_fns:
-                outputs = call_fn()
-                values = outputs.numpy()[1]
-                for index, idx in enumerate(ids):
-                    correct_value = np.array(
-                        [idx] * output_dim, dtype=np.float32
-                    )
-                    self.assertTrue((values[index] == correct_value).all())
+            self._run_forward_pass_and_compare(call_fns, correct_values, output_dim)
 
     def test_embedding_layer_with_input_length(self):
         output_dim = 8
@@ -166,12 +164,10 @@ class EmbeddingLayerTest(unittest.TestCase):
         ids = [[0, 1, 3, 8], [5, 3, 2, 3]]
         flatten_ids = ids[0] + ids[1]
         call_fns = [lambda: layer.call(ids), lambda: module_call(layer, ids)]
-        for call_fn in call_fns:
-            values = call_fn()
-            values = values.numpy().reshape(-1, output_dim)
-            for index, idx in enumerate(flatten_ids):
-                correct_value = np.array([idx] * output_dim, dtype=np.float32)
-                self.assertTrue((values[index] == correct_value).all())
+        correct_values = np.array([
+            np.array([idx] * output_dim, dtype=np.float32) for idx in flatten_ids
+        ])
+        self._run_forward_pass_and_compare(call_fns, correct_values, output_dim)
 
     def test_embedding_layer_with_sparse_input(self):
         output_dim = 8
@@ -192,15 +188,15 @@ class EmbeddingLayerTest(unittest.TestCase):
                 lambda: layer.call(inputs),
                 lambda: module_call(layer, inputs),
             ]
-            for call_fn in call_fns:
-                outputs = call_fn()
-                outputs = outputs.numpy()
-                correct_values = get_correct_values_for_sparse_test(
-                    indices, values, dense_shape, combiner
-                )
-                place = 8 if combiner == "sum" else 5
-                for n, v in enumerate(correct_values):
-                    self.assertAlmostEqual(outputs[n][0], v, place)
+            correct_value_single_line = get_correct_values_for_sparse_test(
+                indices, values, dense_shape, combiner
+            )
+            correct_values = np.array([
+                np.array([idx] * output_dim, dtype=np.float32) for idx in correct_value_single_line
+            ])
+            self._run_forward_pass_and_compare(
+                call_fns, correct_values, output_dim
+            )
 
     def test_embedding_layer_with_mask_zero(self):
         output_dim = 8
@@ -252,8 +248,8 @@ class EmbeddingLayerTest(unittest.TestCase):
                     layer.set_tape(tape)
                     output = module_call(layer, inputs)
                     output = output * multiply_tensor
-                bet = layer.embedding_and_ids[0].batch_embedding
-                grads = tape.gradient(output, bet)
+                batch_embedding = layer.embedding_and_ids[0].batch_embedding
+                grads = tape.gradient(output, batch_embedding)
                 self.assertTrue(
                     (grads.values.numpy() == multiply_values).all()
                 )
@@ -328,17 +324,18 @@ class EmbeddingLayerTest(unittest.TestCase):
                     layer.set_tape(tape)
                     output = module_call(layer, inputs)
                     output = output * multiply_tensor
-                bet = layer.embedding_and_ids[0].batch_embedding
-                grads = tape.gradient(output, bet)
+                batch_embedding = layer.embedding_and_ids[0].batch_embedding
+                grads = tape.gradient(output, batch_embedding)
                 grads = grads.numpy()
                 place = 8 if combiner == "sum" else 5
                 for n, v in enumerate(correct_grads[combiner]):
                     self.assertAlmostEqual(grads[n][0], v, place)
                 self.assertTrue(
                     (
-                        layer.embedding_and_ids[0].batch_ids.numpy()
-                        - np.array([1, 3, 2, 0, 6])
-                        < 0.00001
+                        np.absolute(
+                            layer.embedding_and_ids[0].batch_ids.numpy()
+                            - np.array([1, 3, 2, 0, 6])
+                        ) < 0.00001
                     ).all()
                 )
                 layer.reset()

--- a/elasticdl/python/tests/layer_test.py
+++ b/elasticdl/python/tests/layer_test.py
@@ -89,8 +89,8 @@ def create_embedding_layer(
 
 
 @tf.function
-def layer_call(layer, inputs):
-    return layer.call(inputs)
+def module_call(module, inputs):
+    return module.call(inputs)
 
 
 def get_correct_values_for_sparse_test(indices, values, dense_shape, combiner):
@@ -125,16 +125,13 @@ class EmbeddingLayerTest(unittest.TestCase):
         self.assertEqual(output_shape, input_shape + (output_dim,))
 
         ids = [0, 1, 3, 8, 3, 2, 3]
-        values = layer.call(ids)
-        values = values.numpy()
-        for index, idx in enumerate(ids):
-            correct_value = np.array([idx] * output_dim, dtype=np.float32)
-            self.assertTrue((values[index] == correct_value).all())
-
-        results = layer_call(layer, ids)
-        results = results.numpy()
-        for index, idx in enumerate(ids):
-            self.assertTrue((values[index] == results[index]).all())
+        call_fns = [lambda: layer.call(ids), lambda: module_call(layer, ids)]
+        for call_fn in call_fns:
+            values = call_fn()
+            values = values.numpy()
+            for index, idx in enumerate(ids):
+                correct_value = np.array([idx] * output_dim, dtype=np.float32)
+                self.assertTrue((values[index] == correct_value).all())
 
         # Keras model without/with input_layer
         model_without_input_layer = tf.keras.models.Sequential([layer])
@@ -145,11 +142,19 @@ class EmbeddingLayerTest(unittest.TestCase):
         )
         models = [model_without_input_layer, model_with_input_layer]
         for model in models:
-            outputs = model.call(tf.constant([ids, ids]))
-            values = outputs.numpy()[1]
-            for index, idx in enumerate(ids):
-                correct_value = np.array([idx] * output_dim, dtype=np.float32)
-                self.assertTrue((values[index] == correct_value).all())
+            inputs = tf.constant([ids, ids])
+            call_fns = [
+                lambda: model.call(inputs),
+                lambda: module_call(model, inputs),
+            ]
+            for call_fn in call_fns:
+                outputs = call_fn()
+                values = outputs.numpy()[1]
+                for index, idx in enumerate(ids):
+                    correct_value = np.array(
+                        [idx] * output_dim, dtype=np.float32
+                    )
+                    self.assertTrue((values[index] == correct_value).all())
 
     def test_embedding_layer_with_input_length(self):
         output_dim = 8
@@ -160,11 +165,13 @@ class EmbeddingLayerTest(unittest.TestCase):
         )
         ids = [[0, 1, 3, 8], [5, 3, 2, 3]]
         flatten_ids = ids[0] + ids[1]
-        values = layer.call(ids)
-        values = values.numpy().reshape(-1, output_dim)
-        for index, idx in enumerate(flatten_ids):
-            correct_value = np.array([idx] * output_dim, dtype=np.float32)
-            self.assertTrue((values[index] == correct_value).all())
+        call_fns = [lambda: layer.call(ids), lambda: module_call(layer, ids)]
+        for call_fn in call_fns:
+            values = call_fn()
+            values = values.numpy().reshape(-1, output_dim)
+            for index, idx in enumerate(flatten_ids):
+                correct_value = np.array([idx] * output_dim, dtype=np.float32)
+                self.assertTrue((values[index] == correct_value).all())
 
     def test_embedding_layer_with_sparse_input(self):
         output_dim = 8
@@ -181,14 +188,19 @@ class EmbeddingLayerTest(unittest.TestCase):
             inputs = tf.SparseTensor(
                 indices=indices, values=values, dense_shape=dense_shape
             )
-            outputs = layer.call(inputs)
-            outputs = outputs.numpy()
-            correct_values = get_correct_values_for_sparse_test(
-                indices, values, dense_shape, combiner
-            )
-            place = 8 if combiner == "sum" else 5
-            for n, v in enumerate(correct_values):
-                self.assertAlmostEqual(outputs[n][0], v, place)
+            call_fns = [
+                lambda: layer.call(inputs),
+                lambda: module_call(layer, inputs),
+            ]
+            for call_fn in call_fns:
+                outputs = call_fn()
+                outputs = outputs.numpy()
+                correct_values = get_correct_values_for_sparse_test(
+                    indices, values, dense_shape, combiner
+                )
+                place = 8 if combiner == "sum" else 5
+                for n, v in enumerate(correct_values):
+                    self.assertAlmostEqual(outputs[n][0], v, place)
 
     def test_embedding_layer_with_mask_zero(self):
         output_dim = 8
@@ -231,25 +243,41 @@ class EmbeddingLayerTest(unittest.TestCase):
         multiply_tensor = tf.reshape(multiply_tensor, [2, 3, 8])
 
         for inputs in inputs_list:
-            with tf.GradientTape() as tape:
-                layer.set_tape(tape)
-                output = layer.call(inputs)
-                output = output * multiply_tensor
-            bet = layer.bet_ids_pair[0][0]
-            grads = tape.gradient(output, bet)
-            self.assertTrue((grads.values.numpy() == multiply_values).all())
-            self.assertTrue(
-                (
-                    layer.bet_ids_pair[0][1].numpy()
-                    == inputs.numpy().reshape(-1)
-                ).all()
-            )
-            layer.reset()
+            call_fns = [
+                lambda: layer.call(inputs),
+                lambda: module_call(layer, inputs),
+            ]
+            for call_fn in call_fns:
+                with tf.GradientTape() as tape:
+                    layer.set_tape(tape)
+                    output = module_call(layer, inputs)
+                    output = output * multiply_tensor
+                bet = layer.bet_ids_pair[0][0]
+                grads = tape.gradient(output, bet)
+                self.assertTrue(
+                    (grads.values.numpy() == multiply_values).all()
+                )
+                self.assertTrue(
+                    (
+                        layer.bet_ids_pair[0][1].numpy()
+                        == inputs.numpy().reshape(-1)
+                    ).all()
+                )
+                layer.reset()
 
-        for inputs in inputs_list:
-            with tf.GradientTape() as tape:
-                layer.set_tape(tape)
-                self.assertRaises(RuntimeError, layer_call, layer, inputs)
+        # Test when an embedding layer is called more than once.
+        # When an embedding layer is called more than once, `tf.function` is
+        # not supported.
+        correct_ids_list = [[0, 1, 3, 1, 2, 0], [0, 10, 3, 11, 2, 1]]
+        with tf.GradientTape() as tape:
+            layer.set_tape(tape)
+            for inputs in inputs_list:
+                _ = layer.call(inputs)
+            self.assertTrue(len(layer.bet_ids_pair) == len(inputs_list))
+            for i, correct_ids in enumerate(correct_ids_list):
+                self.assertTrue(
+                    (layer.bet_ids_pair[i][1].numpy() == correct_ids).all()
+                )
 
     def test_embedding_layer_gradient_with_sparse_inputs(self):
         output_dim = 8
@@ -258,6 +286,10 @@ class EmbeddingLayerTest(unittest.TestCase):
         indices = [[0, 0], [1, 1], [1, 2], [2, 1], [3, 1], [3, 3], [3, 5]]
         values = [1, 1, 3, 2, 0, 2, 6]
         dense_shape = [4, 6]
+        inputs = tf.SparseTensor(
+            indices=indices, values=values, dense_shape=dense_shape
+        )
+        inputs = tf.dtypes.cast(inputs, tf.int64)
 
         multiply_values = np.ndarray(shape=(4, output_dim), dtype=np.float32)
         for i in range(4):
@@ -284,27 +316,47 @@ class EmbeddingLayerTest(unittest.TestCase):
             layer = create_embedding_layer(
                 embedding_size, output_dim, combiner=combiner
             )
-            inputs = tf.SparseTensor(
-                indices=indices, values=values, dense_shape=dense_shape
+            call_fns = [
+                lambda: layer.call(inputs),
+                lambda: module_call(layer, inputs),
+            ]
+            for call_fn in call_fns:
+                with tf.GradientTape() as tape:
+                    layer.set_tape(tape)
+                    output = module_call(layer, inputs)
+                    output = output * multiply_tensor
+                bet = layer.bet_ids_pair[0][0]
+                grads = tape.gradient(output, bet)
+                grads = grads.numpy()
+                place = 8 if combiner == "sum" else 5
+                for n, v in enumerate(correct_grads[combiner]):
+                    self.assertAlmostEqual(grads[n][0], v, place)
+                self.assertTrue(
+                    (
+                        layer.bet_ids_pair[0][1].numpy()
+                        - np.array([1, 3, 2, 0, 6])
+                        < 0.00001
+                    ).all()
+                )
+                layer.reset()
+
+        # Test when an embedding layer is called more than once.
+        # When an embedding layer is called more than once, `tf.function` is
+        # not supported.
+        correct_ids = [1, 3, 2, 0, 6]
+        for combiner in combiners:
+            layer = create_embedding_layer(
+                embedding_size, output_dim, combiner=combiner
             )
             with tf.GradientTape() as tape:
                 layer.set_tape(tape)
-                output = layer.call(inputs)
-                output = output * multiply_tensor
-            bet = layer.bet_ids_pair[0][0]
-            grads = tape.gradient(output, bet)
-            grads = grads.numpy()
-            place = 8 if combiner == "sum" else 5
-            for n, v in enumerate(correct_grads[combiner]):
-                self.assertAlmostEqual(grads[n][0], v, place)
-            self.assertTrue(
-                (
-                    layer.bet_ids_pair[0][1].numpy()
-                    - np.array([1, 3, 2, 0, 6])
-                    < 0.00001
-                ).all()
-            )
-            layer.reset()
+                _ = layer.call(inputs)
+                _ = layer.call(inputs)
+                self.assertTrue(len(layer.bet_ids_pair) == 2)
+                for i in range(2):
+                    self.assertTrue(
+                        (layer.bet_ids_pair[i][1].numpy() == correct_ids).all()
+                    )
 
 
 if __name__ == "__main__":

--- a/elasticdl/python/tests/optimizer_wrapper_test.py
+++ b/elasticdl/python/tests/optimizer_wrapper_test.py
@@ -121,7 +121,7 @@ def _train_edl_embedding_with_optimizer_wrapper(
         embed_items = []
         for layer in embed_layers:
             embed_items.extend(
-                [(bet, layer.name, ids) for bet, ids in layer.bet_ids_pair]
+                [(bet, layer.name, ids) for bet, ids in layer.embedding_and_ids]
             )
 
         grads = tape.gradient(

--- a/elasticdl/python/tests/optimizer_wrapper_test.py
+++ b/elasticdl/python/tests/optimizer_wrapper_test.py
@@ -121,7 +121,10 @@ def _train_edl_embedding_with_optimizer_wrapper(
         embed_items = []
         for layer in embed_layers:
             embed_items.extend(
-                [(bet, layer.name, ids) for bet, ids in layer.embedding_and_ids]
+                [
+                    (bet, layer.name, ids)
+                    for bet, ids in layer.embedding_and_ids
+                ]
             )
 
         grads = tape.gradient(

--- a/elasticdl/python/tests/report_gradients_of_bet_test.py
+++ b/elasticdl/python/tests/report_gradients_of_bet_test.py
@@ -10,6 +10,7 @@ from elasticdl.python.master.embedding_service import EmbeddingService
 from elasticdl.python.master.servicer import MasterServicer
 from elasticdl.python.tests.in_process_master import InProcessMaster
 from elasticdl.python.worker.worker import Worker
+from elasticdl.python.elasticdl.layers.embedding import EmbeddingAndIds
 
 _model_zoo_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -69,7 +70,7 @@ class MockEdlEmbedding:
         return self._name
 
     def add_bet_and_ids(self, bet, ids):
-        self.append((bet, ids))
+        self.append(EmbeddingAndIds(bet, ids))
 
 
 class ReportBETGradientTest(unittest.TestCase):
@@ -120,14 +121,14 @@ class ReportBETGradientTest(unittest.TestCase):
 
         layer1 = MockEdlEmbedding(layer_names[0])
         layer1.bet_ids_pair = [
-            (None, tf.constant([1, 2])),
-            (None, tf.constant([2, 3])),
+            EmbeddingAndIds(None, tf.constant([1, 2])),
+            EmbeddingAndIds(None, tf.constant([2, 3])),
         ]
 
         layer2 = MockEdlEmbedding(layer_names[1])
         layer2.bet_ids_pair = [
-            (None, tf.constant([3, 1])),
-            (None, tf.constant([3, 4])),
+            EmbeddingAndIds(None, tf.constant([3, 1])),
+            EmbeddingAndIds(None, tf.constant([3, 4])),
         ]
 
         edlembed_grads = [
@@ -169,14 +170,14 @@ class ReportBETGradientTest(unittest.TestCase):
             layer1.name: tf.IndexedSlices(
                 tf.concat(edlembed_grads[:2], axis=0),
                 tf.concat(
-                    [layer1.bet_ids_pair[0][1], layer1.bet_ids_pair[1][1]],
+                    [layer1.bet_ids_pair[0].batch_ids, layer1.bet_ids_pair[1].batch_ids],
                     axis=0,
                 ),
             ),
             layer2.name: tf.IndexedSlices(
                 tf.concat(edlembed_grads[2:], axis=0),
                 tf.concat(
-                    [layer2.bet_ids_pair[0][1], layer2.bet_ids_pair[1][1]],
+                    [layer2.bet_ids_pair[0].batch_ids, layer2.bet_ids_pair[1].batch_ids],
                     axis=0,
                 ),
             ),
@@ -308,7 +309,7 @@ class ReportBETGradientTest(unittest.TestCase):
         master, worker = self._create_master_and_worker()
         layer = MockEdlEmbedding("test")
         layer.bet_ids_pair = [
-            (tf.Variable([1, 2, 3], name="test_bet"), [1, 2, 3])
+            EmbeddingAndIds(tf.Variable([1, 2, 3], name="test_bet"), [1, 2, 3])
         ]
         worker._embedding_layers = [layer]
         train_vars = worker.get_trainable_items()

--- a/elasticdl/python/tests/report_gradients_of_bet_test.py
+++ b/elasticdl/python/tests/report_gradients_of_bet_test.py
@@ -6,11 +6,11 @@ import numpy as np
 import tensorflow as tf
 
 from elasticdl.python.common.constants import JobType
+from elasticdl.python.elasticdl.layers.embedding import EmbeddingAndIds
 from elasticdl.python.master.embedding_service import EmbeddingService
 from elasticdl.python.master.servicer import MasterServicer
 from elasticdl.python.tests.in_process_master import InProcessMaster
 from elasticdl.python.worker.worker import Worker
-from elasticdl.python.elasticdl.layers.embedding import EmbeddingAndIds
 
 _model_zoo_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -167,14 +167,20 @@ class ReportBETGradientTest(unittest.TestCase):
             layer1.name: tf.IndexedSlices(
                 tf.concat(edlembed_grads[:2], axis=0),
                 tf.concat(
-                    [layer1.embedding_and_ids[0].batch_ids, layer1.embedding_and_ids[1].batch_ids],
+                    [
+                        layer1.embedding_and_ids[0].batch_ids,
+                        layer1.embedding_and_ids[1].batch_ids,
+                    ],
                     axis=0,
                 ),
             ),
             layer2.name: tf.IndexedSlices(
                 tf.concat(edlembed_grads[2:], axis=0),
                 tf.concat(
-                    [layer2.embedding_and_ids[0].batch_ids, layer2.embedding_and_ids[1].batch_ids],
+                    [
+                        layer2.embedding_and_ids[0].batch_ids,
+                        layer2.embedding_and_ids[1].batch_ids,
+                    ],
                     axis=0,
                 ),
             ),

--- a/elasticdl/python/tests/report_gradients_of_bet_test.py
+++ b/elasticdl/python/tests/report_gradients_of_bet_test.py
@@ -63,14 +63,11 @@ def custom_model():
 class MockEdlEmbedding:
     def __init__(self, name):
         self._name = name
-        self.bet_ids_pair = []
+        self.embedding_and_ids = []
 
     @property
     def name(self):
         return self._name
-
-    def add_bet_and_ids(self, bet, ids):
-        self.append(EmbeddingAndIds(bet, ids))
 
 
 class ReportBETGradientTest(unittest.TestCase):
@@ -120,13 +117,13 @@ class ReportBETGradientTest(unittest.TestCase):
         )
 
         layer1 = MockEdlEmbedding(layer_names[0])
-        layer1.bet_ids_pair = [
+        layer1.embedding_and_ids = [
             EmbeddingAndIds(None, tf.constant([1, 2])),
             EmbeddingAndIds(None, tf.constant([2, 3])),
         ]
 
         layer2 = MockEdlEmbedding(layer_names[1])
-        layer2.bet_ids_pair = [
+        layer2.embedding_and_ids = [
             EmbeddingAndIds(None, tf.constant([3, 1])),
             EmbeddingAndIds(None, tf.constant([3, 4])),
         ]
@@ -170,14 +167,14 @@ class ReportBETGradientTest(unittest.TestCase):
             layer1.name: tf.IndexedSlices(
                 tf.concat(edlembed_grads[:2], axis=0),
                 tf.concat(
-                    [layer1.bet_ids_pair[0].batch_ids, layer1.bet_ids_pair[1].batch_ids],
+                    [layer1.embedding_and_ids[0].batch_ids, layer1.embedding_and_ids[1].batch_ids],
                     axis=0,
                 ),
             ),
             layer2.name: tf.IndexedSlices(
                 tf.concat(edlembed_grads[2:], axis=0),
                 tf.concat(
-                    [layer2.bet_ids_pair[0].batch_ids, layer2.bet_ids_pair[1].batch_ids],
+                    [layer2.embedding_and_ids[0].batch_ids, layer2.embedding_and_ids[1].batch_ids],
                     axis=0,
                 ),
             ),
@@ -308,7 +305,7 @@ class ReportBETGradientTest(unittest.TestCase):
     def test_get_trainable_variable(self):
         master, worker = self._create_master_and_worker()
         layer = MockEdlEmbedding("test")
-        layer.bet_ids_pair = [
+        layer.embedding_and_ids = [
             EmbeddingAndIds(tf.Variable([1, 2, 3], name="test_bet"), [1, 2, 3])
         ]
         worker._embedding_layers = [layer]

--- a/elasticdl/python/tests/worker_test.py
+++ b/elasticdl/python/tests/worker_test.py
@@ -233,7 +233,9 @@ class WorkerTest(unittest.TestCase):
                 test_grads.append(grads)
                 ids = {}
                 for layer in worker._embedding_layers:
-                    ids[layer.name] = copy.deepcopy(layer.embedding_and_ids[0].batch_ids)
+                    ids[layer.name] = copy.deepcopy(
+                        layer.embedding_and_ids[0].batch_ids
+                    )
                 test_ids_list.append(ids)
                 worker._reset_embedding()
 

--- a/elasticdl/python/tests/worker_test.py
+++ b/elasticdl/python/tests/worker_test.py
@@ -220,7 +220,7 @@ class WorkerTest(unittest.TestCase):
                 correct_grads.append(grads)
                 ids = {}
                 for layer in worker._embedding_layers:
-                    ids[layer.name] = layer.bet_ids_pair[0][1]
+                    ids[layer.name] = layer.bet_ids_pair[0].batch_ids
                 correct_ids_list.append(ids)
                 worker._reset_embedding()
 
@@ -233,7 +233,7 @@ class WorkerTest(unittest.TestCase):
                 test_grads.append(grads)
                 ids = {}
                 for layer in worker._embedding_layers:
-                    ids[layer.name] = copy.deepcopy(layer.bet_ids_pair[0][1])
+                    ids[layer.name] = copy.deepcopy(layer.bet_ids_pair[0].batch_ids)
                 test_ids_list.append(ids)
                 worker._reset_embedding()
 

--- a/elasticdl/python/tests/worker_test.py
+++ b/elasticdl/python/tests/worker_test.py
@@ -220,7 +220,7 @@ class WorkerTest(unittest.TestCase):
                 correct_grads.append(grads)
                 ids = {}
                 for layer in worker._embedding_layers:
-                    ids[layer.name] = layer.bet_ids_pair[0].batch_ids
+                    ids[layer.name] = layer.embedding_and_ids[0].batch_ids
                 correct_ids_list.append(ids)
                 worker._reset_embedding()
 
@@ -233,7 +233,7 @@ class WorkerTest(unittest.TestCase):
                 test_grads.append(grads)
                 ids = {}
                 for layer in worker._embedding_layers:
-                    ids[layer.name] = copy.deepcopy(layer.bet_ids_pair[0].batch_ids)
+                    ids[layer.name] = copy.deepcopy(layer.embedding_and_ids[0].batch_ids)
                 test_ids_list.append(ids)
                 worker._reset_embedding()
 

--- a/elasticdl/python/tests/worker_test.py
+++ b/elasticdl/python/tests/worker_test.py
@@ -193,6 +193,7 @@ class WorkerTest(unittest.TestCase):
         embedding_dim = 16
         worker.set_model(model_inst)
 
+        # initialize kv store
         for layer in model_inst.layers:
             if isinstance(layer, Embedding):
                 name = layer.name
@@ -211,6 +212,7 @@ class WorkerTest(unittest.TestCase):
             worker._init_embedding_layer()
             worker._run_model_call_before_training(inputs_list[0])
 
+            # run training process without tf.function
             correct_grads = []
             correct_ids_list = []
             for features, labels in zip(inputs_list, labels_list):
@@ -222,6 +224,7 @@ class WorkerTest(unittest.TestCase):
                 correct_ids_list.append(ids)
                 worker._reset_embedding()
 
+            # run training process with tf.function
             test_grads = []
             test_ids_list = []
             for features, labels in zip(inputs_list, labels_list):
@@ -234,6 +237,7 @@ class WorkerTest(unittest.TestCase):
                 test_ids_list.append(ids)
                 worker._reset_embedding()
 
+        # compare the gradients
         for test_g, correct_g in zip(test_grads, correct_grads):
             for g1, g2 in zip(test_g, correct_g):
                 if isinstance(g1, tf.IndexedSlices):

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -315,7 +315,12 @@ class Worker(object):
         bets = []
         if self._embedding_layers:
             for layer in self._embedding_layers:
-                bets.extend([batch_embedding for (batch_embedding, _) in layer.embedding_and_ids])
+                bets.extend(
+                    [
+                        batch_embedding
+                        for (batch_embedding, _) in layer.embedding_and_ids
+                    ]
+                )
         return self._non_embed_vars + bets
 
     def training_process(self, features, labels):

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -110,6 +110,7 @@ class Worker(object):
     def set_model(self, model_inst):
         """Set model instance to worker."""
         self._model = model_inst
+        self._train_eagerly = False
         self._init_embedding_layer()
         self._var_created = self._model.built
         self._non_embed_vars = []
@@ -125,6 +126,9 @@ class Worker(object):
         self._embedding_layers = find_layer(self._model, Embedding)
         for layer in self._embedding_layers:
             layer.set_endpoint(self._embedding_service_endpoint)
+        self._need_embedding_layer_check = (
+            True if self._embedding_layers else False
+        )
 
     def _set_tape_for_embedding(self, tape):
         for layer in self._embedding_layers:
@@ -268,14 +272,39 @@ class Worker(object):
             )
         return True
 
-    def _create_variable_and_report(self, features):
-        # Use model.call to create variables, then report to ps
-        _ = self._model.call(features)
+    def _run_model_call_before_training(self, features):
+        """Call `self._model.call` before training for two things:
+            * Create variables and report to ps if not created.
+            * Check whether there is an embedding layer that is called
+              more than once during one forward-pass.
+        """
+        if self._embedding_layers:
+            with tf.GradientTape() as tape:
+                self._set_tape_for_embedding(tape)
+                _ = self._model.call(features)
+        else:
+            _ = self._model.call(features)
         self._non_embed_vars = get_non_embedding_trainable_vars(
             self._model, self._embedding_layers
         )
-        self.report_variable()
-        self._var_created = True
+
+        if not self._var_created:
+            self.report_variable()
+            self._var_created = True
+
+        if self._need_embedding_layer_check:
+            self._train_eagerly = False
+            for layer in self._embedding_layers:
+                if len(layer.bet_ids_pair) > 1:
+                    self._train_eagerly = True
+                    logger.warning(
+                        "ElasticDL embedding layer %s is called more than "
+                        "once, this will make the training process unable "
+                        "to accelerate with tf.function." % (layer.name)
+                    )
+            self._need_embedding_layer_check = False
+
+        self._reset_embedding()
 
     def get_trainable_items(self):
         """
@@ -294,7 +323,7 @@ class Worker(object):
         training for models with elasticdl.layers.embedding does not
         support tf.function decorator
         """
-        if self._embedding_layers:
+        if self._train_eagerly:
             return self.training_process_eagerly(features, labels)
         else:
             return self.training_process_with_acceleration(features, labels)
@@ -343,8 +372,8 @@ class Worker(object):
     def _process_minibatch(
         self, task_type, features, labels, min_model_version
     ):
-        if not self._var_created:
-            self._create_variable_and_report(features)
+        if self._need_embedding_layer_check or not self._var_created:
+            self._run_model_call_before_training(features)
         for _ in range(self._max_minibatch_retry_num):
             if task_type == elasticdl_pb2.EVALUATION:
                 if min_model_version == -1:

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -315,7 +315,7 @@ class Worker(object):
         bets = []
         if self._embedding_layers:
             for layer in self._embedding_layers:
-                bets.extend([i for (i, _) in layer.bet_ids_pair])
+                bets.extend([batch_embedding for (batch_embedding, _) in layer.bet_ids_pair])
         return self._non_embed_vars + bets
 
     def training_process(self, features, labels):

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -208,7 +208,7 @@ class Worker(object):
             # `bet_id_pair`.
             bet_number = 0
             for layer in self._embedding_layers:
-                bet_number += len(layer.bet_ids_pair)
+                bet_number += len(layer.embedding_and_ids)
             if len(edl_embedding_grads) != bet_number:
                 raise ValueError(
                     "elasticdl.layers.embedding related gradient number %d "
@@ -220,7 +220,7 @@ class Worker(object):
             for layer in self._embedding_layers:
                 g_values = None
                 g_indices = None
-                for _, ids in layer.bet_ids_pair:
+                for _, ids in layer.embedding_and_ids:
                     grad = edl_embedding_grads[grad_accum_iter]
                     grad_accum_iter += 1
                     # ElasticDL embedding layer with Sparse Gradients
@@ -295,7 +295,7 @@ class Worker(object):
         if self._need_embedding_layer_check:
             self._train_eagerly = False
             for layer in self._embedding_layers:
-                if len(layer.bet_ids_pair) > 1:
+                if len(layer.embedding_and_ids) > 1:
                     self._train_eagerly = True
                     logger.warning(
                         "ElasticDL embedding layer %s is called more than "
@@ -315,7 +315,7 @@ class Worker(object):
         bets = []
         if self._embedding_layers:
             for layer in self._embedding_layers:
-                bets.extend([batch_embedding for (batch_embedding, _) in layer.bet_ids_pair])
+                bets.extend([batch_embedding for (batch_embedding, _) in layer.embedding_and_ids])
         return self._non_embed_vars + bets
 
     def training_process(self, features, labels):


### PR DESCRIPTION
Fixes #1188.

This PR includes following:
* As #1188 states, create trainable variables in ElasticDL embedding layer.
* In `layer_test.py`, existing test cases only test embedding layer in eager mode. Modifying these test cases to test embedding layer both in eager mode and in graph mode (i.e. without `tf.function` and with `tf.function`).
* In `worker_test.py`, add a test case to test that embedding layer behaves the same when runs with  `tf.function` and without `tf.function`.


