### PR TITLE
set input_dim=-1 when  shape[1] of ids is None

### DIFF
--- a/elasticdl/python/elasticdl/layers/embedding.py
+++ b/elasticdl/python/elasticdl/layers/embedding.py
@@ -207,7 +207,8 @@ class Embedding(tf.keras.layers.Layer):
         if ids.get_shape().rank == 2:
             input_length = ids.get_shape()[1]
             if input_length is None:
-                return tf.reshape(outputs, (-1, self.output_dim))
+                outputs.set_shape(shape=(None, None, self.output_dim))
+                return outputs
             output_shape = (-1, input_length, self.output_dim)
         else:
             output_shape = ids.get_shape().concatenate(self.output_dim)

--- a/elasticdl/python/elasticdl/layers/embedding.py
+++ b/elasticdl/python/elasticdl/layers/embedding.py
@@ -205,8 +205,10 @@ class Embedding(tf.keras.layers.Layer):
         outputs = tf.gather(batch_embedding, idx)
         # tf.reshape does not support shape with None. Replace None with -1.
         if ids.get_shape().rank == 2:
-            input_dim = 1 if ids.get_shape()[1] is None else ids.get_shape()[1]
-            output_shape = (-1, input_dim, self.output_dim)
+            input_length = (
+                1 if ids.get_shape()[1] is None else ids.get_shape()[1]
+            )
+            output_shape = (-1, input_length, self.output_dim)
         else:
             output_shape = ids.get_shape().concatenate(self.output_dim)
         outputs = tf.reshape(outputs, output_shape)

--- a/elasticdl/python/elasticdl/layers/embedding.py
+++ b/elasticdl/python/elasticdl/layers/embedding.py
@@ -205,9 +205,9 @@ class Embedding(tf.keras.layers.Layer):
         outputs = tf.gather(batch_embedding, idx)
         # tf.reshape does not support shape with None. Replace None with -1.
         if ids.get_shape().rank == 2:
-            input_length = (
-                1 if ids.get_shape()[1] is None else ids.get_shape()[1]
-            )
+            input_length = ids.get_shape()[1]
+            if input_length is None:
+                return outputs
             output_shape = (-1, input_length, self.output_dim)
         else:
             output_shape = ids.get_shape().concatenate(self.output_dim)

--- a/elasticdl/python/elasticdl/layers/embedding.py
+++ b/elasticdl/python/elasticdl/layers/embedding.py
@@ -205,8 +205,9 @@ class Embedding(tf.keras.layers.Layer):
         outputs = tf.gather(batch_embedding, idx)
         # tf.reshape does not support shape with None. Replace None with -1.
         if ids.get_shape().rank == 2:
-            input_dim = -1 if ids.get_shape()[1] is None \
-                else ids.get_shape()[1]
+            input_dim = (
+                -1 if ids.get_shape()[1] is None else ids.get_shape()[1]
+            )
             output_shape = (-1, input_dim, self.output_dim)
         else:
             output_shape = ids.get_shape().concatenate(self.output_dim)

--- a/elasticdl/python/elasticdl/layers/embedding.py
+++ b/elasticdl/python/elasticdl/layers/embedding.py
@@ -205,7 +205,9 @@ class Embedding(tf.keras.layers.Layer):
         outputs = tf.gather(batch_embedding, idx)
         # tf.reshape does not support shape with None. Replace None with -1.
         if ids.get_shape().rank == 2:
-            output_shape = (-1, ids.get_shape()[1], self.output_dim)
+            input_dim = -1 if ids.get_shape()[1] is None \
+                else ids.get_shape()[1]
+            output_shape = (-1, input_dim, self.output_dim)
         else:
             output_shape = ids.get_shape().concatenate(self.output_dim)
         outputs = tf.reshape(outputs, output_shape)

--- a/elasticdl/python/elasticdl/layers/embedding.py
+++ b/elasticdl/python/elasticdl/layers/embedding.py
@@ -205,9 +205,7 @@ class Embedding(tf.keras.layers.Layer):
         outputs = tf.gather(batch_embedding, idx)
         # tf.reshape does not support shape with None. Replace None with -1.
         if ids.get_shape().rank == 2:
-            input_dim = (
-                1 if ids.get_shape()[1] is None else ids.get_shape()[1]
-            )
+            input_dim = 1 if ids.get_shape()[1] is None else ids.get_shape()[1]
             output_shape = (-1, input_dim, self.output_dim)
         else:
             output_shape = ids.get_shape().concatenate(self.output_dim)

--- a/elasticdl/python/elasticdl/layers/embedding.py
+++ b/elasticdl/python/elasticdl/layers/embedding.py
@@ -207,7 +207,7 @@ class Embedding(tf.keras.layers.Layer):
         if ids.get_shape().rank == 2:
             input_length = ids.get_shape()[1]
             if input_length is None:
-                return outputs
+                return tf.reshape(outputs, (-1, self.output_dim))
             output_shape = (-1, input_length, self.output_dim)
         else:
             output_shape = ids.get_shape().concatenate(self.output_dim)

--- a/elasticdl/python/elasticdl/layers/embedding.py
+++ b/elasticdl/python/elasticdl/layers/embedding.py
@@ -206,7 +206,7 @@ class Embedding(tf.keras.layers.Layer):
         # tf.reshape does not support shape with None. Replace None with -1.
         if ids.get_shape().rank == 2:
             input_dim = (
-                -1 if ids.get_shape()[1] is None else ids.get_shape()[1]
+                1 if ids.get_shape()[1] is None else ids.get_shape()[1]
             )
             output_shape = (-1, input_dim, self.output_dim)
         else:

--- a/elasticdl/python/tests/layer_test.py
+++ b/elasticdl/python/tests/layer_test.py
@@ -380,7 +380,7 @@ class EmbeddingLayerTest(unittest.TestCase):
         input = tf.keras.layers.Input(shape=(None,))
         embedding_output = layer(input)
         embedding_output_shape = embedding_output.get_shape().as_list()
-        self.assertEquals(embedding_output_shape, [None, 8])
+        self.assertEquals(embedding_output_shape, [None, None, 8])
 
 
 if __name__ == "__main__":

--- a/elasticdl/python/tests/layer_test.py
+++ b/elasticdl/python/tests/layer_test.py
@@ -373,6 +373,15 @@ class EmbeddingLayerTest(unittest.TestCase):
                         ).all()
                     )
 
+    def test_embedding_layer_with_none_shape_input(self):
+        output_dim = 8
+        embedding_size = 16
+        layer = create_embedding_layer(embedding_size, output_dim)
+        input = tf.keras.layers.Input(shape=(None,))
+        embedding_output = layer(input)
+        embedding_output_shape = embedding_output.get_shape().as_list()
+        assert embedding_output_shape == [None, 1, 8]
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/elasticdl/python/tests/layer_test.py
+++ b/elasticdl/python/tests/layer_test.py
@@ -380,7 +380,7 @@ class EmbeddingLayerTest(unittest.TestCase):
         input = tf.keras.layers.Input(shape=(None,))
         embedding_output = layer(input)
         embedding_output_shape = embedding_output.get_shape().as_list()
-        assert embedding_output_shape == [None, 1, 8]
+        self.assertEquals(embedding_output_shape, [None, 8])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When ids.get_shape()[1] is None, we should use -1 for tf.reshape.  #1331