### PR TITLE
remove version constraint when doing evaluation

### DIFF
--- a/elasticdl/proto/elasticdl.proto
+++ b/elasticdl/proto/elasticdl.proto
@@ -100,18 +100,9 @@ message ReportTaskResultRequest {
     map<string, int32> exec_counters = 3;
 }
 
-message ReportEvaluationMetricsResponse {
-    // If the evaluation metric is accepted.
-    bool accepted = 1;
-    // Current model version on master.
-    int32 model_version = 2;
-}
-
 message ReportEvaluationMetricsRequest {
-    // Model version used to compute evaluation metrics.
-    int32 model_version = 1;
-    repeated Tensor model_outputs = 2;
-    Tensor labels = 3;
+    repeated Tensor model_outputs = 1;
+    Tensor labels = 2;
 }
 
 message ReportVersionRequest {
@@ -120,7 +111,7 @@ message ReportVersionRequest {
 
 service Master {
     rpc GetTask(GetTaskRequest) returns (Task);
-    rpc ReportEvaluationMetrics(ReportEvaluationMetricsRequest) returns (ReportEvaluationMetricsResponse);
+    rpc ReportEvaluationMetrics(ReportEvaluationMetricsRequest) returns (google.protobuf.Empty);
     rpc ReportTaskResult(ReportTaskResultRequest) returns (google.protobuf.Empty);
     rpc ReportVersion(ReportVersionRequest) returns (google.protobuf.Empty);
 }

--- a/elasticdl/python/master/servicer.py
+++ b/elasticdl/python/master/servicer.py
@@ -71,13 +71,10 @@ class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
         return empty_pb2.Empty()
 
     def ReportEvaluationMetrics(self, request, _):
-        report_metrics = self._evaluation_service.report_evaluation_metrics(
-            request.model_version, request.model_outputs, request.labels
+        self._evaluation_service.report_evaluation_metrics(
+            request.model_outputs, request.labels
         )
-        res = elasticdl_pb2.ReportEvaluationMetricsResponse()
-        res.model_version = self._version
-        res.accepted = report_metrics
-        return res
+        return empty_pb2.Empty()
 
     def ReportVersion(self, request, _):
         if self._evaluation_service:

--- a/elasticdl/python/master/servicer.py
+++ b/elasticdl/python/master/servicer.py
@@ -77,6 +77,7 @@ class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
         return empty_pb2.Empty()
 
     def ReportVersion(self, request, _):
+        self._version = request.model_version
         if self._evaluation_service:
             self._evaluation_service.add_evaluation_task_if_needed(
                 master_locking=False, model_version=request.model_version

--- a/elasticdl/python/tests/evaluation_service_test.py
+++ b/elasticdl/python/tests/evaluation_service_test.py
@@ -57,30 +57,9 @@ class EvaluationServiceTest(unittest.TestCase):
         latest_chkp_version = job.model_version + 1
         self.assertTrue(self.ok_to_new_job(job, latest_chkp_version))
 
-        # Start to report metrics
-        evaluation_version = job.model_version + 1
-        model_outputs = [
-            Tensor(
-                np.array([[1], [6], [3]], np.float32),
-                name=MetricsDictKey.MODEL_OUTPUT,
-            ).to_tensor_pb()
-        ]
-        labels = Tensor(np.array([[1], [0], [3]], np.float32)).to_tensor_pb()
-        self.assertFalse(
-            job.report_evaluation_metrics(
-                evaluation_version, model_outputs, labels
-            )
-        )
-        evaluation_version = job.model_version
-        self.assertTrue(
-            job.report_evaluation_metrics(
-                evaluation_version, model_outputs, labels
-            )
-        )
         # One more
         self.assertTrue(
             job.report_evaluation_metrics(
-                evaluation_version,
                 [
                     Tensor(
                         np.array([[4], [5], [6], [7], [8]], np.float32),
@@ -114,19 +93,6 @@ class EvaluationServiceTest(unittest.TestCase):
         # Evaluation metrics will not be accepted if no evaluation ongoing
         evaluation_service = EvaluationService(
             None, task_d, 10, 20, 0, False, _eval_metrics_fn,
-        )
-        model_outputs = [
-            Tensor(
-                np.array([1, 6, 3], np.float32),
-                name=MetricsDictKey.MODEL_OUTPUT,
-            ).to_tensor_pb()
-        ]
-        labels = Tensor(np.array([1, 0, 3], np.float32)).to_tensor_pb()
-
-        self.assertFalse(
-            evaluation_service.report_evaluation_metrics(
-                1, model_outputs, labels
-            )
         )
 
         _ = MasterServicer(2, task_d, evaluation_service=evaluation_service,)

--- a/elasticdl/python/tests/evaluation_service_test.py
+++ b/elasticdl/python/tests/evaluation_service_test.py
@@ -57,19 +57,24 @@ class EvaluationServiceTest(unittest.TestCase):
         latest_chkp_version = job.model_version + 1
         self.assertTrue(self.ok_to_new_job(job, latest_chkp_version))
 
-        # One more
-        self.assertTrue(
-            job.report_evaluation_metrics(
-                [
-                    Tensor(
-                        np.array([[4], [5], [6], [7], [8]], np.float32),
-                        name=MetricsDictKey.MODEL_OUTPUT,
-                    ).to_tensor_pb()
-                ],
+        model_outputs = [
+            Tensor(
+                np.array([[1], [6], [3]], np.float32),
+                name=MetricsDictKey.MODEL_OUTPUT,
+            ).to_tensor_pb()
+        ]
+        labels = Tensor(np.array([[1], [0], [3]], np.float32)).to_tensor_pb()
+        job.report_evaluation_metrics(model_outputs, labels)
+        job.report_evaluation_metrics(
+            [
                 Tensor(
-                    np.array([[7], [8], [9], [10], [11]], np.float32)
-                ).to_tensor_pb(),
-            )
+                    np.array([[4], [5], [6], [7], [8]], np.float32),
+                    name=MetricsDictKey.MODEL_OUTPUT,
+                ).to_tensor_pb()
+            ],
+            Tensor(
+                np.array([[7], [8], [9], [10], [11]], np.float32)
+            ).to_tensor_pb(),
         )
         expected_acc = 0.25
         evaluation_metrics = job.get_evaluation_summary()


### PR DESCRIPTION
Currently, the evaluation of different workers is not strictly consistent. The model version of master is meaningless now. We should remove the version constraint. 

Otherwise, it will cause worker failure when reporting metrics results.