### PR TITLE
Fix task end index that should not exceed the max index for this shard

### DIFF
--- a/elasticdl/python/master/task_dispatcher.py
+++ b/elasticdl/python/master/task_dispatcher.py
@@ -105,7 +105,9 @@ class _TaskDispatcher(object):
                 )
                 # If the start index is not smaller than end index,
                 # we need to find the correct end index by taking the start
-                # index into account.
+                # index into account. We should not create task with
+                # end index that exceeds the maximally possible number of
+                # records available in this shard.
                 if start_ind_this_task >= end_ind_this_task:
                     end_ind_this_task = min(
                         max_ind_this_task,

--- a/elasticdl/python/master/task_dispatcher.py
+++ b/elasticdl/python/master/task_dispatcher.py
@@ -86,16 +86,31 @@ class _TaskDispatcher(object):
         else:
             shards = self._prediction_shards
         tasks = []
-        for shard_name, (start_ind, num_records) in shards.items():
-            for start in range(
-                start_ind, start_ind + num_records, self._records_per_task
+        # Note that a shard may contain records for multiple tasks.
+        for (
+            shard_name,
+            (start_ind_this_shard, num_records_this_shard),
+        ) in shards.items():
+            max_ind_this_shard = start_ind_this_shard + num_records_this_shard
+            for start_ind_this_task in range(
+                start_ind_this_shard,
+                start_ind_this_shard + num_records_this_shard,
+                self._records_per_task,
             ):
-                end_ind = min(start + self._records_per_task, num_records)
+                max_ind_this_task = (
+                    start_ind_this_task + self._records_per_task
+                )
+                end_ind_this_task = min(
+                    max_ind_this_task, num_records_this_shard
+                )
                 # If the start index is not smaller than end index,
-                # we need to take the start index into account
-                if start >= end_ind:
-                    end_ind = min(
-                        start + self._records_per_task, start + num_records
+                # we need to find the correct end index by taking the start
+                # index into account.
+                if start_ind_this_task >= end_ind_this_task:
+                    end_ind_this_task = min(
+                        max_ind_this_task,
+                        start_ind_this_task + num_records_this_shard,
+                        max_ind_this_shard,
                     )
                 # Note that only records in [start, end) of this task
                 # will be consumed later in the worker that handles
@@ -103,8 +118,8 @@ class _TaskDispatcher(object):
                 tasks.append(
                     _Task(
                         shard_name=shard_name,
-                        start=start,
-                        end=end_ind,
+                        start=start_ind_this_task,
+                        end=end_ind_this_task,
                         type=task_type,
                         model_version=model_version,
                     )

--- a/elasticdl/python/tests/task_dispatcher_test.py
+++ b/elasticdl/python/tests/task_dispatcher_test.py
@@ -5,7 +5,7 @@ from elasticdl.python.master.task_dispatcher import _TaskDispatcher
 
 
 class TaskQueueTest(unittest.TestCase):
-    def test_create_get_zero_start_ind(self):
+    def test_create_tasks_with_zero_start_ind(self):
         task_d = _TaskDispatcher({"f1": (0, 10), "f2": (0, 10)}, {}, {}, 3, 1)
 
         all_tasks = [
@@ -55,7 +55,7 @@ class TaskQueueTest(unittest.TestCase):
 
         self.assertTrue(task_d.finished())
 
-    def test_create_get_none_zero_start_ind(self):
+    def test_create_tasks_with_non_zero_start_ind(self):
         task_d = _TaskDispatcher({"f1": (0, 10), "f2": (10, 10)}, {}, {}, 3, 1)
 
         all_tasks = [
@@ -66,7 +66,7 @@ class TaskQueueTest(unittest.TestCase):
             ("f2", 10, 13, elasticdl_pb2.TRAINING, -1),
             ("f2", 13, 16, elasticdl_pb2.TRAINING, -1),
             ("f2", 16, 19, elasticdl_pb2.TRAINING, -1),
-            ("f2", 19, 22, elasticdl_pb2.TRAINING, -1),
+            ("f2", 19, 20, elasticdl_pb2.TRAINING, -1),
         ]
 
         # get all tasks out, each worker is assigned 2 tasks.


### PR DESCRIPTION
We should not create task with end index that exceeds the maximally possible number of records available in this shard. This PR includes:
* Takes the maximally possible number of records available in this shard into account when finding the end index for each task.
* Fixed the task end index in the test case that should be 20 instead of 22 since 20 is the maximally possible number of records available in this shard.
* Renamed the variables and added comments so it's more readable.