### PR TITLE
Allow reading each shard from different starting index

### DIFF
--- a/doc/custom_data_source_support_design.md
+++ b/doc/custom_data_source_support_design.md
@@ -59,7 +59,8 @@ class AbstractDataReader(ABC):
     @abstractmethod
     def create_shards(self):
         """This method creates the dictionary of shards where the keys are the
-        shard names and the values are the number of records.
+        shard names and the values are tuples of the starting
+        index and the number of records in each shard.
         """
         pass
 ```

--- a/elasticdl/python/common/data_reader.py
+++ b/elasticdl/python/common/data_reader.py
@@ -24,7 +24,8 @@ class AbstractDataReader(ABC):
     @abstractmethod
     def create_shards(self):
         """This method creates the dictionary of shards where the keys
-        are the shard names and the values are the number of records.
+        are the shard names and the values are tuples of the starting
+        index and the number of records in each shard.
         """
         pass
 
@@ -51,11 +52,12 @@ class RecordIODataReader(AbstractDataReader):
 
     def create_shards(self):
         data_dir = self._kwargs["data_dir"]
+        start_ind = 0
         if not data_dir:
             return {}
         f_records = {}
         for f in os.listdir(data_dir):
             p = os.path.join(data_dir, f)
             with closing(recordio.Index(p)) as rio:
-                f_records[p] = rio.num_records()
+                f_records[p] = (start_ind, rio.num_records())
         return f_records

--- a/elasticdl/python/master/task_dispatcher.py
+++ b/elasticdl/python/master/task_dispatcher.py
@@ -86,11 +86,11 @@ class _TaskDispatcher(object):
         else:
             shards = self._prediction_shards
         tasks = []
-        for name, num_records in shards.items():
-            for start in range(0, num_records, self._records_per_task):
+        for shard_name, (start_ind, num_records) in shards.items():
+            for start in range(start_ind, num_records, self._records_per_task):
                 tasks.append(
                     _Task(
-                        shard_name=name,
+                        shard_name=shard_name,
                         start=start,
                         end=min(start + self._records_per_task, num_records),
                         type=task_type,

--- a/elasticdl/python/tests/checkpoint_test.py
+++ b/elasticdl/python/tests/checkpoint_test.py
@@ -104,7 +104,7 @@ class CheckpointTest(unittest.TestCase):
             )
             filename = create_recordio_file(128)
             task_d = _TaskDispatcher(
-                {filename: 128}, {}, {}, records_per_task=64, num_epochs=1
+                {filename: (0, 128)}, {}, {}, records_per_task=64, num_epochs=1
             )
             master = MasterServicer(
                 2,

--- a/elasticdl/python/tests/evaluation_service_test.py
+++ b/elasticdl/python/tests/evaluation_service_test.py
@@ -84,7 +84,11 @@ class EvaluationServiceTest(unittest.TestCase):
             chkp_dir = os.path.join(tempdir, "testEvaluationService")
             checkpoint_service = CheckpointService(chkp_dir, 5, 5, True)
             task_d = _TaskDispatcher(
-                {"f1": 10, "f2": 10}, {"f1": 10, "f2": 10}, {}, 3, 1
+                {"f1": (0, 10), "f2": (0, 10)},
+                {"f1": (0, 10), "f2": (0, 10)},
+                {},
+                3,
+                1,
             )
 
             # Evaluation metrics will not be accepted if no evaluation ongoing
@@ -130,7 +134,7 @@ class EvaluationServiceTest(unittest.TestCase):
             self.assertFalse(evaluation_service.try_to_create_new_job())
 
     def testEvaluationOnly(self):
-        task_d = _TaskDispatcher({}, {"f1": 10, "f2": 10}, {}, 3, 1)
+        task_d = _TaskDispatcher({}, {"f1": (0, 10), "f2": (0, 10)}, {}, 3, 1)
 
         evaluation_service = EvaluationService(
             None, None, task_d, 0, 0, 0, True

--- a/elasticdl/python/tests/example_test.py
+++ b/elasticdl/python/tests/example_test.py
@@ -124,11 +124,15 @@ class ExampleTest(unittest.TestCase):
         )
 
         if dataset == "imagenet":
-            shards = {create_imagenet_recordio_file(16, feature_shape): 16}
+            shards = {
+                create_imagenet_recordio_file(16, feature_shape): (0, 16)
+            }
         elif dataset == "frappe":
-            shards = {create_frappe_recordio_file(16, feature_shape, 5383): 16}
+            shards = {
+                create_frappe_recordio_file(16, feature_shape, 5383): (0, 16)
+            }
         else:
-            shards = {create_recordio_file(128, feature_shape): 128}
+            shards = {create_recordio_file(128, feature_shape): (0, 128)}
 
         if training:
             training_shards = shards

--- a/elasticdl/python/tests/k8s_worker_manager_test.py
+++ b/elasticdl/python/tests/k8s_worker_manager_test.py
@@ -14,7 +14,7 @@ class WorkerManagerTest(unittest.TestCase):
         "No Kubernetes cluster available",
     )
     def testCreateDeleteWorkerPod(self):
-        task_d = _TaskDispatcher({"f": 10}, {}, {}, 1, 1)
+        task_d = _TaskDispatcher({"f": (0, 10)}, {}, {}, 1, 1)
         task_d.recover_tasks = MagicMock()
         worker_manager = WorkerManager(
             task_d,
@@ -56,7 +56,7 @@ class WorkerManagerTest(unittest.TestCase):
         Start a pod running a python program destined to fail with
         restart_policy="Never" to test failed_worker_count
         """
-        task_d = _TaskDispatcher({"f": 10}, {}, {}, 1, 1)
+        task_d = _TaskDispatcher({"f": (0, 10)}, {}, {}, 1, 1)
         task_d.recover_tasks = MagicMock()
         worker_manager = WorkerManager(
             task_d,
@@ -94,7 +94,7 @@ class WorkerManagerTest(unittest.TestCase):
         "No Kubernetes cluster available",
     )
     def testRelaunchWorkerPod(self):
-        task_d = _TaskDispatcher({"f": 10}, {}, {}, 1, 1)
+        task_d = _TaskDispatcher({"f": (0, 10)}, {}, {}, 1, 1)
         worker_manager = WorkerManager(
             task_d,
             job_name="test-relaunch-worker-pod-%d-%d"

--- a/elasticdl/python/tests/servicer_test.py
+++ b/elasticdl/python/tests/servicer_test.py
@@ -249,7 +249,7 @@ class ServicerTest(unittest.TestCase):
 
     def testReportTaskResult(self):
         task_d = _TaskDispatcher(
-            {"shard_1": 10, "shard_2": 9},
+            {"shard_1": (0, 10), "shard_2": (0, 9)},
             {},
             {},
             records_per_task=3,

--- a/elasticdl/python/tests/task_dispatcher_test.py
+++ b/elasticdl/python/tests/task_dispatcher_test.py
@@ -6,7 +6,7 @@ from elasticdl.python.master.task_dispatcher import _TaskDispatcher
 
 class TaskQueueTest(unittest.TestCase):
     def test_create_get(self):
-        task_d = _TaskDispatcher({"f1": 10, "f2": 10}, {}, {}, 3, 1)
+        task_d = _TaskDispatcher({"f1": (0, 10), "f2": (0, 10)}, {}, {}, 3, 1)
 
         all_tasks = [
             ("f1", 0, 3, elasticdl_pb2.TRAINING, -1),
@@ -56,7 +56,7 @@ class TaskQueueTest(unittest.TestCase):
         self.assertTrue(task_d.finished())
 
     def test_epoch(self):
-        task_d = _TaskDispatcher({"f1": 10, "f2": 10}, {}, {}, 3, 2)
+        task_d = _TaskDispatcher({"f1": (0, 10), "f2": (0, 10)}, {}, {}, 3, 2)
 
         epoch_tasks = [
             ("f1", 0, 3, elasticdl_pb2.TRAINING, -1),

--- a/elasticdl/python/tests/worker_test.py
+++ b/elasticdl/python/tests/worker_test.py
@@ -70,7 +70,7 @@ class WorkerTest(unittest.TestCase):
             channel=None,
         )
 
-        shards = {create_recordio_file(128): 128}
+        shards = {create_recordio_file(128): (0, 128)}
         if training:
             training_shards = shards
             evaluation_shards = {}


### PR DESCRIPTION
Currently `_TaskDispatcher.create_tasks()` creates the list of tasks by iterating through the shards where each shard contains the shard name and the number of records in that shard.

However, we are creating tasks from **index 0** in each shard through `range(0, num_records, self._records_per_task)` in `_TaskDispatcher.create_tasks()`. This is not ideal for data sources like ODPS where all shards might be in a single ODPS table but each shard starts from a different row.

This PR removes the hard-coded 0 as the starting index for each shard and allows to read each shard from different starting index. Each shard will contain the shard name, starting index, and the number of records in that shard.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>