### PR TITLE
Event handler only cares about pod events

### DIFF
--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -170,6 +170,10 @@ class InstanceManager(object):
             logger.error("Event doesn't have object or type: %s" % event)
             return
 
+        if evt_obj.kind != "Pod":
+            # We only care about pod related events
+            return
+
         pod_name = evt_obj.metadata.name
         phase = evt_obj.status.phase
         logger.info(


### PR DESCRIPTION
We'll add service in the following PRs. So the event handler should check event_obj kind, and only handles `pod`.