### PR TITLE
Remove redis related dependencies

### DIFF
--- a/elasticdl/docker/Dockerfile
+++ b/elasticdl/docker/Dockerfile
@@ -8,11 +8,6 @@ RUN chmod a+rwx /etc/bash.bashrc
 
 RUN apt-get update && apt-get install -y unzip curl git software-properties-common
 
-# Install redis 5.0.5
-RUN add-apt-repository ppa:chris-lea/redis-server -y \
-    && apt-get update \
-    && apt-get install -y redis-server
-
 COPY elasticdl/requirements.txt /requirements.txt
 ARG EXTRA_PYPI_INDEX=https://pypi.org/simple
 RUN pip install -r /requirements.txt --extra-index-url=${EXTRA_PYPI_INDEX}

--- a/elasticdl/docker/Dockerfile.dev
+++ b/elasticdl/docker/Dockerfile.dev
@@ -8,11 +8,6 @@ RUN chmod a+rwx /etc/bash.bashrc
 
 RUN apt-get update && apt-get install -y unzip curl git software-properties-common
 
-# Install redis 5.0.5
-RUN add-apt-repository ppa:chris-lea/redis-server -y \
-    && apt-get update \
-    && apt-get install -y redis-server
-
 COPY elasticdl/requirements.txt /requirements.txt
 COPY elasticdl/requirements-dev.txt /requirements-dev.txt
 ARG EXTRA_PYPI_INDEX=https://pypi.org/simple

--- a/elasticdl/requirements.txt
+++ b/elasticdl/requirements.txt
@@ -3,4 +3,3 @@ kubernetes
 docker
 pyrecordio>=0.0.6
 odps
-redis-py-cluster


### PR DESCRIPTION
Searched around and I don't think redis is being used anywhere now so it's safe to remove the related dependencies.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>