### PR TITLE
PS accepts gradients with version not smaller than its version when sync-sgd.

### DIFF
--- a/elasticdl/python/ps/servicer.py
+++ b/elasticdl/python/ps/servicer.py
@@ -116,7 +116,7 @@ class PserverServicer(elasticdl_pb2_grpc.PserverServicer):
             res.model_version = self._parameters.version
             return res
         else:
-            if request.model_version != self._parameters.version:
+            if request.model_version < self._parameters.version:
                 res.accepted = False
                 res.model_version = self._parameters.version
                 return res


### PR DESCRIPTION
This will prevent PS getting stuck when the model version mismatches in #1500.

Distributed PS may still have different versions though.

