### PR TITLE
Allow to pass additional params to data reader constructor

### DIFF
--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -412,6 +412,13 @@ def add_common_args_between_master_and_worker(parser):
         default=1,
         help="Worker will get_model from PS every these steps.",
     )
+    parser.add_argument(
+        "--data_reader_params",
+        type=str,
+        default="",
+        help="The dictionary of data reader parameters in a string that will be "
+             'used to instantiate the data reader, e.g. "columns=["a", "b"]"',
+    )
 
 
 def parse_master_args(master_args=None):

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -417,7 +417,7 @@ def add_common_args_between_master_and_worker(parser):
         type=str,
         default="",
         help="The data reader parameters in a string separated by semi-colon "
-        'used to instantiate the data reader, e.g. "columns=["a", "b"]"',
+        'used to instantiate the data reader, e.g. "param1=1; param2=2"',
     )
 
 

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -403,8 +403,8 @@ def add_common_args_between_master_and_worker(parser):
         "--model_params",
         type=str,
         default="",
-        help="The dictionary of model parameters in a string that will be "
-        'used to instantiate the model, e.g. "param1=1,param2=2"',
+        help="The model parameters in a string separated by semi-colon "
+        'used to instantiate the model, e.g. "param1=1; param2=2"',
     )
     parser.add_argument(
         "--get_model_steps",
@@ -416,8 +416,8 @@ def add_common_args_between_master_and_worker(parser):
         "--data_reader_params",
         type=str,
         default="",
-        help="The dictionary of data reader parameters in a string that will be "
-             'used to instantiate the data reader, e.g. "columns=["a", "b"]"',
+        help="The data reader parameters in a string separated by semi-colon "
+        'used to instantiate the data reader, e.g. "columns=["a", "b"]"',
     )
 
 

--- a/elasticdl/python/common/model_utils.py
+++ b/elasticdl/python/common/model_utils.py
@@ -24,14 +24,22 @@ def load_model_from_module(model_def, model_module, model_params):
             "in model definition files"
         )
     if model_params:
-        kvs = model_params.split(",")
-        model_params_dict = {}
-        for kv in kvs:
-            k, v = kv.split("=")
-            model_params_dict[k] = eval(v)
+        model_params_dict = get_dict_from_params_str(model_params)
         return model_module[custom_model_name](**model_params_dict)
     else:
         return model_module[custom_model_name]()
+
+
+def get_dict_from_params_str(params_str):
+    if params_str:
+        kvs = params_str.split(",")
+        params_dict = {}
+        for kv in kvs:
+            k, v = kv.split("=")
+            params_dict[k] = eval(v)
+        return params_dict
+    else:
+        return None
 
 
 def get_module_file_path(model_zoo, spec_key):

--- a/elasticdl/python/common/model_utils.py
+++ b/elasticdl/python/common/model_utils.py
@@ -31,11 +31,13 @@ def load_model_from_module(model_def, model_module, model_params):
 
 
 def get_dict_from_params_str(params_str):
+    """Get the dictionary of kv pairs in a string separated
+    by semi-colon."""
     if params_str:
-        kvs = params_str.split(",")
+        kvs = params_str.split(";")
         params_dict = {}
         for kv in kvs:
-            k, v = kv.split("=")
+            k, v = kv.strip().split("=")
             params_dict[k] = eval(v)
         return params_dict
     else:

--- a/elasticdl/python/data/data_reader.py
+++ b/elasticdl/python/data/data_reader.py
@@ -89,7 +89,7 @@ class ODPSDataReader(AbstractDataReader):
             table_name=self._get_odps_table_name(task.shard_name)
         )
         records = reader.read_batch(
-            start=task.start, end=task.end, columns=None
+            start=task.start, end=task.end, columns=self._kwargs.get("columns")
         )
         for batch in records:
             yield batch
@@ -139,7 +139,7 @@ class ODPSDataReader(AbstractDataReader):
         return shard_name.split(":")[0]
 
 
-def create_data_reader(data_origin, records_per_task=None):
+def create_data_reader(data_origin, records_per_task=None, **kwargs):
     if all(
         k in os.environ
         for k in (
@@ -155,6 +155,7 @@ def create_data_reader(data_origin, records_per_task=None):
             table=data_origin,
             endpoint=os.environ.get(ODPSConfig.ENDPOINT),
             records_per_task=records_per_task,
+            **kwargs,
         )
     else:
         return RecordIODataReader(data_dir=data_origin)

--- a/elasticdl/python/data/dataset_utils.py
+++ b/elasticdl/python/data/dataset_utils.py
@@ -3,7 +3,7 @@ import tensorflow as tf
 from elasticdl.python.data.data_reader import create_data_reader
 
 
-def create_dataset_from_tasks(tasks):
+def create_dataset_from_tasks(tasks, data_reader_params=None):
     """
     Returns a `tf.data.Dataset` from a list of `Task`s.
     """
@@ -11,7 +11,10 @@ def create_dataset_from_tasks(tasks):
     class _Generator:
         def __init__(self, tasks):
             self._tasks = tasks
-            self._data_reader = create_data_reader(data_origin=None)
+            if data_reader_params:
+                self._data_reader = create_data_reader(data_origin=None, **data_reader_params)
+            else:
+                self._data_reader = create_data_reader(data_origin=None)
 
         def gen(self):
             for task in self._tasks:

--- a/elasticdl/python/data/dataset_utils.py
+++ b/elasticdl/python/data/dataset_utils.py
@@ -1,9 +1,7 @@
 import tensorflow as tf
 
-from elasticdl.python.data.data_reader import create_data_reader
 
-
-def create_dataset_from_tasks(tasks, data_reader_params=None):
+def create_dataset_from_tasks(tasks, data_reader):
     """
     Returns a `tf.data.Dataset` from a list of `Task`s.
     """
@@ -11,10 +9,7 @@ def create_dataset_from_tasks(tasks, data_reader_params=None):
     class _Generator:
         def __init__(self, tasks):
             self._tasks = tasks
-            if data_reader_params:
-                self._data_reader = create_data_reader(data_origin=None, **data_reader_params)
-            else:
-                self._data_reader = create_data_reader(data_origin=None)
+            self._data_reader = data_reader
 
         def gen(self):
             for task in self._tasks:

--- a/elasticdl/python/tests/data_reader_test.py
+++ b/elasticdl/python/tests/data_reader_test.py
@@ -13,6 +13,7 @@ from elasticdl.python.common.model_utils import load_module
 from elasticdl.python.data.data_reader import (
     ODPSDataReader,
     RecordIODataReader,
+    create_data_reader,
 )
 from elasticdl.python.tests.test_utils import (
     DatasetName,
@@ -98,6 +99,14 @@ class ODPSDataReaderTest(unittest.TestCase):
         self.assertEqual(
             [[6.4, 2.8, 5.6, 2.2, 2], [5.0, 2.3, 3.3, 1.0, 1]], records
         )
+
+    def test_create_data_reader(self):
+        reader = create_data_reader(data_origin="table", records_per_task=10, **{"columns": ["a", "b"]})
+        self.assertEqual(reader._kwargs["columns"], ['a', 'b'])
+        self.assertEqual(reader._kwargs["records_per_task"], 10)
+        reader = create_data_reader(data_origin="table", records_per_task=10)
+        self.assertEqual(reader._kwargs["records_per_task"], 10)
+        self.assertTrue("columns" not in reader._kwargs)
 
     def test_odps_data_reader_integration_with_local_keras(self):
         num_records = 2

--- a/elasticdl/python/tests/data_reader_test.py
+++ b/elasticdl/python/tests/data_reader_test.py
@@ -101,8 +101,10 @@ class ODPSDataReaderTest(unittest.TestCase):
         )
 
     def test_create_data_reader(self):
-        reader = create_data_reader(data_origin="table", records_per_task=10, **{"columns": ["a", "b"]})
-        self.assertEqual(reader._kwargs["columns"], ['a', 'b'])
+        reader = create_data_reader(
+            data_origin="table", records_per_task=10, **{"columns": ["a", "b"]}
+        )
+        self.assertEqual(reader._kwargs["columns"], ["a", "b"])
         self.assertEqual(reader._kwargs["records_per_task"], 10)
         reader = create_data_reader(data_origin="table", records_per_task=10)
         self.assertEqual(reader._kwargs["records_per_task"], 10)

--- a/elasticdl/python/tests/example_test.py
+++ b/elasticdl/python/tests/example_test.py
@@ -15,7 +15,7 @@ _model_zoo_path = os.path.join(
 class ExampleTest(unittest.TestCase):
     def test_deepfm_functional_train(self):
         model_params = (
-            "input_dim=5383,embedding_dim=4,input_length=10,fc_unit=4"
+            "input_dim=5383;embedding_dim=4;input_length=10;fc_unit=4"
         )
         use_asyncs = [False, True]
         for use_async in use_asyncs:
@@ -31,7 +31,7 @@ class ExampleTest(unittest.TestCase):
 
     def test_deepfm_functional_evaluate(self):
         model_params = (
-            "input_dim=5383,embedding_dim=4,input_length=10,fc_unit=4"
+            "input_dim=5383;embedding_dim=4;input_length=10;fc_unit=4"
         )
         distributed_train_and_evaluate(
             10,
@@ -123,7 +123,7 @@ class ExampleTest(unittest.TestCase):
             [224, 224, 3],
             _model_zoo_path,
             "resnet50_subclass.resnet50_subclass.CustomModel",
-            model_params='num_classes=10,dtype="float32"',
+            model_params='num_classes=10;dtype="float32"',
             training=False,
             dataset_name=DatasetName.IMAGENET,
         )

--- a/elasticdl/python/tests/model_utils_test.py
+++ b/elasticdl/python/tests/model_utils_test.py
@@ -5,6 +5,7 @@ from elasticdl.python.common.model_utils import (
     _get_spec_value,
     get_model_spec,
     get_module_file_path,
+    get_dict_from_params_str,
 )
 
 _model_zoo_path = os.path.dirname(os.path.realpath(__file__))
@@ -68,6 +69,16 @@ class ModelHelperTest(unittest.TestCase):
             {},
             True,
         )
+
+    def test_get_dict_from_params_str(self):
+        self.assertEqual(
+            get_dict_from_params_str('ls=["a", "b"]'), {"ls": ["a", "b"]}
+        )
+        self.assertEqual(
+            get_dict_from_params_str('ls=["a", "b"]; d={"a": 3}'),
+            {"ls": ["a", "b"], "d": {"a": 3}},
+        )
+        self.assertEqual(get_dict_from_params_str(""), None)
 
 
 if __name__ == "__main__":

--- a/elasticdl/python/tests/model_utils_test.py
+++ b/elasticdl/python/tests/model_utils_test.py
@@ -3,9 +3,9 @@ import unittest
 
 from elasticdl.python.common.model_utils import (
     _get_spec_value,
+    get_dict_from_params_str,
     get_model_spec,
     get_module_file_path,
-    get_dict_from_params_str,
 )
 
 _model_zoo_path = os.path.dirname(os.path.realpath(__file__))

--- a/elasticdl/python/worker/main.py
+++ b/elasticdl/python/worker/main.py
@@ -35,6 +35,7 @@ def main():
         eval_metrics_fn=args.eval_metrics_fn,
         model_def=args.model_def,
         model_params=args.model_params,
+        data_reader_params=args.data_reader_params,
         get_model_steps=args.get_model_steps,
     )
     worker.run()

--- a/elasticdl/python/worker/task_data_service.py
+++ b/elasticdl/python/worker/task_data_service.py
@@ -9,7 +9,9 @@ from elasticdl.python.data.dataset_utils import create_dataset_from_tasks
 
 
 class TaskDataService(object):
-    def __init__(self, worker, training_with_evaluation, data_reader_params=None):
+    def __init__(
+        self, worker, training_with_evaluation, data_reader_params=None
+    ):
         self._worker = worker
         self._training_with_evaluation = training_with_evaluation
         self._lock = threading.Lock()
@@ -17,7 +19,9 @@ class TaskDataService(object):
         self._pending_eval_tasks = []
         self._reset()
         if data_reader_params:
-            self._data_reader = create_data_reader(data_origin=None, **data_reader_params)
+            self._data_reader = create_data_reader(
+                data_origin=None, **data_reader_params
+            )
         else:
             self._data_reader = create_data_reader(data_origin=None)
 

--- a/elasticdl/python/worker/task_data_service.py
+++ b/elasticdl/python/worker/task_data_service.py
@@ -9,14 +9,17 @@ from elasticdl.python.data.dataset_utils import create_dataset_from_tasks
 
 
 class TaskDataService(object):
-    def __init__(self, worker, training_with_evaluation):
+    def __init__(self, worker, training_with_evaluation, data_reader_params=None):
         self._worker = worker
         self._training_with_evaluation = training_with_evaluation
         self._lock = threading.Lock()
         self._pending_dataset = True
         self._pending_eval_tasks = []
         self._reset()
-        self._data_reader = create_data_reader(data_origin=None)
+        if data_reader_params:
+            self._data_reader = create_data_reader(data_origin=None, **data_reader_params)
+        else:
+            self._data_reader = create_data_reader(data_origin=None)
 
     def _reset(self):
         """

--- a/elasticdl/python/worker/task_data_service.py
+++ b/elasticdl/python/worker/task_data_service.py
@@ -75,7 +75,7 @@ class TaskDataService(object):
                 shards.append(task)
         if shards and task:
             return (
-                create_dataset_from_tasks(shards),
+                create_dataset_from_tasks(shards, self._data_reader),
                 task.model_version,
                 task.task_id,
             )

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -63,11 +63,11 @@ class Worker(object):
             model_def: The import path to the model definition
                 function/class in the model zoo, e.g.
                 "cifar10_subclass.CustomModel".
-            model_params: The dictionary of model parameters in a string that
-                will be used to instantiate the model,
+            model_params: The dictionary of model parameters in a string
+                separated by semi-colon used to instantiate the model,
                 e.g. "param1=1,param2=2".
-            data_reader_params: The dictionary of data reader parameters in
-                a string that will be used to instantiate the data reader,
+            data_reader_params: The data reader parameters in a string
+                separated by semi-colon used to instantiate the data reader,
                 e.g. "param1=1,param2=2".
             prediction_outputs_processor: The name of the prediction output
                 processor class defined in the model file.
@@ -106,7 +106,8 @@ class Worker(object):
         self._max_minibatch_retry_num = max_minibatch_retry_num
         self._model_version = -1
         self._task_data_service = TaskDataService(
-            self, self._job_type == JobType.TRAINING_WITH_EVALUATION,
+            self,
+            self._job_type == JobType.TRAINING_WITH_EVALUATION,
             data_reader_params=get_dict_from_params_str(data_reader_params),
         )
         self._get_model_steps = get_model_steps

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -8,6 +8,7 @@ from elasticdl.python.common.log_utils import default_logger as logger
 from elasticdl.python.common.model_utils import (
     find_layer,
     get_model_spec,
+    get_dict_from_params_str,
     get_non_embedding_trainable_vars,
 )
 from elasticdl.python.common.ndarray import (
@@ -39,6 +40,7 @@ class Worker(object):
         embedding_service_endpoint=None,
         model_def=None,
         model_params="",
+        data_reader_params="",
         prediction_outputs_processor="PredictionOutputsProcessor",
         max_minibatch_retry_num=DEFAULT_MAX_MINIBATCH_RETRY_NUM,
         get_model_steps=1,
@@ -63,6 +65,9 @@ class Worker(object):
                 "cifar10_subclass.CustomModel".
             model_params: The dictionary of model parameters in a string that
                 will be used to instantiate the model,
+                e.g. "param1=1,param2=2".
+            data_reader_params: The dictionary of data reader parameters in
+                a string that will be used to instantiate the data reader,
                 e.g. "param1=1,param2=2".
             prediction_outputs_processor: The name of the prediction output
                 processor class defined in the model file.
@@ -101,7 +106,8 @@ class Worker(object):
         self._max_minibatch_retry_num = max_minibatch_retry_num
         self._model_version = -1
         self._task_data_service = TaskDataService(
-            self, self._job_type == JobType.TRAINING_WITH_EVALUATION
+            self, self._job_type == JobType.TRAINING_WITH_EVALUATION,
+            data_reader_params=get_dict_from_params_str(data_reader_params),
         )
         self._get_model_steps = get_model_steps
         if self._get_model_steps > 1:

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -65,10 +65,10 @@ class Worker(object):
                 "cifar10_subclass.CustomModel".
             model_params: The dictionary of model parameters in a string
                 separated by semi-colon used to instantiate the model,
-                e.g. "param1=1,param2=2".
+                e.g. "param1=1; param2=2".
             data_reader_params: The data reader parameters in a string
                 separated by semi-colon used to instantiate the data reader,
-                e.g. "param1=1,param2=2".
+                e.g. "param1=1; param2=2".
             prediction_outputs_processor: The name of the prediction output
                 processor class defined in the model file.
             get_model_steps: Worker will perform `get_model` from the

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -7,8 +7,8 @@ from elasticdl.python.common.constants import JobType, Mode
 from elasticdl.python.common.log_utils import default_logger as logger
 from elasticdl.python.common.model_utils import (
     find_layer,
-    get_model_spec,
     get_dict_from_params_str,
+    get_model_spec,
     get_non_embedding_trainable_vars,
 )
 from elasticdl.python.common.ndarray import (


### PR DESCRIPTION
Fixes #1256. Changes include:
* Allow to pass additional params to data reader constructor. Tests are added for `create_data_reader()` that demonstrates this new feature.
* Add `--data_reader_params` in CLI and support this in `Worker`.
* Extract `get_dict_from_params_str()` that is reusable for parsing model params and data reader params. Changed to use semi-colon as the kv separator since comma is too common in Python. Tests are added to demonstrate this.