### PR TITLE
Change the parameter docker_image_prefix name

### DIFF
--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -101,10 +101,10 @@ def add_common_params(parser):
     """Common arguments for training/prediction/evaluation"""
     add_common_args_between_master_and_worker(parser)
     parser.add_argument(
-        "--docker_image_prefix",
+        "--docker_image_repository",
         default="",
-        help="The prefix for generated Docker images, if set, the image is "
-        "also pushed to the registry",
+        help="The repository for generated Docker images, if set, the image "
+        "is also pushed to the repository",
     )
     parser.add_argument("--image_base", help="Base Docker image.")
     parser.add_argument("--job_name", help="ElasticDL job name", required=True)

--- a/elasticdl/python/elasticdl/README.md
+++ b/elasticdl/python/elasticdl/README.md
@@ -95,7 +95,7 @@ python -m elasticdl.python.elasticdl.client train \
     --volume="mount_path=/data,claim_name=fileserver-claim" \
     --image_pull_policy=Always \
     --log_level=INFO \
-    --docker_image_prefix=gcr.io/elasticdl \
+    --docker_image_repository=gcr.io/elasticdl \
     --envs=e1=v1,e2=v2
 ```
 

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -15,7 +15,7 @@ def train(args):
     image_name = build_and_push_docker_image(
         model_zoo=args.model_zoo,
         base_image=args.image_base,
-        docker_image_prefix=args.docker_image_prefix,
+        docker_image_repository=args.docker_image_repository,
         extra_pypi=args.extra_pypi_index,
         cluster_spec=args.cluster_spec,
         docker_base_url=args.docker_base_url,
@@ -47,7 +47,7 @@ def evaluate(args):
     image_name = build_and_push_docker_image(
         model_zoo=args.model_zoo,
         base_image=args.image_base,
-        docker_image_prefix=args.docker_image_prefix,
+        docker_image_repository=args.docker_image_repository,
         extra_pypi=args.extra_pypi_index,
         cluster_spec=args.cluster_spec,
         docker_base_url=args.docker_base_url,
@@ -77,7 +77,7 @@ def predict(args):
     image_name = build_and_push_docker_image(
         model_zoo=args.model_zoo,
         base_image=args.image_base,
-        docker_image_prefix=args.docker_image_prefix,
+        docker_image_repository=args.docker_image_repository,
         extra_pypi=args.extra_pypi_index,
         cluster_spec=args.cluster_spec,
         docker_base_url=args.docker_base_url,

--- a/elasticdl/python/elasticdl/image_builder.py
+++ b/elasticdl/python/elasticdl/image_builder.py
@@ -11,7 +11,7 @@ from elasticdl.python.common.log_utils import default_logger as logger
 
 def build_and_push_docker_image(
     model_zoo,
-    docker_image_prefix,
+    docker_image_repository,
     base_image="",
     extra_pypi="",
     cluster_spec="",
@@ -24,10 +24,8 @@ zoo.  The parameter model_zoo could be a local directory or an URL.
 In the later case, we do git clone.
 
     The basename of the Docker image is auto-generated and is globally
-unique.  The full name is docker_image_prefix + "/" + basename.
-
-    The fullname of the Docker image is docker_image_prefix + "/" +
-basename.  Unless prefix is None or "", _push_docker_image is called
+unique.  The fullname of the Docker image is docker_image_repository + ":" +
+basename.  Unless repository is None or "", _push_docker_image is called
 after _build_docker_image.
 
     Returns the full Docker image name.  So the caller can docker rmi
@@ -67,7 +65,7 @@ after _build_docker_image.
                 )
             )
 
-        image_name = _generate_unique_image_name(docker_image_prefix)
+        image_name = _generate_unique_image_name(docker_image_repository)
         if docker_tlscert and docker_tlskey:
             tls_config = docker.tls.TLSConfig(
                 client_cert=(docker_tlscert, docker_tlskey)
@@ -77,7 +75,7 @@ after _build_docker_image.
             client = docker.APIClient(base_url=docker_base_url)
         _build_docker_image(client, ctx_dir, df.name, image_name)
 
-        if docker_image_prefix:
+        if docker_image_repository:
             _push_docker_image(client, image_name)
 
     return image_name
@@ -167,9 +165,9 @@ RUN python -c 'import sys, pkgutil; exit_code = 0 if \
     )
 
 
-def _generate_unique_image_name(prefix):
+def _generate_unique_image_name(repository):
     return os.path.join(
-        prefix if prefix else "", "elasticdl:" + uuid.uuid4().hex
+        repository if repository else "", "elasticdl:" + uuid.uuid4().hex
     )
 
 


### PR DESCRIPTION
We have a `docker_image_prefix` parameter, which actually maps to the `repository` in Docker [document](https://docker-py.readthedocs.io/en/stable/api.html) and CLI. To be consistent, it would be better to change it to `repository`.