### PR TITLE
Enable Travis CI on release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ jobs:
 branches:
   only:
   - develop
+  - "/branch-\\d+\\.\\d+(\\.\\d+)?(-\\S*)?$/"
 
 # Secure tokens for ODPS-related environment variables
 env:


### PR DESCRIPTION
Fixes #1289. Note that the branch name for this PR is `branch-0.1-test` intentionally to test whether this regex works as expected.