### PR TITLE
Correctly creates tasks for when end index is smaller than start index

### DIFF
--- a/elasticdl/python/master/task_dispatcher.py
+++ b/elasticdl/python/master/task_dispatcher.py
@@ -99,7 +99,7 @@ class _TaskDispatcher(object):
                     )
                 # Note that only records in [start, end) of this task
                 # will be consumed later in the worker that handles
-                # this task
+                # this task.
                 tasks.append(
                     _Task(
                         shard_name=shard_name,

--- a/elasticdl/python/master/task_dispatcher.py
+++ b/elasticdl/python/master/task_dispatcher.py
@@ -87,12 +87,21 @@ class _TaskDispatcher(object):
             shards = self._prediction_shards
         tasks = []
         for shard_name, (start_ind, num_records) in shards.items():
-            for start in range(start_ind, num_records, self._records_per_task):
+            for start in range(
+                start_ind, start_ind + num_records, self._records_per_task
+            ):
+                end_ind = (
+                    min(start + self._records_per_task, num_records)
+                    if start_ind == 0
+                    else min(
+                        start + self._records_per_task, start + num_records
+                    )
+                )
                 tasks.append(
                     _Task(
                         shard_name=shard_name,
                         start=start,
-                        end=min(start + self._records_per_task, num_records),
+                        end=end_ind,
                         type=task_type,
                         model_version=model_version,
                     )

--- a/elasticdl/python/master/task_dispatcher.py
+++ b/elasticdl/python/master/task_dispatcher.py
@@ -90,13 +90,16 @@ class _TaskDispatcher(object):
             for start in range(
                 start_ind, start_ind + num_records, self._records_per_task
             ):
-                end_ind = (
-                    min(start + self._records_per_task, num_records)
-                    if start_ind == 0
-                    else min(
+                end_ind = min(start + self._records_per_task, num_records)
+                # If the start index is not smaller than end index,
+                # we need to take the start index into account
+                if start >= end_ind:
+                    end_ind = min(
                         start + self._records_per_task, start + num_records
                     )
-                )
+                # Note that only records in [start, end) of this task
+                # will be consumed later in the worker that handles
+                # this task
                 tasks.append(
                     _Task(
                         shard_name=shard_name,

--- a/elasticdl/python/tests/task_dispatcher_test.py
+++ b/elasticdl/python/tests/task_dispatcher_test.py
@@ -55,6 +55,29 @@ class TaskQueueTest(unittest.TestCase):
 
         self.assertTrue(task_d.finished())
 
+    def test_create_get_none_zero_start_ind(self):
+        task_d = _TaskDispatcher({"f1": (0, 10), "f2": (10, 10)}, {}, {}, 3, 1)
+
+        all_tasks = [
+            ("f1", 0, 3, elasticdl_pb2.TRAINING, -1),
+            ("f1", 3, 6, elasticdl_pb2.TRAINING, -1),
+            ("f1", 6, 9, elasticdl_pb2.TRAINING, -1),
+            ("f1", 9, 10, elasticdl_pb2.TRAINING, -1),
+            ("f2", 10, 13, elasticdl_pb2.TRAINING, -1),
+            ("f2", 13, 16, elasticdl_pb2.TRAINING, -1),
+            ("f2", 16, 19, elasticdl_pb2.TRAINING, -1),
+            ("f2", 19, 22, elasticdl_pb2.TRAINING, -1),
+        ]
+
+        # get all tasks out, each worker is assigned 2 tasks.
+        got_tasks = [task_d.get(i // 2) for i in range(8)]
+
+        # verify ids ranges from 1 to 8
+        self.assertEqual(list(range(1, 9)), [k for k, _ in got_tasks])
+
+        # verify tasks
+        self.assertEqual(sorted([v._info() for _, v in got_tasks]), all_tasks)
+
     def test_epoch(self):
         task_d = _TaskDispatcher({"f1": (0, 10), "f2": (0, 10)}, {}, {}, 3, 2)
 

--- a/elasticdl/python/tests/task_dispatcher_test.py
+++ b/elasticdl/python/tests/task_dispatcher_test.py
@@ -5,7 +5,7 @@ from elasticdl.python.master.task_dispatcher import _TaskDispatcher
 
 
 class TaskQueueTest(unittest.TestCase):
-    def test_create_get(self):
+    def test_create_get_zero_start_ind(self):
         task_d = _TaskDispatcher({"f1": (0, 10), "f2": (0, 10)}, {}, {}, 3, 1)
 
         all_tasks = [


### PR DESCRIPTION
Fixes #1239. Additional test case is added to cover this. Now both RecordIO and ODPS data source could generate tasks correctly.