### PR TITLE
Cast input to int64 for embedding `call`

### DIFF
--- a/elasticdl/python/elasticdl/layers/embedding.py
+++ b/elasticdl/python/elasticdl/layers/embedding.py
@@ -186,6 +186,9 @@ class Embedding(tf.keras.layers.Layer):
         return batch_embedding
 
     def call(self, input):
+        if input.dtype is not tf.int64:
+            input = tf.cast(input, tf.int64)
+
         if isinstance(input, tf.SparseTensor):
             return self._sparse_input_call(input)
 

--- a/elasticdl/python/elasticdl/layers/embedding.py
+++ b/elasticdl/python/elasticdl/layers/embedding.py
@@ -186,9 +186,7 @@ class Embedding(tf.keras.layers.Layer):
         return batch_embedding
 
     def call(self, input):
-        if input.dtype is not tf.int64:
-            input = tf.cast(input, tf.int64)
-
+        input = tf.cast(input, tf.int64)
         if isinstance(input, tf.SparseTensor):
             return self._sparse_input_call(input)
 


### PR DESCRIPTION
We should check the input dtype for elasticdl.layers.Embedding `call` and cast to int64. #1374