### PR TITLE
Remove logging on train/eval/predict data arg

### DIFF
--- a/elasticdl/python/master/main.py
+++ b/elasticdl/python/master/main.py
@@ -86,15 +86,6 @@ def main():
         tb_service = None
 
     # Start task queue
-    logger.debug(
-        "Starting task queue with training data directory %s, "
-        "evaluation data directory %s, "
-        "and prediction data directory %s",
-        args.training_data,
-        args.evaluation_data,
-        args.prediction_data,
-    )
-
     records_per_task = args.minibatch_size * args.num_minibatches_per_task
     task_d = _make_task_dispatcher(
         args.training_data,


### PR DESCRIPTION
Right now we are seeing logs like 
```
2019-09-24 17:25:34,392] [DEBUG] [main.py:88:main] Starting task queue with training data directory sqlflow_test_iris_train, evaluation data directory , and prediction data directory
```
which should not contain the word "directory" in case they are ODPS table names and can be removed completely since we are already printing out all the parsed arguments through `print_args()`.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>