### PR TITLE
Fix dummy loss and metrics in odps_iris_dnn_model

### DIFF
--- a/model_zoo/odps_iris_dnn_model/odps_iris_dnn_model.py
+++ b/model_zoo/odps_iris_dnn_model/odps_iris_dnn_model.py
@@ -5,13 +5,17 @@ from elasticdl.python.common.constants import Mode
 
 def custom_model():
     inputs = tf.keras.layers.Input(shape=(4, 1), name="input")
-    outputs = tf.keras.layers.Dense(3, name="output")(inputs)
+    x = tf.keras.layers.Flatten()(inputs)
+    outputs = tf.keras.layers.Dense(3, name="output")(x)
     return tf.keras.Model(inputs=inputs, outputs=outputs, name="simple-model")
 
 
 def loss(output, labels):
     return tf.reduce_mean(
-        tf.nn.sparse_softmax_cross_entropy_with_logits(labels, output)
+        tf.nn.sparse_softmax_cross_entropy_with_logits(
+            tf.cast(tf.reshape(labels, [-1]), tf.int32),
+            output
+        )
     )
 
 

--- a/model_zoo/odps_iris_dnn_model/odps_iris_dnn_model.py
+++ b/model_zoo/odps_iris_dnn_model/odps_iris_dnn_model.py
@@ -13,8 +13,7 @@ def custom_model():
 def loss(output, labels):
     return tf.reduce_mean(
         tf.nn.sparse_softmax_cross_entropy_with_logits(
-            tf.cast(tf.reshape(labels, [-1]), tf.int32),
-            output
+            tf.cast(tf.reshape(labels, [-1]), tf.int32), output
         )
     )
 

--- a/model_zoo/odps_iris_dnn_model/odps_iris_dnn_model.py
+++ b/model_zoo/odps_iris_dnn_model/odps_iris_dnn_model.py
@@ -10,7 +10,9 @@ def custom_model():
 
 
 def loss(output, labels):
-    return tf.reduce_sum(tf.reduce_mean(tf.reshape(output, [-1])) - labels)
+    return tf.reduce_mean(
+        tf.nn.sparse_softmax_cross_entropy_with_logits(labels, output)
+    )
 
 
 def optimizer(lr=0.1):
@@ -65,7 +67,8 @@ def dataset_fn(dataset, mode, metadata):
 
 def eval_metrics_fn():
     return {
-        "dummy_metric": lambda labels, predictions: tf.reduce_sum(
-            tf.reduce_mean(tf.reshape(predictions, [-1])) - labels
+        "accuracy": lambda labels, predictions: tf.equal(
+            tf.argmax(predictions, 1, output_type=tf.int32),
+            tf.cast(tf.reshape(labels, [-1]), tf.int32),
         )
     }


### PR DESCRIPTION
Fixes dummy loss and metrics in `model_zoo/odps_iris_dnn_model.py`.