### PR TITLE
Rename CheckRetrainCallback to CheckRetryCallback

### DIFF
--- a/elasticdl/python/tests/test_call_back.py
+++ b/elasticdl/python/tests/test_call_back.py
@@ -6,7 +6,7 @@ ON_REPORT_EVALUATION_METRICS_BEGIN = "on_report_evaluation_metrics_begin"
 
 
 class BaseCallback(ABC):
-    """Baseclass of callbacks used for unittests."""
+    """Base class of callbacks used for testing."""
 
     def __init__(self, master, worker, unittest_inst, call_times):
         self._master = master

--- a/elasticdl/python/tests/worker_test.py
+++ b/elasticdl/python/tests/worker_test.py
@@ -61,7 +61,7 @@ def create_recordio_file(size):
     return temp_file.name
 
 
-class CheckRetrainCallback(BaseCallback):
+class CheckRetryCallback(BaseCallback):
     """Checks the retry functionality of workers.
 
     When workers report Gradient or evaluation metrics, this callback
@@ -70,7 +70,7 @@ class CheckRetrainCallback(BaseCallback):
     """
 
     def __init__(self, master, worker, unittest_inst):
-        super(CheckRetrainCallback, self).__init__(
+        super(CheckRetryCallback, self).__init__(
             master,
             worker,
             unittest_inst,
@@ -201,12 +201,12 @@ class WorkerTest(unittest.TestCase):
 
     def test_distributed_train_tf_example(self):
         self.distributed_train_and_evaluate(
-            training=True, callback_classes=[CheckRetrainCallback]
+            training=True, callback_classes=[CheckRetryCallback]
         )
 
     def test_distributed_evaluate_tf_example(self):
         self.distributed_train_and_evaluate(
-            training=False, callback_classes=[CheckRetrainCallback]
+            training=False, callback_classes=[CheckRetryCallback]
         )
 
     def test_distributed_train_get_model_steps(self):


### PR DESCRIPTION
"Retrain" has a special meaning in statistical modeling so it's better to use "retry" here.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>