### PR TITLE
Only run ODPS related tests if required env vars are set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
         - docker run --rm -it -v $PWD:/work -w /work elasticdl:dev bash -c "make -f elasticdl/Makefile && K8S_TESTS=False pytest elasticdl/python/tests --cov=elasticdl/python"
         # Run unit tests related to ODPS
         - |
-          if [ "$ODPS_ACCESS_ID" = "" ] || [ "$ODPS_ACCESS_KEY" == "" ]; then
+          if [ "$ODPS_ACCESS_ID" == "" ] || [ "$ODPS_ACCESS_KEY" == "" ]; then
             echo "Skipping ODPS related unit tests since either ODPS_ACCESS_ID or ODPS_ACCESS_KEY is not set"
           else
             docker run --rm -it -e ODPS_PROJECT_NAME=gomaxcompute_driver_w7u -e ODPS_ACCESS_ID=$ODPS_ACCESS_ID -e ODPS_ACCESS_KEY=$ODPS_ACCESS_KEY -v $PWD:/work -w /work elasticdl:dev bash -c "make -f elasticdl/Makefile && K8S_TESTS=False ODPS_TESTS=True pytest elasticdl/python/tests/odps_*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,12 @@ jobs:
         # Run unit tests without k8s or ODPS
         - docker run --rm -it -v $PWD:/work -w /work elasticdl:dev bash -c "make -f elasticdl/Makefile && K8S_TESTS=False pytest elasticdl/python/tests --cov=elasticdl/python"
         # Run unit tests related to ODPS
-        # - docker run --rm -it -e ODPS_PROJECT_NAME=gomaxcompute_driver_w7u -e ODPS_ACCESS_ID=$ODPS_ACCESS_ID -e ODPS_ACCESS_KEY=$ODPS_ACCESS_KEY -v $PWD:/work -w /work elasticdl:dev bash -c "make -f elasticdl/Makefile && K8S_TESTS=False ODPS_TESTS=True pytest elasticdl/python/tests/odps_*"
+        - |
+          if [ "$ODPS_ACCESS_ID" = "" ] || [ "$ODPS_ACCESS_KEY" == "" ]; then
+            echo "Skipping ODPS related unit tests since either ODPS_ACCESS_ID or ODPS_ACCESS_KEY is not set"
+          else
+            docker run --rm -it -e ODPS_PROJECT_NAME=gomaxcompute_driver_w7u -e ODPS_ACCESS_ID=$ODPS_ACCESS_ID -e ODPS_ACCESS_KEY=$ODPS_ACCESS_KEY -v $PWD:/work -w /work elasticdl:dev bash -c "make -f elasticdl/Makefile && K8S_TESTS=False ODPS_TESTS=True pytest elasticdl/python/tests/odps_*"
+          fi
     - stage: integrationtest
       name: "Integration Tests"
       script:


### PR DESCRIPTION
As pointed out in [Travis documentation](https://docs.travis-ci.com/user/encryption-keys/),  encrypted environment variables are not available for pull requests from forks. The only solution for now is to only run ODPS related tests if the environment variables are set (e.g. when PRs are created from branches instead of forks). [SQLFlow is currently using the same solution](https://github.com/sql-machine-learning/sqlflow/blob/develop/scripts/test_maxcompute.sh#L18).

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>