### PR TITLE
Add allreduce strategy option to CLI arg

### DIFF
--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -493,6 +493,7 @@ def add_common_args_between_master_and_worker(parser):
         "--distribution_strategy",
         type=str,
         choices=[
+            "",
             DistributionStrategy.PARAMETER_SERVER,
             DistributionStrategy.ALLREDUCE,
         ],

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -1,6 +1,7 @@
 import argparse
 from itertools import chain
 
+from elasticdl.python.common.constants import DistributionStrategy
 from elasticdl.python.common.log_utils import default_logger as logger
 
 MODEL_SPEC_GROUP = [
@@ -491,9 +492,13 @@ def add_common_args_between_master_and_worker(parser):
     parser.add_argument(
         "--distribution_strategy",
         type=str,
+        choices=[
+            DistributionStrategy.PARAMETER_SERVER,
+            DistributionStrategy.ALLREDUCE,
+        ],
         help="Master will use a distribution policy on a list of devices "
         "according to the distributed strategy, "
-        'e.g. "ParameterServerStrategy"',
+        'e.g. "ParameterServerStrategy" or "AllreduceStrategy"',
     )
 
 

--- a/elasticdl/python/common/constants.py
+++ b/elasticdl/python/common/constants.py
@@ -42,6 +42,7 @@ class MetricsDictKey(object):
 
 class DistributionStrategy(object):
     PARAMETER_SERVER = "ParameterServerStrategy"
+    ALLREDUCE = "AllreduceStrategy"
 
 
 class SaveModelConfig(object):

--- a/elasticdl/python/common/model_handler.py
+++ b/elasticdl/python/common/model_handler.py
@@ -56,8 +56,12 @@ class ModelHandler(metaclass=abc.ABCMeta):
         """
         if distribution_strategy == DistributionStrategy.PARAMETER_SERVER:
             return ParameterServerModelHandler(stub=stub)
-        else:
-            return DefaultModelHandler()
+        elif distribution_strategy == DistributionStrategy.ALLREDUCE:
+            logger.warning(
+                "Allreduce distribution strategy is not supported yet. "
+                "Switching to use the default distribution strategy."
+            )
+        return DefaultModelHandler()
 
 
 class DefaultModelHandler(ModelHandler):

--- a/elasticdl/python/tests/model_handler_test.py
+++ b/elasticdl/python/tests/model_handler_test.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 import tensorflow as tf
 
+from elasticdl.python.common.constants import DistributionStrategy
 from elasticdl.python.common.model_handler import ModelHandler
 from elasticdl.python.elasticdl.layers.embedding import Embedding
 from elasticdl.python.master.checkpoint_service import CheckpointService
@@ -127,7 +128,8 @@ class ParameterSeverModelHandlerTest(unittest.TestCase):
         )
         self.master._version = 1
         self.model_handler = ModelHandler.get_model_handler(
-            distribution_strategy="ParameterServerStrategy", stub=self.master
+            distribution_strategy=DistributionStrategy.PARAMETER_SERVER,
+            stub=self.master,
         )
 
     def test_get_model_to_train(self):

--- a/elasticdl/python/tests/worker_ps_interaction_test.py
+++ b/elasticdl/python/tests/worker_ps_interaction_test.py
@@ -8,7 +8,7 @@ import tensorflow as tf
 
 from elasticdl.proto import elasticdl_pb2
 from elasticdl.python.common.args import parse_worker_args
-from elasticdl.python.common.constants import GRPC
+from elasticdl.python.common.constants import GRPC, DistributionStrategy
 from elasticdl.python.common.hash_utils import int_to_id, string_to_id
 from elasticdl.python.common.model_utils import get_model_spec
 from elasticdl.python.data.recordio_gen.frappe_recordio_gen import (
@@ -102,7 +102,7 @@ class WorkerPSInteractionTest(unittest.TestCase):
             "--model_def",
             self._model_def,
             "--distribution_strategy",
-            "ParameterServerStrategy",
+            DistributionStrategy.PARAMETER_SERVER,
         ]
         args = parse_worker_args(arguments)
         worker = Worker(args, ps_channels=self._channel)
@@ -153,7 +153,7 @@ class WorkerPSInteractionTest(unittest.TestCase):
             "--model_def",
             "mnist_functional_api.mnist_functional_api.custom_model",
             "--distribution_strategy",
-            "ParameterServerStrategy",
+            DistributionStrategy.PARAMETER_SERVER,
         ]
         args = parse_worker_args(arguments)
 
@@ -222,7 +222,7 @@ class WorkerPSInteractionTest(unittest.TestCase):
             "--model_def",
             model_def,
             "--distribution_strategy",
-            "ParameterServerStrategy",
+            DistributionStrategy.PARAMETER_SERVER,
         ]
         args = parse_worker_args(arguments)
 
@@ -385,7 +385,7 @@ class WorkerPSInteractionTest(unittest.TestCase):
                 "--model_def",
                 self._model_def,
                 "--distribution_strategy",
-                "ParameterServerStrategy",
+                DistributionStrategy.PARAMETER_SERVER,
             ]
             args = parse_worker_args(arguments)
 

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -438,7 +438,7 @@ class Worker(object):
                     req = reqs[ps_id]
                     gv, gi = results[ps_id]
                     emplace_tensor_pb_from_ndarray(
-                        req.gradients, values=gv, indices=gi, name=layer.name,
+                        req.gradients, values=gv, indices=gi, name=layer.name
                     )
 
         # TODO: call `push_gradient` in parallel


### PR DESCRIPTION
This adds the allreduce strategy option to the CLI. Fallback to `DefaultModelHandler` until we finish the implementation. Also change the hard-coded "ParameterServerStrategy" in test to reuse the existing constant.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>