### PR TITLE
Move create_service to k8s_client to be reused by other components

### DIFF
--- a/elasticdl/python/common/k8s_client.py
+++ b/elasticdl/python/common/k8s_client.py
@@ -318,7 +318,7 @@ class Client(object):
         return self._create_service(
             name=self.get_tensorboard_service_name(),
             port=port,
-            target_port=6006,
+            target_port=target_port,
             replica_type=replica_type,
             service_type=service_type,
             owner=self.get_master_pod(),

--- a/elasticdl/python/common/k8s_client.py
+++ b/elasticdl/python/common/k8s_client.py
@@ -313,6 +313,7 @@ class Client(object):
         port=80,
         target_port=6006,
         replica_type="master",
+        replica_index=0,
         service_type="LoadBalancer",
     ):
         return self._create_service(
@@ -320,6 +321,7 @@ class Client(object):
             port=port,
             target_port=target_port,
             replica_type=replica_type,
+            replica_index=replica_index,
             service_type=service_type,
             owner=self.get_master_pod(),
         )
@@ -334,7 +336,7 @@ class Client(object):
             # Otherwise annotation is `None` and cannot be modified
             # using `with_service()` for cluster specific information.
             annotations=labels,
-            owner_references=kargs["owner_reference"],
+            owner_references=kargs.get("owner", None),
             namespace=self.namespace,
         )
         spec = client.V1ServiceSpec(

--- a/elasticdl/python/common/k8s_client.py
+++ b/elasticdl/python/common/k8s_client.py
@@ -313,7 +313,7 @@ class Client(object):
         port=80,
         target_port=6006,
         replica_type="master",
-        replica_index=0,
+        replica_index="0",
         service_type="LoadBalancer",
     ):
         return self._create_service(

--- a/elasticdl/python/common/k8s_client.py
+++ b/elasticdl/python/common/k8s_client.py
@@ -336,7 +336,9 @@ class Client(object):
             # Otherwise annotation is `None` and cannot be modified
             # using `with_service()` for cluster specific information.
             annotations=labels,
-            owner_references=kargs.get("owner", None),
+            owner_references=self.create_owner_reference(kargs["owner"])
+            if "owner" in kargs
+            else None,
             namespace=self.namespace,
         )
         spec = client.V1ServiceSpec(

--- a/elasticdl/python/common/k8s_tensorboard_client.py
+++ b/elasticdl/python/common/k8s_tensorboard_client.py
@@ -17,55 +17,8 @@ class TensorBoardClient(object):
         """
         self._k8s_client = k8s.Client(**kwargs)
 
-    def _get_tensorboard_service_name(self):
-        return "tensorboard-" + self._k8s_client.job_name
-
-    def _create_tensorboard_service(
-        self, port=80, target_port=6006, service_type="LoadBalancer"
-    ):
-        service = client.V1Service(
-            api_version="v1",
-            kind="Service",
-            metadata=client.V1ObjectMeta(
-                name=self._get_tensorboard_service_name(),
-                labels={
-                    "app": k8s.ELASTICDL_APP_NAME,
-                    k8s.ELASTICDL_JOB_KEY: self._k8s_client.job_name,
-                },
-                # Note: We have to add at least one annotation here.
-                # Otherwise annotation is `None` and cannot be modified
-                # using `with_service()` for cluster specific information.
-                annotations={k8s.ELASTICDL_JOB_KEY: self._k8s_client.job_name},
-                owner_references=k8s.Client.create_owner_reference(
-                    self._k8s_client.get_master_pod()
-                ),
-                namespace=self._k8s_client.namespace,
-            ),
-            spec=client.V1ServiceSpec(
-                ports=[
-                    client.V1ServicePort(port=port, target_port=target_port)
-                ],
-                selector={
-                    "app": k8s.ELASTICDL_APP_NAME,
-                    k8s.ELASTICDL_JOB_KEY: self._k8s_client.job_name,
-                    k8s.ELASTICDL_REPLICA_TYPE_KEY: "master",
-                },
-                type=service_type,
-            ),
-        )
-        if self._k8s_client.cluster:
-            with_service_fn = getattr(
-                self._k8s_client.cluster, "with_service", None
-            )
-            if with_service_fn:
-                service = with_service_fn(service)
-
-        self._k8s_client.client.create_namespaced_service(
-            self._k8s_client.namespace, service
-        )
-
     def start_tensorboard_service(self):
-        self._create_tensorboard_service()
+        self._k8s_client.create_tensorboard_service()
         logger.info("Waiting for the URL for TensorBoard service...")
         tb_url = self._get_tensorboard_url()
         if tb_url:
@@ -76,7 +29,7 @@ class TensorBoardClient(object):
     def _get_tensorboard_service(self):
         try:
             return self._k8s_client.client.read_namespaced_service(
-                name=self._get_tensorboard_service_name(),
+                name=self._k8s_client.get_tensorboard_service_name(),
                 namespace=self._k8s_client.namespace,
             ).to_dict()
         except client.api_client.ApiException as e:

--- a/elasticdl/python/master/k8s_worker_manager.py
+++ b/elasticdl/python/master/k8s_worker_manager.py
@@ -84,7 +84,7 @@ class WorkerManager(object):
         )
 
     def start_workers(self):
-        for i in range(self._num_workers):
+        for _ in range(self._num_workers):
             self._start_worker(self._next_worker_id())
 
     def _remove_worker(self, worker_id):

--- a/elasticdl/python/tests/k8s_tensorboard_client_test.py
+++ b/elasticdl/python/tests/k8s_tensorboard_client_test.py
@@ -19,7 +19,7 @@ class K8sTensorBoardClientTest(unittest.TestCase):
             % (int(time.time()), random.randint(1, 101)),
             event_callback=None,
         )
-        tb_client._create_tensorboard_service(
+        tb_client._k8s_client.create_tensorboard_service(
             port=80, service_type="LoadBalancer"
         )
         time.sleep(1)


### PR DESCRIPTION
Move inside to be reused by other components. For example, to create services for workers.