### PR TITLE
remove ps pod grpc channel workaround in worker

### DIFF
--- a/elasticdl/python/worker/main.py
+++ b/elasticdl/python/worker/main.py
@@ -1,7 +1,4 @@
-import time
-
 import grpc
-from kubernetes import client, config
 
 from elasticdl.python.common import log_utils
 from elasticdl.python.common.args import parse_worker_args
@@ -21,25 +18,8 @@ def main():
 
     ps_channels = []
     if args.ps_addrs:
-        # TODO: use ps_addrs from master directly after ps service is working.
-        #       Get ps pod ip for ps grpc connection for now.
         ps_addrs = args.ps_addrs.split(",")
-
-        config.load_incluster_config()
-        api = client.CoreV1Api()
-
         for addr in ps_addrs:
-            # addr is in the form as "ps-pod-name.namespace.svc:port"
-            addr_splitted = addr.split(".")
-            while True:
-                pod = api.read_namespaced_pod(
-                    namespace=addr_splitted[1], name=addr_splitted[0]
-                )
-                if pod.status.pod_ip:
-                    break
-                # If ps pod is not ready yet, sleep 2 seconds and try again.
-                time.sleep(2)
-            addr = pod.status.pod_ip + ":" + addr.split(":")[-1]
             channel = grpc.insecure_channel(
                 addr,
                 options=[
@@ -56,10 +36,7 @@ def main():
 
             # Wait the channel is ready by a Future object.
             grpc.channel_ready_future(channel).result()
-            logger.info(
-                "grpc channel %s to connect pod %s is ready"
-                % (addr, pod.metadata.name)
-            )
+            logger.info("grpc channel to %s is ready" % addr)
             ps_channels.append(channel)
 
     worker = Worker(args, channel=master_channel, ps_channels=ps_channels)


### PR DESCRIPTION
With the new sigma.py, PS service domain name is working for workers to create grpc channels. 

This is the last PR to fix #1365 