### PR TITLE
Switch to use assertEqual since assertEquals is deprecated

### DIFF
--- a/elasticdl/python/tests/layer_test.py
+++ b/elasticdl/python/tests/layer_test.py
@@ -380,7 +380,7 @@ class EmbeddingLayerTest(unittest.TestCase):
         input = tf.keras.layers.Input(shape=(None,))
         embedding_output = layer(input)
         embedding_output_shape = embedding_output.get_shape().as_list()
-        self.assertEquals(embedding_output_shape, [None, None, 8])
+        self.assertEqual(embedding_output_shape, [None, None, 8])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the following warning in unit test:
```
elasticdl/python/tests/layer_test.py::EmbeddingLayerTest::test_embedding_layer_with_none_shape_input
  /work/elasticdl/python/tests/layer_test.py:383: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(embedding_output_shape, [None, None, 8])
```

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>