### PR TITLE
Implement Tensor python data structure and related util functions

### DIFF
--- a/elasticdl/python/common/dtypes.py
+++ b/elasticdl/python/common/dtypes.py
@@ -5,7 +5,10 @@ from elasticdl.proto import tensor_dtype_pb2
 
 def dtype_tensor_to_numpy(dtype):
     """Convert tensor dtype to numpy dtype object."""
-    return np.dtype(_DT_TENSOR_TO_NP.get(dtype, None))
+    np_dtype_name = _DT_TENSOR_TO_NP.get(dtype, None)
+    if not np_dtype_name:
+        raise ValueError("Got wrong tensor PB dtype %s.", dtype)
+    return np.dtype(np_dtype_name)
 
 
 def dtype_numpy_to_tensor(dtype):

--- a/elasticdl/python/common/tensor.py
+++ b/elasticdl/python/common/tensor.py
@@ -25,7 +25,7 @@ def serialize_tensor(tensor, tensor_pb):
 
 
 def deserialize_tensor_pb(tensor_pb, tensor):
-    """Create an Tensor instance from Tensor proto message.
+    """Create a Tensor instance from Tensor proto message.
 
     Note: upon return, the input tensor message is reset and underlying buffer
     passed to the returned ndarray.
@@ -64,9 +64,9 @@ class Tensor(object):
     def __init__(self, values=None, indices=None, name=None):
         """
         `Tensor` can save dense tensors and sparse tensors.
-        To save dense tensors, `values` should be `numpy.ndarray` and `indices`
-            should be None.
-        There are two ways to save sparse tensors:
+        To pass in a dense tensor, `values` should be `numpy.ndarray` and
+            `indices` should be None.
+        There are two ways to pass in a sparse tensor:
             * `values` is a `numpy.ndarray` and `indices` is a `numpy.ndarray`.
             * `values` is a `TensorFlow.IndexedSlices` and `indices` is None.
 
@@ -74,7 +74,8 @@ class Tensor(object):
             values: A `numpy.ndarray` or `TensorFlow.IndexedSlices`.
                 If `values` is a `TensorFlow.IndexedSlices`, `indices` should
                 be None.
-            indices: `indices` of `TensorFlow`
+            indices: A `numpy.ndarray` or None.
+            name: A python string.
         """
         self.set(values, indices, name)
 

--- a/elasticdl/python/common/tensor.py
+++ b/elasticdl/python/common/tensor.py
@@ -27,8 +27,8 @@ def serialize_tensor(tensor, tensor_pb):
 def deserialize_tensor_pb(tensor_pb, tensor):
     """Create a Tensor instance from Tensor proto message.
 
-    Note: upon return, the input tensor message is reset and underlying buffer
-    passed to the returned ndarray.
+    Note that the input tensor message is reset and underlying buffer is passed
+    to the returned ndarray.
     """
 
     if not tensor_pb.dim:
@@ -47,7 +47,7 @@ def deserialize_tensor_pb(tensor_pb, tensor):
         )
     tensor.set(
         np.ndarray(shape=tensor_pb.dim, dtype=dtype, buffer=tensor_pb.content),
-        tensor_pb.indices,
+        np.array(tensor_pb.indices),
         tensor_pb.name,
     )
     tensor_pb.Clear()
@@ -83,8 +83,8 @@ class Tensor(object):
         if isinstance(values, tf.IndexedSlices):
             if indices is not None:
                 raise ValueError(
-                    "When creating a Tensor instance with values of type "
-                    "tf.IndexedSlices, indices should be None."
+                    "When creating a Tensor object with values of type "
+                    "tf.IndexedSlices, indices must be None."
                 )
             self.values = values.values.numpy()
             self.indices = values.indices.numpy()
@@ -98,8 +98,8 @@ class Tensor(object):
     def from_tensor_pb(self, tensor_pb):
         """Parse tensor from Tensor proto message.
 
-        Note: upon return, the input tensor message is reset and underlying
-        buffer passed to the returned ndarray.
+        Note that the input tensor message is reset and underlying buffer is
+        passed to the returned ndarray.
         """
         deserialize_tensor_pb(tensor_pb, self)
 

--- a/elasticdl/python/common/tensor.py
+++ b/elasticdl/python/common/tensor.py
@@ -1,0 +1,114 @@
+import numpy as np
+import tensorflow as tf
+
+from elasticdl.proto import elasticdl_pb2
+from elasticdl.python.common.dtypes import (
+    dtype_numpy_to_tensor,
+    dtype_tensor_to_numpy,
+    is_numpy_dtype_allowed,
+)
+
+
+def serialize_tensor(tensor, tensor_pb):
+    """Convert Tensor to Tensor PB"""
+    dtype = tensor.values.dtype
+    if not is_numpy_dtype_allowed(dtype):
+        raise ValueError("Dtype of ndarray %s is not supported", dtype)
+    tensor_pb.dim.extend(tensor.values.shape)
+    tensor_pb.content = tensor.values.tobytes()
+    if tensor.is_indexed_slices():
+        tensor_pb.indices.extend(tensor.indices)
+    tensor_pb.dtype = dtype_numpy_to_tensor(dtype)
+    if tensor.name:
+        tensor_pb.name = tensor.name
+
+
+def deserialize_tensor_pb(tensor_pb, tensor):
+    """Create an Tensor instance from Tensor proto message.
+
+    Note: upon return, the input tensor message is reset and underlying buffer
+    passed to the returned ndarray.
+    """
+
+    if not tensor_pb.dim:
+        raise ValueError("Tensor PB has no dim defined")
+
+    dtype = dtype_tensor_to_numpy(tensor_pb.dtype)
+    # Check that the buffer size agrees with dimensions.
+    size = dtype.itemsize
+    for d in tensor_pb.dim:
+        size *= d
+    if size != len(tensor_pb.content):
+        raise ValueError(
+            "Tensor PB size mismatch, dim: %s, len(content): %d",
+            tensor_pb.dim,
+            len(tensor_pb.content),
+        )
+    tensor = Tensor()
+    tensor.set(
+        np.ndarray(shape=tensor_pb.dim, dtype=dtype, buffer=tensor_pb.content),
+        tensor_pb.indices,
+        tensor_pb.name,
+    )
+    tensor_pb.Clear()
+
+
+class Tensor(object):
+    """Data structure for tensors in ElasticDL.
+
+    `Tensor` can save dense tensors and sparse tensors. For sparse tensors,
+    this structure saves them in the same way as `TensorFlow.IndexedSlices`.
+    """
+
+    def __init__(self, values=None, indices=None, name=None):
+        """
+        `Tensor` can save dense tensors and sparse tensors.
+        To save dense tensors, `values` should be `numpy.ndarray` and `indices`
+            should be None.
+        There are two ways to save sparse tensors:
+            * `values` is a `numpy.ndarray` and `indices` is a `numpy.ndarray`.
+            * `values` is a `TensorFlow.IndexedSlices` and `indices` is None.
+
+        Args:
+            values: A `numpy.ndarray` or `TensorFlow.IndexedSlices`.
+                If `values` is a `TensorFlow.IndexedSlices`, `indices` should
+                be None.
+            indices: `indices` of `TensorFlow`
+        """
+        self.set(values, indices, name)
+
+    def set(self, values=None, indices=None, name=None):
+        self.name = name
+        if isinstance(values, tf.IndexedSlices):
+            if indices is not None:
+                raise ValueError(
+                    "When creating a Tensor instance with values of type "
+                    "tf.IndexedSlices, indices should be None."
+                )
+            self.values = values.values.numpy()
+            self.indices = values.indices.numpy()
+        else:
+            self.values = values
+            self.indices = indices
+
+    def is_indexed_slices(self):
+        return self.indices is not None
+
+    def from_tensor_pb(self, tensor_pb):
+        """Parse tensor from Tensor proto message.
+
+        Note: upon return, the input tensor message is reset and underlying
+        buffer passed to the returned ndarray.
+        """
+        deserialize_tensor_pb(tensor_pb, self)
+
+    def to_tensor_pb(self):
+        tensor_pb = elasticdl_pb2.Tensor()
+        serialize_tensor(self, tensor_pb)
+        return tensor_pb
+
+    def to_tf_tensor(self):
+        if self.is_indexed_slices():
+            return tf.IndexedSlices(self.values, self.indices)
+        else:
+            return tf.constant(self.values)

--- a/elasticdl/python/common/tensor.py
+++ b/elasticdl/python/common/tensor.py
@@ -5,20 +5,21 @@ from elasticdl.proto import elasticdl_pb2
 from elasticdl.python.common.dtypes import (
     dtype_numpy_to_tensor,
     dtype_tensor_to_numpy,
-    is_numpy_dtype_allowed,
 )
 
 
 def serialize_tensor(tensor, tensor_pb):
     """Convert Tensor to Tensor PB"""
-    dtype = tensor.values.dtype
-    if not is_numpy_dtype_allowed(dtype):
-        raise ValueError("Dtype of ndarray %s is not supported", dtype)
+    dtype = dtype_numpy_to_tensor(tensor.values.dtype)
+    if not dtype:
+        raise ValueError(
+            "Dtype of ndarray %s is not supported", tensor.values.dtype
+        )
+    tensor_pb.dtype = dtype
     tensor_pb.dim.extend(tensor.values.shape)
     tensor_pb.content = tensor.values.tobytes()
     if tensor.is_indexed_slices():
         tensor_pb.indices.extend(tensor.indices)
-    tensor_pb.dtype = dtype_numpy_to_tensor(dtype)
     if tensor.name:
         tensor_pb.name = tensor.name
 

--- a/elasticdl/python/common/tensor.py
+++ b/elasticdl/python/common/tensor.py
@@ -45,7 +45,6 @@ def deserialize_tensor_pb(tensor_pb, tensor):
             tensor_pb.dim,
             len(tensor_pb.content),
         )
-    tensor = Tensor()
     tensor.set(
         np.ndarray(shape=tensor_pb.dim, dtype=dtype, buffer=tensor_pb.content),
         tensor_pb.indices,

--- a/elasticdl/python/tests/tensor_test.py
+++ b/elasticdl/python/tests/tensor_test.py
@@ -1,0 +1,186 @@
+"""Unittests for ElasticDL's Tensor data structure."""
+import unittest
+
+import numpy as np
+
+from elasticdl.proto import elasticdl_pb2, tensor_dtype_pb2
+from elasticdl.python.common.tensor import (
+    Tensor,
+    deserialize_tensor_pb,
+    serialize_tensor,
+)
+
+
+class TensorTest(unittest.TestCase):
+    def test_tensor_data_structure(self):
+        # Test tensor values, without indices
+        arr = np.ndarray(shape=[3, 1, 2, 4], dtype=np.int32)
+        tensor = Tensor(arr)
+        self.assertTrue(np.array_equal(arr, tensor.values))
+        self.assertTrue(np.array_equal(arr, tensor.to_tf_tensor()))
+        self.assertFalse(tensor.is_indexed_slices())
+
+        # Test tensor values, with indices
+        indices = np.array([2, 0, 1])
+        tensor = Tensor(arr, indices)
+        self.assertTrue(np.array_equal(arr, tensor.values))
+        self.assertTrue(np.array_equal(indices, tensor.indices))
+        self.assertTrue(np.array_equal(arr, tensor.to_tf_tensor().values))
+        self.assertTrue(np.array_equal(indices, tensor.to_tf_tensor().indices))
+        self.assertTrue(tensor.is_indexed_slices())
+
+        # Test round trip
+        # tensor to tensor PB
+        tensor = Tensor(arr, indices, name="test")
+        pb = tensor.to_tensor_pb()
+        self.assertEqual(pb.name, "test")
+        self.assertEqual(pb.dim, [3, 1, 2, 4])
+        self.assertEqual(pb.dtype, tensor_dtype_pb2.DT_INT32)
+        np.testing.assert_array_equal(pb.indices, indices)
+
+        # tensor PB to tensor
+        tensor_new = Tensor()
+        tensor_new.from_tensor_pb(pb)
+        self.assertEqual(tensor.name, "test")
+        np.testing.assert_array_equal(tensor.values, arr)
+        np.testing.assert_array_equal(tensor.indices, indices)
+
+    def test_serialize_tensor(self):
+        def _ndarray_to_tensor_pb(values, name=None, indices=None):
+            tensor = Tensor(values, indices, name)
+            tensor_pb = elasticdl_pb2.Tensor()
+            serialize_tensor(tensor, tensor_pb)
+            return tensor_pb
+
+        # Wrong type, should raise
+        arr = np.array([1, 2, 3, 4], dtype=np.uint8)
+        with self.assertRaises(ValueError):
+            _ndarray_to_tensor_pb(arr)
+
+        # Empty array
+        arr = np.array([], dtype=np.float32)
+        t = _ndarray_to_tensor_pb(arr)
+        self.assertEqual([0], t.dim)
+        self.assertEqual(0, len(t.content))
+
+        # Pathological case, one of the dimensions is 0.
+        arr = np.ndarray(shape=[2, 0, 1, 9], dtype=np.float32)
+        t = _ndarray_to_tensor_pb(arr)
+        self.assertEqual([2, 0, 1, 9], t.dim)
+        self.assertEqual(0, len(t.content))
+
+        # 1-D array
+        arr = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+        t = _ndarray_to_tensor_pb(arr)
+        self.assertEqual([4], t.dim)
+        self.assertEqual(4 * 4, len(t.content))
+
+        # 4-D random array
+        arr = np.ndarray(shape=[2, 1, 3, 4], dtype=np.float32)
+        t = _ndarray_to_tensor_pb(arr)
+        self.assertEqual([2, 1, 3, 4], t.dim)
+        self.assertEqual(4 * 2 * 1 * 3 * 4, len(t.content))
+
+        # test name argument
+        arr = np.ndarray(shape=[2, 1, 3, 4], dtype=np.float32)
+        t = _ndarray_to_tensor_pb(arr, "test")
+        self.assertTrue(t.name == "test")
+        self.assertEqual([2, 1, 3, 4], t.dim)
+        self.assertEqual(4 * 2 * 1 * 3 * 4, len(t.content))
+
+        # test tf.IndexedSlices
+        arr = np.ndarray(shape=[2, 1, 3, 4], dtype=np.float32)
+        indices = np.array([3, 0], dtype=np.int64)
+        t = _ndarray_to_tensor_pb(arr, "test", indices)
+        self.assertTrue(t.name == "test")
+        self.assertEqual([2, 1, 3, 4], t.dim)
+        self.assertEqual([3, 0], t.indices)
+        self.assertEqual(4 * 2 * 1 * 3 * 4, len(t.content))
+
+    def test_deserialize_tensor_pb(self):
+        pb = elasticdl_pb2.Tensor()
+        tensor = Tensor()
+        # No dim defined, should raise.
+        self.assertRaises(ValueError, deserialize_tensor_pb, pb, tensor)
+
+        # Empty array, should be ok.
+        pb.dim.append(0)
+        pb.content = b""
+        pb.dtype = tensor_dtype_pb2.DT_FLOAT32
+        deserialize_tensor_pb(pb, tensor)
+        np.testing.assert_array_equal(
+            np.array([], dtype=np.float32), tensor.values
+        )
+
+        # Wrong type, should raise
+        del pb.dim[:]
+        pb.dim.append(0)
+        pb.content = b""
+        pb.dtype = tensor_dtype_pb2.DT_INVALID
+        self.assertRaises(ValueError, deserialize_tensor_pb, pb, tensor)
+
+        # Pathological case, one of the dimensions is 0.
+        del pb.dim[:]
+        pb.dim.extend([2, 0, 1, 9])
+        pb.content = b""
+        pb.dtype = tensor_dtype_pb2.DT_FLOAT32
+        deserialize_tensor_pb(pb, tensor)
+        np.testing.assert_array_equal(
+            np.ndarray(shape=[2, 0, 1, 9], dtype=np.float32), tensor.values
+        )
+
+        # Wrong content size, should raise
+        del pb.dim[:]
+        pb.dim.append(11)
+        pb.content = b"\0" * (4 * 12)
+        pb.dtype = tensor_dtype_pb2.DT_FLOAT32
+        self.assertRaises(ValueError, deserialize_tensor_pb, pb, tensor)
+
+        # Compatible dimensions, should be ok.
+        for m in (1, 2, 3, 4, 6, 12):
+            for with_inidices in [True, False]:
+                del pb.dim[:]
+                pb.content = b"\0" * (4 * 12)
+                pb.dim.extend([m, 12 // m])
+                if with_inidices:
+                    pb.indices.extend([0] * m)
+                pb.dtype = tensor_dtype_pb2.DT_FLOAT32
+                deserialize_tensor_pb(pb, tensor)
+
+    def testRoundTrip(self):
+        def verify(values, name=None, indices=None):
+            tensor = Tensor(values, indices, name)
+            pb = elasticdl_pb2.Tensor()
+            serialize_tensor(tensor, pb)
+            deserialize_tensor_pb(pb, tensor)
+            np.testing.assert_array_equal(values, tensor.values)
+            if indices is not None:
+                np.testing.assert_array_equal(indices, tensor.indices)
+            if name:
+                assert name == tensor.name
+
+        # dtype = np.float32
+        # 1-D array
+        verify(np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32))
+        # 4-D random array
+        verify(np.ndarray(shape=[2, 1, 3, 4], dtype=np.float32))
+
+        # verify with name
+        verify(np.array([1, 2, 3, 4], dtype=np.float32), "test")
+
+        # verify with indices
+        verify(
+            np.ndarray([2, 1, 3, 4], dtype=np.float32),
+            "test",
+            np.array([1, 0]),
+        )
+
+        # dtype = np.int64
+        # 1-D random array
+        verify(np.array([1, 2, 3, 4], dtype=np.int64))
+        # 4-D random array
+        verify(np.ndarray(shape=[2, 1, 3, 4], dtype=np.int64))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/elasticdl/python/tests/tensor_test.py
+++ b/elasticdl/python/tests/tensor_test.py
@@ -147,6 +147,8 @@ class TensorTest(unittest.TestCase):
                 pb.dtype = tensor_dtype_pb2.DT_FLOAT32
                 deserialize_tensor_pb(pb, tensor)
                 self.assertEqual((m, 12 // m), tensor.values.shape)
+                self.assertTrue(isinstance(tensor.values, np.ndarray))
+                self.assertTrue(isinstance(tensor.indices, np.ndarray))
 
     def testRoundTrip(self):
         def verify(values, name=None, indices=None):
@@ -159,7 +161,7 @@ class TensorTest(unittest.TestCase):
             if indices is not None:
                 np.testing.assert_array_equal(indices, tensor_new.indices)
             if name:
-                assert name == tensor.name
+                self.assertEqual(name, tensor.name)
 
         # dtype = np.float32
         # 1-D array

--- a/elasticdl/python/tests/tensor_test.py
+++ b/elasticdl/python/tests/tensor_test.py
@@ -42,8 +42,8 @@ class TensorTest(unittest.TestCase):
         tensor_new = Tensor()
         tensor_new.from_tensor_pb(pb)
         self.assertEqual(tensor.name, "test")
-        np.testing.assert_array_equal(tensor.values, arr)
-        np.testing.assert_array_equal(tensor.indices, indices)
+        np.testing.assert_array_equal(tensor_new.values, arr)
+        np.testing.assert_array_equal(tensor_new.indices, indices)
 
     def test_serialize_tensor(self):
         def _ndarray_to_tensor_pb(values, name=None, indices=None):
@@ -146,16 +146,18 @@ class TensorTest(unittest.TestCase):
                     pb.indices.extend([0] * m)
                 pb.dtype = tensor_dtype_pb2.DT_FLOAT32
                 deserialize_tensor_pb(pb, tensor)
+                self.assertEqual((m, 12 // m), tensor.values.shape)
 
     def testRoundTrip(self):
         def verify(values, name=None, indices=None):
             tensor = Tensor(values, indices, name)
             pb = elasticdl_pb2.Tensor()
             serialize_tensor(tensor, pb)
-            deserialize_tensor_pb(pb, tensor)
-            np.testing.assert_array_equal(values, tensor.values)
+            tensor_new = Tensor()
+            deserialize_tensor_pb(pb, tensor_new)
+            np.testing.assert_array_equal(values, tensor_new.values)
             if indices is not None:
-                np.testing.assert_array_equal(indices, tensor.indices)
+                np.testing.assert_array_equal(indices, tensor_new.indices)
             if name:
                 assert name == tensor.name
 


### PR DESCRIPTION
Part of #1360 . This PR is step 1.

This PR implements `Tensor` python data structure and related util functions. Note that they are slightly differ from design doc. And we may need to modify them in the step 2 of #1360. We will modify design doc when finish step 2 of #1360 .