### PR TITLE
Allow user to specify tf.keras style loss function

### DIFF
--- a/docs/tutorials/model_building.md
+++ b/docs/tutorials/model_building.md
@@ -105,20 +105,19 @@ def dataset_fn(dataset, mode):
 
 ### loss
 ```
-loss(output, labels)
+loss(labels, output)
 ```
 `loss` is the loss function used in ElasticDL training.
 
 Arguments:
 
-- output:  [model](#model)'s output.
-
 - labels: `labels` from [`dataset_fn`](#dataset_fn).
+- output:  [model](#model)'s output.
 
 Example:
 
 ```
-def loss(output, labels):
+def loss(labels, output):
     return tf.reduce_mean(
         input_tensor=tf.nn.sparse_softmax_cross_entropy_with_logits(
             logits=output, labels=labels.flatten()

--- a/elasticdl/python/tests/data_reader_test.py
+++ b/elasticdl/python/tests/data_reader_test.py
@@ -149,7 +149,7 @@ class ODPSDataReaderTest(unittest.TestCase):
         for features, labels in dataset:
             with tf.GradientTape() as tape:
                 logits = model(features, training=True)
-                loss_value = loss(logits, labels)
+                loss_value = loss(labels, logits)
             loss_history.append(loss_value.numpy())
             grads = tape.gradient(loss_value, model.trainable_variables)
             optimizer.apply_gradients(zip(grads, model.trainable_variables))

--- a/elasticdl/python/tests/embedding_test_module.py
+++ b/elasticdl/python/tests/embedding_test_module.py
@@ -85,7 +85,7 @@ class KerasEmbeddingModel(tf.keras.Model):
         return x
 
 
-def loss(predictions, labels):
+def loss(labels, predictions):
     return tf.reduce_mean(tf.square(predictions - labels))
 
 

--- a/elasticdl/python/tests/test_module.py
+++ b/elasticdl/python/tests/test_module.py
@@ -13,8 +13,12 @@ def custom_model():
     return Model(inputs, outputs)
 
 
-def loss(predictions, labels):
+def loss(labels, predictions):
     return tf.reduce_mean(tf.square(predictions - labels))
+
+
+def keras_loss(labels, predictions):
+    return tf.keras.losses.mean_squared_error(labels, predictions)
 
 
 def dataset_fn(dataset, mode, metadata):

--- a/elasticdl/python/tests/test_utils.py
+++ b/elasticdl/python/tests/test_utils.py
@@ -143,6 +143,7 @@ def distributed_train_and_evaluate(
     model_def,
     model_params="",
     eval_metrics_fn="eval_metrics_fn",
+    loss="loss",
     training=True,
     dataset_name=DatasetName.IMAGE_DEFAULT,
     callback_classes=[],
@@ -192,6 +193,8 @@ def distributed_train_and_evaluate(
         model_def,
         "--model_params",
         model_params,
+        "--loss",
+        loss,
         "--get_model_steps",
         get_model_steps,
     ]

--- a/elasticdl/python/tests/worker_ps_interaction_test.py
+++ b/elasticdl/python/tests/worker_ps_interaction_test.py
@@ -241,7 +241,7 @@ class WorkerPSInteractionTest(unittest.TestCase):
         with tf.GradientTape() as tape:
             output = model.call(images, training=True)
             labels = tf.reshape(labels, [-1])
-            loss = loss_fn(output, labels)
+            loss = loss_fn(labels, output)
         grads = tape.gradient(loss, model.trainable_variables)
         opt_fn().apply_gradients(zip(grads, model.trainable_variables))
 
@@ -289,7 +289,7 @@ class WorkerPSInteractionTest(unittest.TestCase):
         for step, (x, y) in enumerate(db):
             with tf.GradientTape() as tape:
                 out = model.call(x, training=True)
-                ll = loss_fn(out, y)
+                ll = loss_fn(y, out)
             grads = tape.gradient(ll, model.trainable_variables)
             opt_fn().apply_gradients(zip(grads, model.trainable_variables))
 

--- a/elasticdl/python/tests/worker_test.py
+++ b/elasticdl/python/tests/worker_test.py
@@ -112,6 +112,17 @@ class WorkerTest(unittest.TestCase):
             callback_classes=[CheckRetryCallback],
         )
 
+    def test_distributed_train_tf_example_with_keras_loss(self):
+        distributed_train_and_evaluate(
+            1,
+            _model_zoo_path,
+            "test_module.custom_model",
+            loss="keras_loss",
+            training=True,
+            dataset_name=DatasetName.TEST_MODULE,
+            callback_classes=[CheckRetryCallback],
+        )
+
     def test_distributed_evaluate_tf_example(self):
         distributed_train_and_evaluate(
             1,

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -590,7 +590,7 @@ class Worker(object):
         with tf.GradientTape() as tape:
             self._set_tape_for_embedding(tape)
             outputs = self._model.call(features, training=True)
-            loss = self._loss(outputs, labels)
+            loss = self._loss(labels, outputs)
             # Add regularization loss if any
             if self._model.losses:
                 loss += tf.math.add_n(self._model.losses)
@@ -687,7 +687,7 @@ class Worker(object):
                     features, labels
                 )
                 if accepted:
-                    logger.info("Loss is %f" % loss.numpy())
+                    logger.info("Loss is {}" % loss.numpy())
                     break
             elif task_type == elasticdl_pb2.PREDICTION:
                 if self._model_version != min_model_version:

--- a/model_zoo/cifar10_functional_api/cifar10_functional_api.py
+++ b/model_zoo/cifar10_functional_api/cifar10_functional_api.py
@@ -101,11 +101,11 @@ def custom_model():
     return tf.keras.Model(inputs=inputs, outputs=outputs, name="cifar10_model")
 
 
-def loss(output, labels):
+def loss(labels, predictions):
     labels = tf.reshape(labels, [-1])
     return tf.reduce_mean(
         input_tensor=tf.nn.sparse_softmax_cross_entropy_with_logits(
-            logits=output, labels=labels
+            logits=predictions, labels=labels
         )
     )
 

--- a/model_zoo/cifar10_subclass/cifar10_subclass.py
+++ b/model_zoo/cifar10_subclass/cifar10_subclass.py
@@ -121,11 +121,11 @@ class CustomModel(tf.keras.Model):
         return self._dense_1(x)
 
 
-def loss(output, labels):
+def loss(labels, predictions):
     labels = tf.reshape(labels, [-1])
     return tf.reduce_mean(
         input_tensor=tf.nn.sparse_softmax_cross_entropy_with_logits(
-            logits=output, labels=labels
+            logits=predictions, labels=labels
         )
     )
 

--- a/model_zoo/deepfm_edl_embedding/deepfm_edl_embedding.py
+++ b/model_zoo/deepfm_edl_embedding/deepfm_edl_embedding.py
@@ -60,8 +60,8 @@ def custom_model(
     return m
 
 
-def loss(output, labels):
-    logits = output["logits"]
+def loss(labels, predictions):
+    logits = predictions["logits"]
     labels = tf.cast(tf.reshape(labels, [-1]), tf.dtypes.float32)
     logits = tf.reshape(logits, [-1])
     return tf.reduce_mean(

--- a/model_zoo/deepfm_functional_api/deepfm_functional_api.py
+++ b/model_zoo/deepfm_functional_api/deepfm_functional_api.py
@@ -71,8 +71,8 @@ def custom_model(
     return m
 
 
-def loss(output, labels):
-    logits = output["logits"]
+def loss(labels, predictions):
+    logits = predictions["logits"]
     labels = tf.cast(tf.reshape(labels, [-1]), tf.dtypes.float32)
     logits = tf.reshape(logits, [-1])
     return tf.reduce_mean(

--- a/model_zoo/mnist_functional_api/mnist_functional_api.py
+++ b/model_zoo/mnist_functional_api/mnist_functional_api.py
@@ -41,11 +41,11 @@ def prepare_data_for_a_single_file(file_object, filename):
     return example.SerializeToString()
 
 
-def loss(output, labels):
+def loss(labels, predictions):
     labels = tf.reshape(labels, [-1])
     return tf.reduce_mean(
         input_tensor=tf.nn.sparse_softmax_cross_entropy_with_logits(
-            logits=output, labels=labels
+            logits=predictions, labels=labels
         )
     )
 

--- a/model_zoo/mnist_subclass/mnist_subclass.py
+++ b/model_zoo/mnist_subclass/mnist_subclass.py
@@ -35,11 +35,11 @@ class CustomModel(tf.keras.Model):
         return x
 
 
-def loss(output, labels):
+def loss(labels, predictions):
     labels = tf.reshape(labels, [-1])
     return tf.reduce_mean(
         input_tensor=tf.nn.sparse_softmax_cross_entropy_with_logits(
-            logits=output, labels=labels
+            logits=predictions, labels=labels
         )
     )
 

--- a/model_zoo/odps_iris_dnn_model/odps_iris_dnn_model.py
+++ b/model_zoo/odps_iris_dnn_model/odps_iris_dnn_model.py
@@ -10,10 +10,10 @@ def custom_model():
     return tf.keras.Model(inputs=inputs, outputs=outputs, name="simple-model")
 
 
-def loss(output, labels):
+def loss(labels, predictions):
     return tf.reduce_mean(
         tf.nn.sparse_softmax_cross_entropy_with_logits(
-            tf.cast(tf.reshape(labels, [-1]), tf.int32), output
+            tf.cast(tf.reshape(labels, [-1]), tf.int32), predictions
         )
     )
 

--- a/model_zoo/resnet50_subclass/resnet50_subclass.py
+++ b/model_zoo/resnet50_subclass/resnet50_subclass.py
@@ -156,11 +156,11 @@ class CustomModel(tf.keras.Model):
         return self._activation_2(x)
 
 
-def loss(output, labels):
+def loss(labels, predictions):
     labels = tf.reshape(labels, [-1])
     return tf.reduce_mean(
         input_tensor=tf.keras.losses.sparse_categorical_crossentropy(
-            labels, output
+            labels, predictions
         )
     )
 


### PR DESCRIPTION
This addresses the third issue on `loss` in https://github.com/sql-machine-learning/elasticdl/issues/1476 to support loss functions from `tf.keras.losses`. Also added a test case.

cc: @typhoonzero 

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>