### PR TITLE
Refactor read_odps_one_shot to ODPSReader.read_batch()

### DIFF
--- a/elasticdl/python/common/odps_io.py
+++ b/elasticdl/python/common/odps_io.py
@@ -194,7 +194,7 @@ class ODPSReader(object):
                 for i in range(0, len(records), batch_size):
                     yield records[i : i + batch_size]  # noqa: E203
 
-    def read_batch(self, start, end, columns, max_retries=3):
+    def read_batch(self, start, end, columns=None, max_retries=3):
         """
         Read ODPS table in chosen row range [ `start`, `end` ) with the
         specified columns `columns`.
@@ -209,6 +209,8 @@ class ODPSReader(object):
             Two-dimension python list with shape: (end - start, len(columns))
         """
         retry_count = 0
+        if columns is None:
+            columns = self._odps_table.schema.names
         while retry_count < max_retries:
             try:
                 batch_record = []

--- a/elasticdl/python/common/odps_io.py
+++ b/elasticdl/python/common/odps_io.py
@@ -1,8 +1,8 @@
 import random
-from concurrent.futures import ThreadPoolExecutor as Executor
-from queue import Queue
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor as Executor
+from queue import Queue
 
 import numpy as np
 import odps

--- a/elasticdl/python/common/odps_io.py
+++ b/elasticdl/python/common/odps_io.py
@@ -2,6 +2,7 @@ import random
 from concurrent.futures import ThreadPoolExecutor as Executor
 from queue import Queue
 import sys
+import time
 
 import numpy as np
 import odps
@@ -208,7 +209,6 @@ class ODPSReader(object):
             Two-dimension python list with shape: (end - start, len(columns))
         """
         retry_count = 0
-
         while retry_count < max_retries:
             try:
                 batch_record = []
@@ -222,12 +222,9 @@ class ODPSReader(object):
                             [record[column] for column in columns]
                         )
                 return batch_record
-
             except Exception as e:
-                import time
-
                 if retry_count >= max_retries:
-                    raise
+                    raise Exception("Exceeded maximum number of retries")
                 logger.warning(
                     "ODPS read exception {} for {} in {}."
                     "Retrying time: {}".format(


### PR DESCRIPTION
This will be reused for the implementation of `ODPSDataReader` that's part of #1105. Changes include:
* Move `_read_odps_one_shot` to `ODPSReader.read_batch()`
* Move ODPS table initialization to `ODPSReader.__init__`
* If `columns=None`, get rows for all columns