### PR TITLE
Add check for empty string for ODPS endpoint

### DIFF
--- a/elasticdl/python/data/odps_io.py
+++ b/elasticdl/python/data/odps_io.py
@@ -27,7 +27,7 @@ def _nested_list_size(l):
 
 
 def _configure_odps_options(endpoint, options=None):
-    if endpoint is not None and endpoint != '':
+    if endpoint is not None and endpoint != "":
         odps.options.retry_times = options.get("odps.options.retry_times", 5)
         odps.options.read_timeout = options.get(
             "odps.options.read_timeout", 200

--- a/elasticdl/python/data/odps_io.py
+++ b/elasticdl/python/data/odps_io.py
@@ -27,7 +27,7 @@ def _nested_list_size(l):
 
 
 def _configure_odps_options(endpoint, options=None):
-    if endpoint is not None:
+    if endpoint is not None and endpoint != '':
         odps.options.retry_times = options.get("odps.options.retry_times", 5)
         odps.options.read_timeout = options.get(
             "odps.options.read_timeout", 200

--- a/scripts/client_test.sh
+++ b/scripts/client_test.sh
@@ -70,7 +70,7 @@ elif [[ "$JOB_TYPE" == "odps" ]]; then
       --model_def=odps_iris_dnn_model.odps_iris_dnn_model.custom_model \
       --training_data=$ODPS_TABLE_NAME \
       --data_reader_params='columns=["sepal_length", "sepal_width", "petal_length", "petal_width", "class"]' \
-      --envs="ODPS_PROJECT_NAME=$ODPS_PROJECT_NAME,ODPS_ACCESS_ID=$ODPS_ACCESS_ID,ODPS_ACCESS_KEY=$ODPS_ACCESS_KEY" \
+      --envs="ODPS_PROJECT_NAME=$ODPS_PROJECT_NAME,ODPS_ACCESS_ID=$ODPS_ACCESS_ID,ODPS_ACCESS_KEY=$ODPS_ACCESS_KEY,ODPS_ENDPOINT=" \
       --num_epochs=2 \
       --master_resource_request="cpu=400m,memory=1024Mi" \
       --master_resource_limit="cpu=1,memory=2048Mi" \


### PR DESCRIPTION
Added explicit check for empty string so users can be explicit about using public ODPS endpoint. Also included this in CI so we can test it as well as showing off all the available options in `scripts/client_test.sh`.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>