### PR TITLE
Fix pip install warnings

### DIFF
--- a/elasticdl/docker/Dockerfile
+++ b/elasticdl/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN add-apt-repository ppa:chris-lea/redis-server -y \
     && apt-get install -y redis-server
 
 COPY elasticdl/requirements.txt /requirements.txt
-ARG EXTRA_PYPI_INDEX
+ARG EXTRA_PYPI_INDEX=https://pypi.org/simple
 RUN pip install -r /requirements.txt --extra-index-url=${EXTRA_PYPI_INDEX}
 
 WORKDIR /

--- a/elasticdl/docker/Dockerfile.data_process
+++ b/elasticdl/docker/Dockerfile.data_process
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE}
 RUN apt-get update
 RUN apt-get install -y unzip curl
 
-ARG EXTRA_PYPI_INDEX
+ARG EXTRA_PYPI_INDEX=https://pypi.org/simple
 
 # Install PySpark
 RUN pip install pyspark --extra-index-url=${EXTRA_PYPI_INDEX}

--- a/elasticdl/docker/Dockerfile.dev
+++ b/elasticdl/docker/Dockerfile.dev
@@ -15,7 +15,7 @@ RUN add-apt-repository ppa:chris-lea/redis-server -y \
 
 COPY elasticdl/requirements.txt /requirements.txt
 COPY elasticdl/requirements-dev.txt /requirements-dev.txt
-ARG EXTRA_PYPI_INDEX
+ARG EXTRA_PYPI_INDEX=https://pypi.org/simple
 RUN pip install -r /requirements.txt --extra-index-url=${EXTRA_PYPI_INDEX}
 RUN pip install -r /requirements-dev.txt --extra-index-url=${EXTRA_PYPI_INDEX}
 

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -164,7 +164,9 @@ def add_common_params(parser):
         "comma is supported in value field",
     )
     parser.add_argument(
-        "--extra_pypi_index", help="The extra python package repository"
+        "--extra_pypi_index",
+        default="https://pypi.org/simple",
+        help="The extra python package repository",
     )
     parser.add_argument(
         "--namespace",

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -166,7 +166,7 @@ def add_common_params(parser):
     parser.add_argument(
         "--extra_pypi_index",
         default="https://pypi.org/simple",
-        help="The extra python package repository",
+        help="The extra URLs of Python package repository indexes",
     )
     parser.add_argument(
         "--namespace",


### PR DESCRIPTION
Fixes #1325. Switched to use `https://pypi.org/simple` as the default instead of empty string, which is consistent with `--index-url`'s default value.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>