### PR TITLE
Add elasticdl clean command to clean up local docker images

### DIFF
--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -321,6 +321,30 @@ def add_predict_params(parser):
     )
 
 
+def add_clean_params(parser):
+    parser.add_argument(
+        "--docker_image_prefix",
+        type=str,
+        help="Only clean docker images with the given prefix",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Clean all local docker images",
+    )
+    parser.add_argument(
+        "--docker_base_url",
+        help="URL to the Docker server",
+        default="unix://var/run/docker.sock",
+    )
+    parser.add_argument(
+        "--docker_tlscert", help="Path to Docker client cert", default=""
+    )
+    parser.add_argument(
+        "--docker_tlskey", help="Path to Docker client key", default=""
+    )
+
+
 def print_args(args, groups=None):
     """
     Args:

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -323,14 +323,12 @@ def add_predict_params(parser):
 
 def add_clean_params(parser):
     parser.add_argument(
-        "--docker_image_prefix",
+        "--docker_image_repository",
         type=str,
-        help="Only clean docker images with the given prefix",
+        help="Clean docker images belonging to this repository.",
     )
     parser.add_argument(
-        "--all",
-        action="store_true",
-        help="Clean all local docker images",
+        "--all", action="store_true", help="Clean all local docker images"
     )
     parser.add_argument(
         "--docker_base_url",

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -105,19 +105,25 @@ def predict(args):
 
 
 def clean(args):
-    if args.docker_image_prefix and args.all:
-        raise ValueError("--docker_image_prefix and --all cannot be specified at the same time")
-    if not args.docker_image_prefix and not args.all:
-        raise ValueError("--docker_image_prefix and --all")
-    
-    if args.all:
-    remove_images()
-    # if args.docker_image_prefix and args.all:
-    #     # throw exception
-    # if args.docker_image_prefix:
-    #     # Only clean images with the given prefix
-    # elif args.all:
-    #     # Clean all
+    if args.docker_image_repository and args.all:
+        raise ValueError(
+            "--docker_image_repository and --all cannot "
+            "be specified at the same time"
+        )
+    if not (args.docker_image_repository or args.all):
+        raise ValueError(
+            "Either --docker_image_repository or --all "
+            "needs to be configured"
+        )
+    repository = (
+        args.docker_image_repository if args.docker_image_repository else ""
+    )
+    remove_images(
+        docker_image_repository=repository,
+        docker_base_url=args.docker_base_url,
+        docker_tlscert=args.docker_tlscert,
+        docker_tlskey=args.docker_tlskey,
+    )
 
 
 def _submit_job(image_name, client_args, container_args):

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -8,6 +8,7 @@ from elasticdl.python.common.args import (
 from elasticdl.python.common.log_utils import default_logger as logger
 from elasticdl.python.elasticdl.image_builder import (
     build_and_push_docker_image,
+    remove_images,
 )
 
 
@@ -101,6 +102,22 @@ def predict(args):
     )
 
     _submit_job(image_name, args, container_args)
+
+
+def clean(args):
+    if args.docker_image_prefix and args.all:
+        raise ValueError("--docker_image_prefix and --all cannot be specified at the same time")
+    if not args.docker_image_prefix and not args.all:
+        raise ValueError("--docker_image_prefix and --all")
+    
+    if args.all:
+    remove_images()
+    # if args.docker_image_prefix and args.all:
+    #     # throw exception
+    # if args.docker_image_prefix:
+    #     # Only clean images with the given prefix
+    # elif args.all:
+    #     # Clean all
 
 
 def _submit_job(image_name, client_args, container_args):

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -115,11 +115,8 @@ def clean(args):
             "Either --docker_image_repository or --all "
             "needs to be configured"
         )
-    repository = (
-        args.docker_image_repository if args.docker_image_repository else ""
-    )
     remove_images(
-        docker_image_repository=repository,
+        docker_image_repository=args.docker_image_repository,
         docker_base_url=args.docker_base_url,
         docker_tlscert=args.docker_tlscert,
         docker_tlskey=args.docker_tlskey,

--- a/elasticdl/python/elasticdl/client.py
+++ b/elasticdl/python/elasticdl/client.py
@@ -1,12 +1,13 @@
 import argparse
 
 from elasticdl.python.common.args import (
+    add_clean_params,
     add_common_params,
     add_evaluate_params,
     add_predict_params,
     add_train_params,
 )
-from elasticdl.python.elasticdl.api import evaluate, predict, train
+from elasticdl.python.elasticdl.api import clean, evaluate, predict, train
 
 
 def main():
@@ -34,6 +35,12 @@ def main():
     predict_parser.set_defaults(func=predict)
     add_common_params(predict_parser)
     add_predict_params(predict_parser)
+
+    clean_parser = subparsers.add_parser(
+        "clean", help="Cleanup local docker images built by ElasticDL"
+    )
+    clean_parser.set_defaults(func=clean)
+    add_clean_params(clean_parser)
 
     args, _ = parser.parse_known_args()
     args.func(args)

--- a/elasticdl/python/elasticdl/image_builder.py
+++ b/elasticdl/python/elasticdl/image_builder.py
@@ -82,13 +82,13 @@ after _build_docker_image.
 
 
 def remove_images(
-    docker_image_prefix="",
+    docker_image_repository="",
     docker_base_url="unix://var/run/docker.sock",
     docker_tlscert="",
     docker_tlskey="",
 ):
     """Remove all docker images with repository name equal to
-    docker_image_prefix. If docker_image_prefix is empyt, it
+    docker_image_repository. If docker_image_repository is empty, it
     will remove all images.
     """
     client = _get_docker_client(
@@ -97,7 +97,7 @@ def remove_images(
         docker_tlskey=docker_tlskey,
     )
     # Use repository tags to delete images
-    images = client.images(name=docker_image_prefix, quiet=False)
+    images = client.images(name=docker_image_repository, quiet=False)
     for image in images:
         repo_tags = image.get("RepoTags", [])
         for repo_tag in repo_tags:
@@ -108,7 +108,7 @@ def remove_images(
                 logger.warning("Failed to delete image %s: %s" % (repo_tag, e))
     # For image not having full repository tags, use ID
     # Note that, here we need to re-list images
-    images = client.images(name=docker_image_prefix, quiet=False)
+    images = client.images(name=docker_image_repository, quiet=False)
     for image in images:
         image_id = image.get("Id")
         if image_id:
@@ -118,7 +118,7 @@ def remove_images(
             except docker.errors.APIError as e:
                 logger.warning("Failed to delete image %s: %s" % (image_id, e))
     # If we want to remove all images, also run prune to remove untagged images
-    if not docker_image_prefix:
+    if not docker_image_repository:
         logger.info("Cleanning up unused images")
         try:
             client.prune_images()


### PR DESCRIPTION
To resolve #1202. Add `elasticdl clean` command to clean up local images. Support to different configs:
- `elasticdl clean --docker_image_repository repo1` is to clean all images with repository equals to `repo1`.
- `elasticdl clean --all` is to clean all local docker images.