### PR TITLE
fix build image when running outside repo path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ setup(
     extras_require=extras,
     python_requires=">=3.5",
     packages=find_packages(exclude=["*test*"]),
-    package_data={"": ["proto/*.proto", "docker/*", "Makefile", "requirements.txt"]},
+    package_data={
+        "": ["proto/*.proto", "docker/*", "Makefile", "requirements.txt"]
+    },
     entry_points={
         "console_scripts": ["elasticdl=elasticdl.python.elasticdl.client:main"]
     },

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     extras_require=extras,
     python_requires=">=3.5",
     packages=find_packages(exclude=["*test*"]),
-    package_data={"": ["proto/elasticdl.proto", "docker/*", "Makefile"]},
+    package_data={"": ["proto/*.proto", "docker/*", "Makefile", "requirements.txt"]},
     entry_points={
         "console_scripts": ["elasticdl=elasticdl.python.elasticdl.client:main"]
     },


### PR DESCRIPTION
Will encounter error when running `elasticdl train ...` outside repo path, e.g. install elasticdl under `/usr/local` and run `elasticdl train ...` in `/`.

TODO: need to change CI to run tests outside repo path.