### PR TITLE
stop ps pod when master pod is stopped

### DIFF
--- a/elasticdl/python/common/k8s_client.py
+++ b/elasticdl/python/common/k8s_client.py
@@ -16,15 +16,15 @@ ELASTICDL_REPLICA_TYPE_KEY = "elasticdl-replica-type"
 ELASTICDL_REPLICA_INDEX_KEY = "elasticdl-replica-index"
 
 
-def get_master_pod_name(self, job_name):
+def get_master_pod_name(job_name):
     return "elasticdl-%s-master" % job_name
 
 
-def get_worker_pod_name(self, job_name, worker_id):
+def get_worker_pod_name(job_name, worker_id):
     return "elasticdl-%s-worker-%s" % (job_name, str(worker_id))
 
 
-def get_ps_pod_name(self, job_name, ps_id):
+def get_ps_pod_name(job_name, ps_id):
     return "elasticdl-%s-ps-%s" % (job_name, str(ps_id))
 
 

--- a/elasticdl/python/common/k8s_client.py
+++ b/elasticdl/python/common/k8s_client.py
@@ -16,6 +16,18 @@ ELASTICDL_REPLICA_TYPE_KEY = "elasticdl-replica-type"
 ELASTICDL_REPLICA_INDEX_KEY = "elasticdl-replica-index"
 
 
+def get_master_pod_name(self, job_name):
+    return "elasticdl-%s-master" % job_name
+
+
+def get_worker_pod_name(self, job_name, worker_id):
+    return "elasticdl-%s-worker-%s" % (job_name, str(worker_id))
+
+
+def get_ps_pod_name(self, job_name, ps_id):
+    return "elasticdl-%s-ps-%s" % (job_name, str(ps_id))
+
+
 class Client(object):
     def __init__(
         self,
@@ -78,13 +90,13 @@ class Client(object):
                 traceback.print_exc()
 
     def get_master_pod_name(self):
-        return "elasticdl-%s-master" % self.job_name
+        return get_master_pod_name(self.job_name)
 
     def get_worker_pod_name(self, worker_id):
-        return "elasticdl-%s-worker-%s" % (self.job_name, str(worker_id))
+        return get_worker_pod_name(self.job_name, worker_id)
 
     def get_ps_pod_name(self, ps_id):
-        return "elasticdl-%s-ps-%s" % (self.job_name, str(ps_id))
+        return get_ps_pod_name(self.job_name, ps_id)
 
     def get_ps_service_name(self, ps_id):
         return self.get_ps_pod_name(ps_id)

--- a/elasticdl/python/ps/parameter_server.py
+++ b/elasticdl/python/ps/parameter_server.py
@@ -77,6 +77,10 @@ class ParameterServer(object):
                     namespace=self.namespace, name=self.master_name
                 )
                 if master_pod.status.phase == "Succeeded":
+                    self.logger.info("Master pod is Succeeded")
+                    break
+                elif master_pod.status.phase == "Failed":
+                    self.logger.info("Master pod is Failed")
                     break
         except KeyboardInterrupt:
             self.logger.warning("Server stopping")

--- a/elasticdl/python/tests/test_utils.py
+++ b/elasticdl/python/tests/test_utils.py
@@ -33,6 +33,8 @@ class PserverArgs(object):
         optimizer="optimizer",
         port=9999,
         log_level="INFO",
+        job_name="test_pserver",
+        namespace="default",
     ):
         self.grads_to_wait = grads_to_wait
         self.lr_staleness_modulation = lr_staleness_modulation
@@ -42,6 +44,8 @@ class PserverArgs(object):
         self.optimizer = optimizer
         self.port = port
         self.log_level = log_level
+        self.job_name = job_name
+        self.namespace = namespace
 
 
 class DatasetName(object):


### PR DESCRIPTION
I find that we must call `read_namespaced_pod `  inside the loop. Otherwise, we will get outdated pod status.

This PR will make ps pod stopped elegantly:

```
kubectl get pods
NAME                            READY   STATUS      RESTARTS   AGE
elasticdl-test-mnist-master     0/1     Completed   0          3m6s
elasticdl-test-mnist-ps-0       0/1     Completed   0          3m3s
elasticdl-test-mnist-worker-0   0/1     Completed   0          3m2s
```