### PR TITLE
Add Python version requirement to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     url="https://elasticdl.org",
     install_requires=required_deps,
     extras_require=extras,
+    python_requires=">=3.5",
     packages=find_packages(exclude=["*test*"]),
     package_data={"": ["proto/elasticdl.proto", "docker/*", "Makefile"]},
     entry_points={


### PR DESCRIPTION
Running ElasticDL for other versions would result in indiscernible error messages and we should be explicit in Python version requirements.