### PR TITLE
Support saving metadata in data reader

### DIFF
--- a/elasticdl/python/tests/data_reader_test.py
+++ b/elasticdl/python/tests/data_reader_test.py
@@ -11,11 +11,13 @@ from odps import ODPS
 from elasticdl.python.common.constants import ODPSConfig
 from elasticdl.python.common.model_utils import load_module
 from elasticdl.python.data.data_reader import (
+    Metadata,
     ODPSDataReader,
     RecordIODataReader,
     create_data_reader,
 )
 from elasticdl.python.tests.test_utils import (
+    IRIS_TABLE_COLUMN_NAMES,
     DatasetName,
     create_iris_odps_table,
     create_recordio_file,
@@ -99,6 +101,9 @@ class ODPSDataReaderTest(unittest.TestCase):
         self.assertEqual(
             [[6.4, 2.8, 5.6, 2.2, 2], [5.0, 2.3, 3.3, 1.0, 1]], records
         )
+        self.assertEqual(
+            self.reader.metadata.column_names, IRIS_TABLE_COLUMN_NAMES
+        )
 
     def test_create_data_reader(self):
         reader = create_data_reader(
@@ -132,7 +137,9 @@ class ODPSDataReaderTest(unittest.TestCase):
                     yield data
 
         dataset = tf.data.Dataset.from_generator(_gen, tf.float32)
-        dataset = dataset_fn(dataset, None)
+        dataset = dataset_fn(
+            dataset, None, Metadata(column_names=IRIS_TABLE_COLUMN_NAMES)
+        )
 
         loss_history = []
         grads = None

--- a/elasticdl/python/tests/embedding_test_module.py
+++ b/elasticdl/python/tests/embedding_test_module.py
@@ -89,7 +89,7 @@ def loss(predictions, labels):
     return tf.reduce_mean(tf.square(predictions - labels))
 
 
-def dataset_fn(dataset, training=True):
+def dataset_fn(dataset, mode, metadata):
     def _parse_data(record):
         feature_description = {
             "f1": tf.io.FixedLenFeature([1], tf.int64),

--- a/elasticdl/python/tests/test_module.py
+++ b/elasticdl/python/tests/test_module.py
@@ -17,7 +17,7 @@ def loss(predictions, labels):
     return tf.reduce_mean(tf.square(predictions - labels))
 
 
-def dataset_fn(dataset, training=True):
+def dataset_fn(dataset, mode, metadata):
     def _parse_data(record):
         feature_description = {
             "x": tf.io.FixedLenFeature([1], tf.float32),

--- a/elasticdl/python/tests/test_utils.py
+++ b/elasticdl/python/tests/test_utils.py
@@ -214,6 +214,15 @@ def distributed_train_and_evaluate(
     return master._version
 
 
+IRIS_TABLE_COLUMN_NAMES = [
+    "sepal_length",
+    "sepal_width",
+    "petal_length",
+    "petal_width",
+    "class",
+]
+
+
 def create_iris_odps_table(odps_client, project_name, table_name):
     sql_tmpl = """
     DROP TABLE IF EXISTS {PROJECT_NAME}.{TABLE_NAME};

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -456,7 +456,11 @@ class Worker(object):
         if not eval_info:
             return False
         (eval_dataset, model_version, task_id) = eval_info
-        eval_dataset = self._dataset_fn(eval_dataset, Mode.EVALUATION)
+        eval_dataset = self._dataset_fn(
+            eval_dataset,
+            Mode.EVALUATION,
+            self._task_data_service.data_reader.metadata,
+        )
         eval_dataset = eval_dataset.batch(self._minibatch_size).prefetch(1)
         err_msg = ""
         for dataset_batch in eval_dataset:
@@ -532,7 +536,9 @@ class Worker(object):
             dataset = self._task_data_service.get_dataset()
             if not dataset:
                 break
-            dataset = self._dataset_fn(dataset, mode)
+            dataset = self._dataset_fn(
+                dataset, mode, self._task_data_service.data_reader.metadata
+            )
             dataset = dataset.batch(self._minibatch_size).prefetch(1)
             for dataset_batch in dataset:
                 if self._job_type == JobType.TRAINING_WITH_EVALUATION:

--- a/model_zoo/cifar10_functional_api/cifar10_functional_api.py
+++ b/model_zoo/cifar10_functional_api/cifar10_functional_api.py
@@ -114,7 +114,7 @@ def optimizer(lr=0.1):
     return tf.optimizers.SGD(lr)
 
 
-def dataset_fn(dataset, mode):
+def dataset_fn(dataset, mode, _):
     def _parse_data(record):
         if mode == Mode.PREDICTION:
             feature_description = {

--- a/model_zoo/cifar10_subclass/cifar10_subclass.py
+++ b/model_zoo/cifar10_subclass/cifar10_subclass.py
@@ -134,7 +134,7 @@ def optimizer(lr=0.1):
     return tf.optimizers.SGD(lr)
 
 
-def dataset_fn(dataset, mode):
+def dataset_fn(dataset, mode, _):
     def _parse_data(record):
         if mode == Mode.PREDICTION:
             feature_description = {

--- a/model_zoo/deepfm_edl_embedding/deepfm_edl_embedding.py
+++ b/model_zoo/deepfm_edl_embedding/deepfm_edl_embedding.py
@@ -75,7 +75,7 @@ def optimizer(lr=0.1):
     return tf.optimizers.SGD(lr)
 
 
-def dataset_fn(dataset, mode):
+def dataset_fn(dataset, mode, _):
     def _parse_data(record):
         if mode == Mode.PREDICTION:
             feature_description = {

--- a/model_zoo/deepfm_functional_api/deepfm_functional_api.py
+++ b/model_zoo/deepfm_functional_api/deepfm_functional_api.py
@@ -86,7 +86,7 @@ def optimizer(lr=0.1):
     return tf.optimizers.SGD(lr)
 
 
-def dataset_fn(dataset, mode):
+def dataset_fn(dataset, mode, _):
     def _parse_data(record):
         if mode == Mode.PREDICTION:
             feature_description = {

--- a/model_zoo/mnist_functional_api/mnist_functional_api.py
+++ b/model_zoo/mnist_functional_api/mnist_functional_api.py
@@ -54,7 +54,7 @@ def optimizer(lr=0.1):
     return tf.optimizers.SGD(lr)
 
 
-def dataset_fn(dataset, mode):
+def dataset_fn(dataset, mode, _):
     def _parse_data(record):
         if mode == Mode.PREDICTION:
             feature_description = {

--- a/model_zoo/mnist_subclass/mnist_subclass.py
+++ b/model_zoo/mnist_subclass/mnist_subclass.py
@@ -48,7 +48,7 @@ def optimizer(lr=0.01):
     return tf.optimizers.SGD(lr)
 
 
-def dataset_fn(dataset, mode):
+def dataset_fn(dataset, mode, _):
     def _parse_data(record):
         if mode == Mode.PREDICTION:
             feature_description = {

--- a/model_zoo/odps_iris_dnn_model/odps_iris_dnn_model.py
+++ b/model_zoo/odps_iris_dnn_model/odps_iris_dnn_model.py
@@ -17,13 +17,44 @@ def optimizer(lr=0.1):
     return tf.optimizers.SGD(lr)
 
 
-def dataset_fn(dataset, mode):
+def dataset_fn(dataset, mode, metadata):
     def _parse_data(record):
-        features = tf.reshape(record[0:3], (3, 1))
-        if mode == Mode.PREDICTION:
-            return features
+        label_col_name = "class"
+
+        def _get_features_without_labels(
+            record, label_col_ind, features_shape
+        ):
+            features = [
+                record[:label_col_ind],
+                record[label_col_ind + 1 :],  # noqa: E203
+            ]
+            features = tf.concat(features, -1)
+            return tf.reshape(features, features_shape)
+
+        features_shape = (4, 1)
+        labels_shape = (1,)
+        if mode != Mode.PREDICTION:
+            if label_col_name not in metadata.column_names:
+                raise ValueError(
+                    "Missing the label column '%s' in the retrieved "
+                    "ODPS table." % label_col_name
+                )
+            label_col_ind = metadata.column_names.index(label_col_name)
+            labels = tf.reshape(record[label_col_ind], labels_shape)
+            return (
+                _get_features_without_labels(
+                    record, label_col_ind, features_shape
+                ),
+                labels,
+            )
         else:
-            return features, tf.reshape(record[4], (1,))
+            if label_col_name in metadata.column_names:
+                label_col_ind = metadata.column_names.index(label_col_name)
+                return _get_features_without_labels(
+                    record, label_col_ind, features_shape
+                )
+            else:
+                return tf.reshape(record, features_shape)
 
     dataset = dataset.map(_parse_data)
 

--- a/model_zoo/resnet50_subclass/resnet50_subclass.py
+++ b/model_zoo/resnet50_subclass/resnet50_subclass.py
@@ -169,7 +169,7 @@ def optimizer(lr=0.02):
     return tf.keras.optimizers.SGD(lr)
 
 
-def dataset_fn(dataset, mode):
+def dataset_fn(dataset, mode, _):
     def _parse_data(record):
         if mode == Mode.PREDICTION:
             feature_description = {


### PR DESCRIPTION
The addition of this metadata information would be useful in the following scenarios:
* When we want to cache some meta information (might be time consuming) that can be reused across  each `read_records()` call.
* When we want to validate the consistency of the result from each `read_records()` call.
* When users want to do more validation around the retrieved data in `dataset_fn()` instead of previously having to remember the indices for each column themselves, e.g. `record[0:3]` that represents the features and `record[4]` that represents the labels.

Right now only `ODPSDataReader` uses this for saving column names information, we can add more metadata information if needed in the future.