### PR TITLE
Split requirements to required deps and extras

### DIFF
--- a/elasticdl/docker/Dockerfile.dev
+++ b/elasticdl/docker/Dockerfile.dev
@@ -14,9 +14,10 @@ RUN add-apt-repository ppa:chris-lea/redis-server -y \
     && apt-get install -y redis-server
 
 COPY elasticdl/requirements.txt /requirements.txt
+COPY elasticdl/requirements-dev.txt /requirements-dev.txt
 ARG EXTRA_PYPI_INDEX
 RUN pip install -r /requirements.txt --extra-index-url=${EXTRA_PYPI_INDEX}
-RUN pip install pre-commit --extra-index-url=${EXTRA_PYPI_INDEX}
+RUN pip install -r /requirements-dev.txt --extra-index-url=${EXTRA_PYPI_INDEX}
 
 # Copy the data generation package to /var and run them from there.
 # This assumes that the data generation package is independent with the

--- a/elasticdl/requirements-dev.txt
+++ b/elasticdl/requirements-dev.txt
@@ -1,0 +1,5 @@
+pytest
+pytest-cov
+mock
+Pillow
+pre-commit

--- a/elasticdl/requirements.txt
+++ b/elasticdl/requirements.txt
@@ -1,10 +1,6 @@
 grpcio-tools
 kubernetes
 docker
-pytest
-pytest-cov
 pyrecordio>=0.0.6
-Pillow
 odps
 redis-py-cluster
-mock

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
 from setuptools import find_packages, setup
 
 with open("elasticdl/requirements.txt") as f:
-    requirements = f.read().splitlines()
+    required_deps = f.read().splitlines()
+
+extras = {}
+with open("elasticdl/requirements-dev.txt") as f:
+    extras["develop"] = f.read().splitlines()
 
 setup(
     name="elasticdl",
@@ -13,7 +17,8 @@ setup(
     long_description_content_type="text/markdown",
     author="Ant Financial",
     url="https://elasticdl.org",
-    install_requires=requirements,
+    install_requires=required_deps,
+    extras_require=extras,
     packages=find_packages(exclude=["*test*"]),
     package_data={"": ["proto/elasticdl.proto", "docker/*", "Makefile"]},
     entry_points={


### PR DESCRIPTION
Fixes #1286. After this, pip install will only install the required dependencies in `requirements.txt`. If developers wants to install all the optional dependencies in `requirements-dev.txt`, they can do so by installing the extra `develop` module via `pip install -e ".[develop]"`.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>