### PR TITLE
Rename initializer parameter to keep consistency with Keras

### DIFF
--- a/elasticdl/python/elasticdl/layers/embedding.py
+++ b/elasticdl/python/elasticdl/layers/embedding.py
@@ -24,7 +24,7 @@ class Embedding(tf.keras.layers.Layer):
       output_dim: the dimension of the embedding vector
       input_dim: the max input id. If None, the input_dim will be
       the max id which can be acquired during training through all records.
-      embedding_initializer: Initializer for embedding table
+      embeddings_initializer: Initializer for embedding table
       mask_zero: Whether or not the input value 0 is a special "padding"
         value that should be masked out.
         If input is SparseTensor, mask_zero must be False.
@@ -41,7 +41,7 @@ class Embedding(tf.keras.layers.Layer):
         self,
         output_dim,
         input_dim=None,
-        embedding_initializer="uniform",
+        embeddings_initializer="uniform",
         mask_zero=False,
         input_length=None,
         combiner=None,
@@ -54,7 +54,7 @@ class Embedding(tf.keras.layers.Layer):
 
         self.input_dim = input_dim
         self.output_dim = output_dim
-        self.embedding_initializer = embedding_initializer
+        self.embeddings_initializer = embeddings_initializer
         self.supports_masking = mask_zero
         self.input_length = input_length
         self.combiner = combiner
@@ -143,7 +143,9 @@ class Embedding(tf.keras.layers.Layer):
         if unknown_keys_index:
             # Initialize unknown_keys' embedding vectors and write into Redis.
             unknown_keys = [keys[index] for index in unknown_keys_index]
-            initializer = tf.keras.initializers.get(self.embedding_initializer)
+            initializer = tf.keras.initializers.get(
+                self.embeddings_initializer
+            )
             embedding_vector_init = [
                 initializer(shape=[1, self.output_dim]).numpy()
                 for _ in unknown_keys


### PR DESCRIPTION
Modify "embedding_initializer" to "embeddings_initializer" which keeps consistency with Keras Embedding args name.

https://github.com/keras-team/keras/blob/e8946d5240f3b18528d4d34668ee615907879953/keras/layers/embeddings.py#L80-L87