### PR TITLE
Automatically pass arguments

### DIFF
--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -501,7 +501,13 @@ def build_arguments_from_parsed_result(args, filter_args=None):
     items = vars(args).items()
     if filter_args:
         items = filter(lambda item: item[0] not in filter_args, items)
-    arguments = map(str, chain(*items))
+
+    def _str_ignore_none(s):
+        if s is None:
+            return s
+        return str(s)
+
+    arguments = map(_str_ignore_none, chain(*items))
     arguments = [
         "--" + k if i % 2 == 0 else k for i, k in enumerate(arguments)
     ]

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -88,7 +88,7 @@ def parse_envs(arg):
 
 def add_bool_param(parser, name, default, help):
     parser.add_argument(
-        name,  # should be int --foo format
+        name,  # should be in "--foo" format
         nargs="?",
         const=not default,
         default=default,
@@ -492,13 +492,11 @@ def parse_worker_args(worker_args=None):
 
 def build_arguments_from_parsed_result(args, filter_args=None):
     """Resconstruct arguments from parsed result
-    Please be aware that for boolean arguments
-    + action="store_true", will be filtered if value is False
-    + action="store_false", will be filtered if value is True
     Args:
         args: result from `parser.parse_args()`
     Returns:
-        list of string: ready for parser to parse
+        list of string: ready for parser to parse,
+        such as ["--foo", "3", "--bar", False]
     """
     items = vars(args).items()
     if filter_args:

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -1,4 +1,5 @@
 import argparse
+from itertools import chain
 
 from elasticdl.python.common.log_util import default_logger as logger
 
@@ -83,6 +84,17 @@ def parse_envs(arg):
             pre_key = fields[i][r + 1 :]  # noqa: E203
         i += 1
     return envs
+
+
+def add_bool_param(parser, name, default, help):
+    parser.add_argument(
+        name,  # should be int --foo format
+        nargs="?",
+        const=not default,
+        default=default,
+        type=lambda x: x.lower() in ["true", "yes", "t", "y"],
+        help=help,
+    )
 
 
 def add_common_params(parser):
@@ -262,13 +274,16 @@ def add_train_params(parser):
         default="",
         help="The path to save the final trained model",
     )
-    parser.add_argument(
-        "--use_async",
+
+    add_bool_param(
+        parser=parser,
+        name="--use_async",
         default=False,
         help="True for asynchronous SGD, False for synchronous SGD",
     )
-    parser.add_argument(
-        "--lr_staleness_modulation",
+    add_bool_param(
+        parser=parser,
+        name="--lr_staleness_modulation",
         default=False,
         help="If True, master will modulate the learning rate with staleness "
         "in asynchronous SGD",
@@ -473,3 +488,23 @@ def parse_worker_args(worker_args=None):
     print_args(args, groups=ALL_ARGS_GROUPS)
     logger.warning("Unknown arguments: %s", _)
     return args
+
+
+def build_arguments_from_parsed_result(args, filter_args=None):
+    """Resconstruct arguments from parsed result
+    Please be aware that for boolean arguments
+    + action="store_true", will be filtered if value is False
+    + action="store_false", will be filtered if value is True
+    Args:
+        args: result from `parser.parse_args()`
+    Returns:
+        list of string: ready for parser to parse
+    """
+    items = vars(args).items()
+    if filter_args:
+        items = filter(lambda item: item[0] not in filter_args, items)
+    arguments = map(str, chain(*items))
+    arguments = [
+        "--" + k if i % 2 == 0 else k for i, k in enumerate(arguments)
+    ]
+    return arguments

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -34,8 +34,9 @@ def train(args):
         _cluster_spec_def_in_docker(args.cluster_spec),
     ]
     container_args.extend(
-        build_arguments_from_parsed_result(args),
-        filter_args=["model_zoo", "cluster_spec", "worker_image"],
+        build_arguments_from_parsed_result(
+            args, filter_args=["model_zoo", "cluster_spec", "worker_image"]
+        )
     )
 
     _submit_job(image_name, args, container_args)
@@ -64,8 +65,9 @@ def evaluate(args):
         _cluster_spec_def_in_docker(args.cluster_spec),
     ]
     container_args.extend(
-        build_arguments_from_parsed_result(args),
-        filter_args=["model_zoo", "cluster_spec", "worker_image"],
+        build_arguments_from_parsed_result(
+            args, filter_args=["model_zoo", "cluster_spec", "worker_image"]
+        )
     )
 
     _submit_job(image_name, args, container_args)
@@ -93,8 +95,9 @@ def predict(args):
         _cluster_spec_def_in_docker(args.cluster_spec),
     ]
     container_args.extend(
-        build_arguments_from_parsed_result(args),
-        filter_args=["model_zoo", "cluster_spec", "worker_image"],
+        build_arguments_from_parsed_result(
+            args, filter_args=["model_zoo", "cluster_spec", "worker_image"]
+        )
     )
 
     _submit_job(image_name, args, container_args)

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -34,7 +34,8 @@ def train(args):
         _cluster_spec_def_in_docker(args.cluster_spec),
     ]
     container_args.extend(
-        build_arguments_from_parsed_result(args), filter_args=["model_zoo"]
+        build_arguments_from_parsed_result(args),
+        filter_args=["model_zoo", "cluster_spec", "worker_image"],
     )
 
     _submit_job(image_name, args, container_args)
@@ -63,7 +64,8 @@ def evaluate(args):
         _cluster_spec_def_in_docker(args.cluster_spec),
     ]
     container_args.extend(
-        build_arguments_from_parsed_result(args), filter_args=["model_zoo"]
+        build_arguments_from_parsed_result(args),
+        filter_args=["model_zoo", "cluster_spec", "worker_image"],
     )
 
     _submit_job(image_name, args, container_args)
@@ -91,7 +93,8 @@ def predict(args):
         _cluster_spec_def_in_docker(args.cluster_spec),
     ]
     container_args.extend(
-        build_arguments_from_parsed_result(args), filter_args=["model_zoo"]
+        build_arguments_from_parsed_result(args),
+        filter_args=["model_zoo", "cluster_spec", "worker_image"],
     )
 
     _submit_job(image_name, args, container_args)

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -1,7 +1,10 @@
 import os
 
 from elasticdl.python.common import k8s_client as k8s
-from elasticdl.python.common.args import parse_envs
+from elasticdl.python.common.args import (
+    build_arguments_from_parsed_result,
+    parse_envs,
+)
 from elasticdl.python.common.log_util import default_logger as logger
 from elasticdl.python.elasticdl.image_builder import (
     build_and_push_docker_image,
@@ -23,70 +26,16 @@ def train(args):
     container_args = [
         "-m",
         "elasticdl.python.master.main",
-        "--job_name",
-        args.job_name,
         "--worker_image",
         image_name,
         "--model_zoo",
         _model_zoo_in_docker(args.model_zoo),
         "--cluster_spec",
         _cluster_spec_def_in_docker(args.cluster_spec),
-        "--num_workers",
-        str(args.num_workers),
-        "--master_resource_request",
-        args.master_resource_request,
-        "--master_resource_limit",
-        args.master_resource_limit,
-        "--worker_resource_request",
-        args.worker_resource_request,
-        "--worker_resource_limit",
-        args.worker_resource_limit,
-        "--envs",
-        args.envs,
-        "--namespace",
-        args.namespace,
-        "--tensorboard_log_dir",
-        args.tensorboard_log_dir,
-        "--records_per_task",
-        str(args.records_per_task),
-        "--num_epochs",
-        str(args.num_epochs),
-        "--grads_to_wait",
-        str(args.grads_to_wait),
-        "--minibatch_size",
-        str(args.minibatch_size),
-        "--training_data_dir",
-        args.training_data_dir,
-        "--evaluation_data_dir",
-        args.evaluation_data_dir,
-        "--checkpoint_steps",
-        str(args.checkpoint_steps),
-        "--checkpoint_dir",
-        args.checkpoint_dir,
-        "--keep_checkpoint_max",
-        str(args.keep_checkpoint_max),
-        "--evaluation_steps",
-        str(args.evaluation_steps),
-        "--evaluation_start_delay_secs",
-        str(args.evaluation_start_delay_secs),
-        "--evaluation_throttle_secs",
-        str(args.evaluation_throttle_secs),
-        "--dataset_fn",
-        args.dataset_fn,
-        "--loss",
-        args.loss,
-        "--optimizer",
-        args.optimizer,
-        "--eval_metrics_fn",
-        args.eval_metrics_fn,
-        "--model_def",
-        args.model_def,
-        "--model_params",
-        args.model_params,
     ]
-    container_args.extend(["--image_pull_policy", args.image_pull_policy])
-    container_args.extend(["--restart_policy", args.restart_policy])
-    container_args.extend(["--volume", args.volume])
+    container_args.extend(
+        build_arguments_from_parsed_result(args), filter_args=["model_zoo"]
+    )
 
     _submit_job(image_name, args, container_args)
     # TODO: print dashboard url after launching the master pod
@@ -106,44 +55,16 @@ def evaluate(args):
     container_args = [
         "-m",
         "elasticdl.python.master.main",
-        "--job_name",
-        args.job_name,
         "--worker_image",
         image_name,
         "--model_zoo",
         _model_zoo_in_docker(args.model_zoo),
         "--cluster_spec",
         _cluster_spec_def_in_docker(args.cluster_spec),
-        "--num_workers",
-        str(args.num_workers),
-        "--worker_resource_request",
-        args.worker_resource_request,
-        "--worker_resource_limit",
-        args.worker_resource_limit,
-        "--envs",
-        args.envs,
-        "--namespace",
-        args.namespace,
-        "--records_per_task",
-        str(args.records_per_task),
-        "--minibatch_size",
-        str(args.minibatch_size),
-        "--evaluation_data_dir",
-        args.evaluation_data_dir,
-        "--checkpoint_filename_for_init",
-        args.checkpoint_filename_for_init,
-        "--dataset_fn",
-        args.dataset_fn,
-        "--eval_metrics_fn",
-        args.eval_metrics_fn,
-        "--model_def",
-        args.model_def,
-        "--model_params",
-        args.model_params,
     ]
-    container_args.extend(["--image_pull_policy", args.image_pull_policy])
-    container_args.extend(["--restart_policy", args.restart_policy])
-    container_args.extend(["--volume", args.volume])
+    container_args.extend(
+        build_arguments_from_parsed_result(args), filter_args=["model_zoo"]
+    )
 
     _submit_job(image_name, args, container_args)
 
@@ -162,42 +83,16 @@ def predict(args):
     container_args = [
         "-m",
         "elasticdl.python.master.main",
-        "--job_name",
-        args.job_name,
         "--worker_image",
         image_name,
         "--model_zoo",
         _model_zoo_in_docker(args.model_zoo),
         "--cluster_spec",
         _cluster_spec_def_in_docker(args.cluster_spec),
-        "--num_workers",
-        str(args.num_workers),
-        "--worker_resource_request",
-        args.worker_resource_request,
-        "--worker_resource_limit",
-        args.worker_resource_limit,
-        "--envs",
-        args.envs,
-        "--namespace",
-        args.namespace,
-        "--records_per_task",
-        str(args.records_per_task),
-        "--minibatch_size",
-        str(args.minibatch_size),
-        "--prediction_data_dir",
-        args.prediction_data_dir,
-        "--checkpoint_filename_for_init",
-        args.checkpoint_filename_for_init,
-        "--dataset_fn",
-        args.dataset_fn,
-        "--model_def",
-        args.model_def,
-        "--model_params",
-        args.model_params,
     ]
-    container_args.extend(["--image_pull_policy", args.image_pull_policy])
-    container_args.extend(["--restart_policy", args.restart_policy])
-    container_args.extend(["--volume", args.volume])
+    container_args.extend(
+        build_arguments_from_parsed_result(args), filter_args=["model_zoo"]
+    )
 
     _submit_job(image_name, args, container_args)
 

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -39,11 +39,6 @@ def train(args):
         )
     )
 
-    logger.info("============================")
-    logger.info(args)
-    logger.info(container_args)
-    logger.info("============================")
-
     _submit_job(image_name, args, container_args)
     # TODO: print dashboard url after launching the master pod
 
@@ -75,11 +70,6 @@ def evaluate(args):
         )
     )
 
-    logger.info("============================")
-    logger.info(args)
-    logger.info(container_args)
-    logger.info("============================")
-
     _submit_job(image_name, args, container_args)
 
 
@@ -109,11 +99,6 @@ def predict(args):
             args, filter_args=["model_zoo", "cluster_spec", "worker_image"]
         )
     )
-
-    logger.info("============================")
-    logger.info(args)
-    logger.info(container_args)
-    logger.info("============================")
 
     _submit_job(image_name, args, container_args)
 

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -39,6 +39,11 @@ def train(args):
         )
     )
 
+    logger.info("============================")
+    logger.info(args)
+    logger.info(container_args)
+    logger.info("============================")
+
     _submit_job(image_name, args, container_args)
     # TODO: print dashboard url after launching the master pod
 
@@ -70,6 +75,11 @@ def evaluate(args):
         )
     )
 
+    logger.info("============================")
+    logger.info(args)
+    logger.info(container_args)
+    logger.info("============================")
+
     _submit_job(image_name, args, container_args)
 
 
@@ -99,6 +109,11 @@ def predict(args):
             args, filter_args=["model_zoo", "cluster_spec", "worker_image"]
         )
     )
+
+    logger.info("============================")
+    logger.info(args)
+    logger.info(container_args)
+    logger.info("============================")
 
     _submit_job(image_name, args, container_args)
 

--- a/elasticdl/python/master/embedding_service.py
+++ b/elasticdl/python/master/embedding_service.py
@@ -164,7 +164,7 @@ class EmbeddingService(object):
             "can be unavailable",
         )
 
-        args = parser.parse_args()
+        args, _ = parser.parse_known_args()
 
         return args
 

--- a/elasticdl/python/tests/args_test.py
+++ b/elasticdl/python/tests/args_test.py
@@ -1,0 +1,36 @@
+import argparse
+import unittest
+
+from elasticdl.python.common.args import (
+    add_bool_param,
+    build_arguments_from_parsed_result,
+)
+
+
+class ArgsTest(unittest.TestCase):
+    def setUp(self):
+        self._parser = argparse.ArgumentParser()
+        self._parser.add_argument("--foo", default=3, type=int)
+        add_bool_param(self._parser, "--bar", False, "")
+
+    def test_build_arguments_from_parsed_result(self):
+        args = ["--foo", "4", "--bar"]
+        results = self._parser.parse_args(args=args)
+        original_arguments = build_arguments_from_parsed_result(results)
+        value = "\t".join(sorted(original_arguments))
+        target = "\t".join(sorted(["--foo", "4", "--bar", "True"]))
+        self.assertEqual(value, target)
+
+        original_arguments = build_arguments_from_parsed_result(
+            results, filter_args=["foo"]
+        )
+        value = "\t".join(sorted(original_arguments))
+        target = "\t".join(sorted(["--bar", "True"]))
+        self.assertEqual(value, target)
+
+        args = ["--foo", "4"]
+        results = self._parser.parse_args(args=args)
+        original_arguments = build_arguments_from_parsed_result(results)
+        value = "\t".join(sorted(original_arguments))
+        target = "\t".join(sorted(["--bar", "False", "--foo", "4"]))
+        self.assertEqual(value, target)


### PR DESCRIPTION
Fixes #1208 

+ Support boolean arguments, which is more robust than default `store_true` or `store_false`
+ Automatically generate arguments for different jobs in `api.py`