### PR TITLE
Correct parameters used by example jobs in the README

### DIFF
--- a/elasticdl/README.md
+++ b/elasticdl/README.md
@@ -138,7 +138,12 @@ docker run --net=host --rm -it -v $EDL_REPO:/edl_dir -w /edl_dir \
           --log_level=INFO"
 ```
 
-This will train MNIST data with a model defined in [model_zoo/mnist_functional_api/mnist_functional_api.py](../model_zoo/mnist_functional_api/mnist_functional_api.py) for 2 epoches.
+This will train MNIST data with a model defined in [model_zoo/mnist_functional_api/mnist_functional_api.py](../model_zoo/mnist_functional_api/mnist_functional_api.py) for 2 epoches. Note that, the master will save model checkpoints in a local directory `checkpoint_dir`.
+
+If you get some issues related to proto definitions, please run the following command to build latest proto components.
+```bash
+make -f elasticdl/Makefile
+```
 
 ### Test with Kubernetes
 

--- a/elasticdl/README.md
+++ b/elasticdl/README.md
@@ -114,6 +114,7 @@ docker run --net=host --rm -it -v $EDL_REPO:/edl_dir -w /edl_dir \
           --job_name=test \
           --training_data_dir=/data/mnist/train \
           --evaluation_data_dir=/data/mnist/test \
+          --evaluation_steps=15 \
           --num_epochs=2 \
           --checkpoint_steps=2 \
           --grads_to_wait=2 \
@@ -132,7 +133,7 @@ docker run --net=host --rm -it -v $EDL_REPO:/edl_dir -w /edl_dir \
           --model_zoo=model_zoo \
           --model_def=mnist_functional_api.mnist_functional_api.custom_model \
           --minibatch_size=10 \
-          --job_type=TRAINING \
+          --job_type=training_with_evaluation \
           --master_addr=localhost:50001 \
           --log_level=INFO"
 ```


### PR DESCRIPTION
Two fixes:
- The master should add `--evaluation_steps` parameter to enable evaluation. Only providing `--evaluation_date_dir` is not enough;
- The worker should use correct `--job_type` parameter. The old "TRAINING" is an invalid value.