### PR TITLE
Strip potential redundant spaces in resource and volume strings

### DIFF
--- a/elasticdl/python/common/k8s_resource.py
+++ b/elasticdl/python/common/k8s_resource.py
@@ -45,11 +45,13 @@ def parse(resource_str):
     Return:
         A Python dictionary parsed from the given resource string.
     """
-    kvs = resource_str.split(",")
+    kvs = resource_str.strip().split(",")
     resource_names = []
     parsed_res_dict = {}
     for kv in kvs:
-        k, v = kv.split("=")
+        k, v = kv.strip().split("=")
+        k = k.strip()
+        v = v.strip()
         if k not in resource_names:
             resource_names.append(k)
         else:

--- a/elasticdl/python/common/k8s_volume.py
+++ b/elasticdl/python/common/k8s_volume.py
@@ -11,11 +11,13 @@ def parse(volume_str):
     Return:
         A Python dictionary parsed from the given volume string.
     """
-    kvs = volume_str.split(",")
+    kvs = volume_str.strip().split(",")
     volume_keys = []
     parsed_volume_dict = {}
     for kv in kvs:
-        k, v = kv.split("=")
+        k, v = kv.strip().split("=")
+        k = k.strip()
+        v = v.strip()
         if k not in volume_keys:
             volume_keys.append(k)
         else:

--- a/elasticdl/python/tests/k8s_resource_test.py
+++ b/elasticdl/python/tests/k8s_resource_test.py
@@ -28,7 +28,8 @@ class K8SResourceTest(unittest.TestCase):
                 "ephemeral-storage": "32Mi",
             },
             parse(
-                " cpu=250m, memory=32Mi,disk =64Mi,gpu= 1,ephemeral-storage=32Mi "
+                " cpu=250m, memory=32Mi,disk =64Mi,"
+                "gpu= 1,ephemeral-storage=32Mi "
             ),
         )
         # When cpu is non-numeric, parse works as expected

--- a/elasticdl/python/tests/k8s_resource_test.py
+++ b/elasticdl/python/tests/k8s_resource_test.py
@@ -18,6 +18,19 @@ class K8SResourceTest(unittest.TestCase):
                 "cpu=250m,memory=32Mi,disk=64Mi,gpu=1,ephemeral-storage=32Mi"
             ),
         )
+        # parse works as expected with redundant spaces
+        self.assertEqual(
+            {
+                "cpu": "250m",
+                "memory": "32Mi",
+                "disk": "64Mi",
+                "nvidia.com/gpu": "1",
+                "ephemeral-storage": "32Mi",
+            },
+            parse(
+                " cpu=250m, memory=32Mi,disk =64Mi,gpu= 1,ephemeral-storage=32Mi "
+            ),
+        )
         # When cpu is non-numeric, parse works as expected
         self.assertEqual(
             {

--- a/elasticdl/python/tests/k8s_volume_test.py
+++ b/elasticdl/python/tests/k8s_volume_test.py
@@ -10,6 +10,11 @@ class K8SVolumeTest(unittest.TestCase):
             {"claim_name": "c1", "mount_path": "/path1"},
             parse("claim_name=c1,mount_path=/path1"),
         )
+        # parse works as expected with redundant spaces
+        self.assertEqual(
+            {"claim_name": "c1", "mount_path": "/path1"},
+            parse("  claim_name=c1,   mount_path = /path1 "),
+        )
         # When volume key is unknown, raise an error
         self.assertRaisesRegex(
             ValueError,


### PR DESCRIPTION
The parsing should work in this case so they don't have to wait to see what's failed to parse and then submit a new job again. This PR would improve the user experience by stripping off the redundant spaces.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>