### PR TITLE
Support ODPS data source in ElasticDL job

### DIFF
--- a/elasticdl/python/common/data_reader.py
+++ b/elasticdl/python/common/data_reader.py
@@ -5,8 +5,8 @@ from contextlib import closing
 import recordio
 import tensorflow as tf
 
-from elasticdl.python.common.odps_io import ODPSReader
 from elasticdl.python.common.constants import ODPSConfig
+from elasticdl.python.common.odps_io import ODPSReader
 
 
 class AbstractDataReader(ABC):

--- a/elasticdl/python/common/data_reader.py
+++ b/elasticdl/python/common/data_reader.py
@@ -141,7 +141,7 @@ class ODPSDataReader(AbstractDataReader):
         return shard_name.split(":")[0]
 
 
-def create_data_reader(data_origin):
+def create_data_reader(data_origin, records_per_task=None):
     if all(
         k in os.environ
         for k in (
@@ -156,6 +156,7 @@ def create_data_reader(data_origin):
             access_key=os.environ[ODPSConfig.ACCESS_KEY],
             table=data_origin,
             endpoint=os.environ.get(ODPSConfig.ENDPOINT),
+            records_per_task=records_per_task,
         )
     else:
         return RecordIODataReader(data_dir=data_origin)

--- a/elasticdl/python/common/dataset_utils.py
+++ b/elasticdl/python/common/dataset_utils.py
@@ -1,6 +1,6 @@
 import tensorflow as tf
 
-from elasticdl.python.common.data_reader import RecordIODataReader
+from elasticdl.python.common.data_reader import create_data_reader
 
 
 def create_dataset_from_tasks(tasks):
@@ -11,8 +11,7 @@ def create_dataset_from_tasks(tasks):
     class _Generator:
         def __init__(self, tasks):
             self._tasks = tasks
-            # TODO: Support any subclasses of `AbstractDataReader`
-            self._data_reader = RecordIODataReader(data_dir=None)
+            self._data_reader = create_data_reader(data_origin=None)
 
         def gen(self):
             for task in self._tasks:
@@ -22,6 +21,6 @@ def create_dataset_from_tasks(tasks):
 
     generator = _Generator(tasks)
     dataset = tf.data.Dataset.from_generator(
-        generator.gen, (tf.string), (tf.TensorShape([]))
+        generator.gen, generator._data_reader.records_output_types
     )
     return dataset

--- a/elasticdl/python/master/main.py
+++ b/elasticdl/python/master/main.py
@@ -45,7 +45,7 @@ def _make_task_dispatcher(
     # TODO: Support any subclasses of `AbstractDataReader`
     # and support passing specified parameters to the constructor
     prediction_f_records = create_data_reader(
-        data_origin=prediction_data_dir
+        data_origin=prediction_data_dir, records_per_task=records_per_task
     ).create_shards()
 
     return _TaskDispatcher(

--- a/elasticdl/python/master/main.py
+++ b/elasticdl/python/master/main.py
@@ -16,7 +16,7 @@ from elasticdl.python.common.constants import (
     JobType,
     WorkerManagerStatus,
 )
-from elasticdl.python.common.data_reader import RecordIODataReader
+from elasticdl.python.common.data_reader import create_data_reader
 from elasticdl.python.common.k8s_tensorboard_client import TensorBoardClient
 from elasticdl.python.common.log_util import get_logger
 from elasticdl.python.common.model_helper import (
@@ -44,13 +44,13 @@ def _make_task_dispatcher(
 ):
     # TODO: Support any subclasses of `AbstractDataReader`
     # and support passing specified parameters to the constructor
-    prediction_f_records = RecordIODataReader(
-        data_dir=prediction_data_dir
+    prediction_f_records = create_data_reader(
+        data_origin=prediction_data_dir
     ).create_shards()
 
     return _TaskDispatcher(
-        RecordIODataReader(data_dir=training_data_dir).create_shards(),
-        RecordIODataReader(data_dir=evaluation_data_dir).create_shards(),
+        create_data_reader(data_origin=training_data_dir).create_shards(),
+        create_data_reader(data_origin=evaluation_data_dir).create_shards(),
         prediction_f_records,
         records_per_task,
         # Only generate prediction tasks for 1 epoch

--- a/elasticdl/python/tests/odps_data_reader_test.py
+++ b/elasticdl/python/tests/odps_data_reader_test.py
@@ -98,14 +98,18 @@ class ODPSDataReaderTest(unittest.TestCase):
 
     def test_odps_data_reader_shards_creation(self):
         expected_shards = {
-            "shard_0": (0, self.records_per_task),
-            "shard_1": (50, self.records_per_task),
-            "shard_2": (100, 10),
+            self.test_table + ":shard_0": (0, self.records_per_task),
+            self.test_table + ":shard_1": (50, self.records_per_task),
+            self.test_table + ":shard_2": (100, 10),
         }
         self.assertEqual(expected_shards, self.reader.create_shards())
 
     def test_odps_data_reader_records_reading(self):
-        records = list(self.reader.read_records(_MockedTask(0, 2, "shard_0")))
+        records = list(
+            self.reader.read_records(
+                _MockedTask(0, 2, self.test_table + ":shard_0")
+            )
+        )
         self.assertEqual(
             [[6.4, 2.8, 5.6, 2.2, 2], [5.0, 2.3, 3.3, 1.0, 1]], records
         )
@@ -125,12 +129,12 @@ class ODPSDataReaderTest(unittest.TestCase):
 
         def _gen():
             for data in self.reader.read_records(
-                _MockedTask(0, num_records, "shard_0")
+                _MockedTask(0, num_records, self.test_table + ":shard_0")
             ):
                 if data is not None:
                     yield data
 
-        dataset = tf.data.Dataset.from_generator(_gen, (tf.float32))
+        dataset = tf.data.Dataset.from_generator(_gen, tf.float32)
         dataset = dataset_fn(dataset, None)
 
         loss_history = []

--- a/elasticdl/python/worker/task_data_service.py
+++ b/elasticdl/python/worker/task_data_service.py
@@ -3,7 +3,7 @@ import threading
 import tensorflow as tf
 
 from elasticdl.proto import elasticdl_pb2
-from elasticdl.python.common.data_reader import RecordIODataReader
+from elasticdl.python.common.data_reader import create_data_reader
 from elasticdl.python.common.dataset_utils import create_dataset_from_tasks
 from elasticdl.python.common.log_util import default_logger as logger
 
@@ -16,8 +16,7 @@ class TaskDataService(object):
         self._pending_dataset = True
         self._pending_eval_tasks = []
         self._reset()
-        # TODO: Support any subclasses of `AbstractDataReader`
-        self._data_reader = RecordIODataReader(data_dir=None)
+        self._data_reader = create_data_reader(data_origin=None)
 
     def _reset(self):
         """
@@ -92,7 +91,7 @@ class TaskDataService(object):
                 return None
             self._reset()
             ds = tf.data.Dataset.from_generator(
-                self._gen, (tf.string), (tf.TensorShape([]))
+                self._gen, self._data_reader.records_output_types
             )
             self._pending_dataset = False
             return ds


### PR DESCRIPTION
This fixes #1105. Changes include:
* Removes hard-coded `tf.string` output types and move this to be specific to data readers through property `records_output_types`. Note that this just provides the default output types for `tf.data.Dataset.from_generator` to use. Users can still cast the fields to desired types in `dataset_fn` in model definition files.
* Refactored `ODPSDataReader` and changed shard name for each ODPS shard to be `tablename:shard_0` so that each worker knows where to grab data from each task.This way users can pass different table names for training/evaluation/prediction, etc.
* Added `create_data_reader` to create different data readers, e.g. when ODPS env variables are provided, this will instantiate a `ODPSDataReader`.
* Enable `master.main` to instantiate the correct data readers from the specified data origins for each different phases.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>