### PR TITLE
Modify data type to tf.string in ODPS reader

### DIFF
--- a/elasticdl/python/data/data_reader.py
+++ b/elasticdl/python/data/data_reader.py
@@ -141,7 +141,7 @@ class ODPSDataReader(AbstractDataReader):
 
     @property
     def records_output_types(self):
-        return tf.float32
+        return tf.string
 
     @property
     def metadata(self):

--- a/elasticdl/python/data/odps_io.py
+++ b/elasticdl/python/data/odps_io.py
@@ -221,7 +221,7 @@ class ODPSReader(object):
                         start=start, count=end - start, columns=columns
                     ):
                         batch_record.append(
-                            [record[column] for column in columns]
+                            [str(record[column]) for column in columns]
                         )
                 return batch_record
             except Exception as e:

--- a/model_zoo/odps_iris_dnn_model/odps_iris_dnn_model.py
+++ b/model_zoo/odps_iris_dnn_model/odps_iris_dnn_model.py
@@ -24,7 +24,8 @@ def optimizer(lr=0.1):
 
 def dataset_fn(dataset, mode, metadata):
     def _parse_data(record):
-        label_col_name = "class"
+        label_col_name = "label"
+        record = tf.strings.to_number(record, tf.float32)
 
         def _get_features_without_labels(
             record, label_col_ind, features_shape

--- a/model_zoo/odps_iris_dnn_model/odps_iris_dnn_model.py
+++ b/model_zoo/odps_iris_dnn_model/odps_iris_dnn_model.py
@@ -24,7 +24,7 @@ def optimizer(lr=0.1):
 
 def dataset_fn(dataset, mode, metadata):
     def _parse_data(record):
-        label_col_name = "label"
+        label_col_name = "class"
         record = tf.strings.to_number(record, tf.float32)
 
         def _get_features_without_labels(


### PR DESCRIPTION
Create tf.data.Dataset with dtype tf.string and cast string to float32 in dataset_fn for odps_iris_dnn_model. https://github.com/sql-machine-learning/elasticdl/issues/1302