### PR TITLE
report_variable for ps init when needed

### DIFF
--- a/elasticdl/python/tests/worker_ps_interaction_test.py
+++ b/elasticdl/python/tests/worker_ps_interaction_test.py
@@ -255,8 +255,9 @@ class WorkerPSInteractionTest(unittest.TestCase):
 
         tf.keras.backend.clear_session()
         tf.random.set_seed(22)
+        stop_step = 20
         worker_results = self._worker_train(
-            train_db=db, test_db=test_db, dataset="mnist", stop_step=50
+            train_db=db, test_db=test_db, dataset="mnist", stop_step=stop_step
         )
 
         tf.keras.backend.clear_session()
@@ -302,7 +303,7 @@ class WorkerPSInteractionTest(unittest.TestCase):
                 )
                 acc_meter.reset_states()
 
-            if step > 50:
+            if step > stop_step:
                 break
 
         for w, l in zip(worker_results, local_results):
@@ -331,10 +332,10 @@ class WorkerPSInteractionTest(unittest.TestCase):
         test_db = test_db.batch(self._batch_size)
 
         worker_results = self._worker_train(
-            train_db=db, test_db=test_db, dataset="frappe", stop_step=200
+            train_db=db, test_db=test_db, dataset="frappe", stop_step=100
         )
         acc = max([r[1] for r in worker_results])
-        self.assertLess(0.7, acc)
+        self.assertLess(0.6, acc)
 
     def test_restart_ps(self):
         num_data = 8

--- a/elasticdl/python/tests/worker_ps_interaction_test.py
+++ b/elasticdl/python/tests/worker_ps_interaction_test.py
@@ -78,8 +78,7 @@ class WorkerPSInteractionTest(unittest.TestCase):
 
     def _restart_pserver(self):
         # Stop first
-        for ps in self._pserver:
-            ps.server.stop(0)
+        self.tearDown()
         # Start again
         self._pserver, self._channel = self._create_pserver_and_channel(
             self._ports

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -232,6 +232,11 @@ class Worker(object):
                 # push variable to ps for initialization
                 self.report_variable_to_ps(ps_id)
                 res = stub.pull_variable(req)
+                if not res.model_init_status:
+                    # TODO: support PS fault-tolerance
+                    raise RuntimeError(
+                        "PS pod %d cannot be initialized" % ps_id
+                    )
 
             for tensor_pb in res.model.param:
                 tensor = Tensor.from_tensor_pb(tensor_pb)


### PR DESCRIPTION
fix #1448 
For PS, lazy initialization is used. When a worker finds out that ps is not initialized by checking `model_init_status` in `pull_variable` call, it sends its variables to PS by `report_variable` for PS initialization.