### PR TITLE
Fix odps test in data_reader_test.py

### DIFF
--- a/elasticdl/python/tests/data_reader_test.py
+++ b/elasticdl/python/tests/data_reader_test.py
@@ -140,6 +140,7 @@ class ODPSDataReaderTest(unittest.TestCase):
         dataset = dataset_fn(
             dataset, None, Metadata(column_names=IRIS_TABLE_COLUMN_NAMES)
         )
+        dataset = dataset.batch(1)
 
         loss_history = []
         grads = None


### PR DESCRIPTION
Keras model requires model input to have shape `[batch_size, feature_shape]`, even if batch size equals to 1. However, `test_odps_data_reader_integration_with_local_keras` in `tests/data_reader_test.py` generate features with shape `[feature_shape]`.