### PR TITLE
Add services to rbac manifest

### DIFF
--- a/elasticdl/manifests/examples/elasticdl-rbac.yaml
+++ b/elasticdl/manifests/examples/elasticdl-rbac.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - pods
   - pods/exec
+  - services
   verbs:
   - create
   - get


### PR DESCRIPTION
Fixes the following exception in Travis build observed in https://travis-ci.org/sql-machine-learning/elasticdl/jobs/608374669.

```
\nMaster log:\n
  File "/usr/local/lib/python3.6/dist-packages/kubernetes/client/rest.py", line 266, in POST
    body=body)
  File "/usr/local/lib/python3.6/dist-packages/kubernetes/client/rest.py", line 222, in request
    raise ApiException(http_resp=r)
kubernetes.client.rest.ApiException: (403)
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'Date': 'Wed, 06 Nov 2019 19:53:52 GMT', 'Content-Length': '296'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"services is forbidden: User \"system:serviceaccount:default:default\" cannot create resource \"services\" in API group \"\" in the namespace \"default\"","reason":"Forbidden","details":{"kind":"services"},"code":403}
```

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>