### PR TITLE
fix command in embedding service

### DIFF
--- a/elasticdl/python/master/embedding_service.py
+++ b/elasticdl/python/master/embedding_service.py
@@ -67,7 +67,7 @@ class EmbeddingService(object):
     ):
         self.start_embedding_pod_and_redis(
             command=["python"],
-            args=["-m", "elasticdl.python.common.embedding_service"],
+            args=["-m", "elasticdl.python.master.embedding_service"],
             embedding_service_id=embedding_service_id,
             resource_request=resource_request,
             resource_limit=resource_limit,


### PR DESCRIPTION
embedding_service.py has been moved from `common` to `master` for #1062 

The command inside embedding_service also needs to change.