### PR TITLE
Initial version of elasticdl customized embedding column

### DIFF
--- a/elasticdl/python/elasticdl/__init__.py
+++ b/elasticdl/python/elasticdl/__init__.py
@@ -1,1 +1,2 @@
 from elasticdl.python.elasticdl import layers  # noqa: F401
+from elasticdl.python.elasticdl import feature_column

--- a/elasticdl/python/elasticdl/__init__.py
+++ b/elasticdl/python/elasticdl/__init__.py
@@ -1,2 +1,1 @@
 from elasticdl.python.elasticdl import layers  # noqa: F401
-from elasticdl.python.elasticdl import feature_column

--- a/elasticdl/python/elasticdl/feature_column/feature_column.py
+++ b/elasticdl/python/elasticdl/feature_column/feature_column.py
@@ -1,10 +1,10 @@
 import collections
 import math
-import numpy as np
+
 import tensorflow as tf
 from tensorflow.python.feature_column import feature_column as fc_old
 from tensorflow.python.feature_column import feature_column_v2 as fc_lib
-from tensorflow.python.framework import ops, tensor_shape
+from tensorflow.python.framework import tensor_shape
 from tensorflow.python.ops import init_ops
 
 
@@ -101,7 +101,8 @@ class EmbeddingColumn(
         ):
             raise ValueError(
                 "In embedding_column: {}. "
-                "categorical_column must not be of type SequenceCategoricalColumn. "
+                "categorical_column must not be of "
+                "type SequenceCategoricalColumn. "
                 "Suggested fix A: If you wish to use DenseFeatures, use a "
                 "non-sequence categorical_column_with_*. "
                 "Suggested fix B: If you wish to create sequence input, use "

--- a/elasticdl/python/elasticdl/feature_column/feature_column.py
+++ b/elasticdl/python/elasticdl/feature_column/feature_column.py
@@ -1,6 +1,5 @@
 import collections
 import math
-
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.feature_column import feature_column as fc_old

--- a/elasticdl/python/elasticdl/feature_column/feature_column.py
+++ b/elasticdl/python/elasticdl/feature_column/feature_column.py
@@ -20,7 +20,7 @@ def embedding_column(
     Create a customized EmbeddingColumn for ElasticDL.
     The native EmbeddingColumn will create a variable to
     store the entire embedding table. It can't leverage the
-    benifit from the ElasticDL parameter server to partition
+    benefit from the ElasticDL parameter server to partition
     the embedding table. Create this ElasticDL EmbeddingColumn
     to interact with ElasticDL parameter server.
     The API signature is based on the native

--- a/elasticdl/python/elasticdl/feature_column/feature_column.py
+++ b/elasticdl/python/elasticdl/feature_column/feature_column.py
@@ -1,0 +1,156 @@
+import collections
+import math
+
+import numpy as np
+import tensorflow as tf
+from tensorflow.python.feature_column import feature_column as fc_old
+from tensorflow.python.feature_column import feature_column_v2 as fc_lib
+from tensorflow.python.framework import ops, tensor_shape
+from tensorflow.python.ops import init_ops
+
+
+def embedding_column(
+    categorical_column,
+    dimension,
+    combiner="mean",
+    initializer=None,
+    ckpt_to_load_from=None,
+    tensor_name_in_ckpt=None,
+    max_norm=None,
+    trainable=True,
+):
+    if (dimension is None) or (dimension < 1):
+        raise ValueError("Invalid dimension {}.".format(dimension))
+    if (ckpt_to_load_from is None) != (tensor_name_in_ckpt is None):
+        raise ValueError(
+            "Must specify both `ckpt_to_load_from` and "
+            "`tensor_name_in_ckpt` or none of them."
+        )
+
+    if (initializer is not None) and (not callable(initializer)):
+        raise ValueError(
+            "initializer must be callable if specified. "
+            "Embedding of column_name: {}".format(categorical_column.name)
+        )
+    if initializer is None:
+        initializer = init_ops.truncated_normal_initializer(
+            mean=0.0, stddev=1 / math.sqrt(dimension)
+        )
+
+    return EmbeddingColumn(
+        categorical_column=categorical_column,
+        dimension=dimension,
+        combiner=combiner,
+        initializer=initializer,
+        ckpt_to_load_from=ckpt_to_load_from,
+        tensor_name_in_ckpt=tensor_name_in_ckpt,
+        max_norm=max_norm,
+        trainable=trainable,
+    )
+
+
+class EmbeddingColumn(
+    fc_lib.DenseColumn,
+    fc_lib.SequenceDenseColumn,
+    fc_old._DenseColumn,
+    fc_old._SequenceDenseColumn,
+    collections.namedtuple(
+        "EmbeddingColumn",
+        (
+            "categorical_column",
+            "dimension",
+            "combiner",
+            "initializer",
+            "ckpt_to_load_from",
+            "tensor_name_in_ckpt",
+            "max_norm",
+            "trainable",
+        ),
+    ),
+):
+    def __init__(self, **kwargs):
+        self.tape = None
+
+    @property
+    def _is_v2_column(self):
+        return (
+            isinstance(self.categorical_column, fc_lib.FeatureColumn)
+            and self.categorical_column._is_v2_column
+        )
+
+    @property
+    def name(self):
+        """See `FeatureColumn` base class."""
+        return "{}_embedding_elasticdl".format(self.categorical_column.name)
+
+    @property
+    def parse_example_spec(self):
+        """See `FeatureColumn` base class."""
+        return self.categorical_column.parse_example_spec
+
+    @property
+    def variable_shape(self):
+        """See `DenseColumn` base class."""
+        return tensor_shape.TensorShape([self.dimension])
+
+    def create_state(self, state_manager):
+        pass
+
+    def get_dense_tensor(self, transformation_cache, state_manager):
+        if isinstance(
+            self.categorical_column, fc_lib.SequenceCategoricalColumn
+        ):
+            raise ValueError(
+                "In embedding_column: {}. "
+                "categorical_column must not be of type SequenceCategoricalColumn. "
+                "Suggested fix A: If you wish to use DenseFeatures, use a "
+                "non-sequence categorical_column_with_*. "
+                "Suggested fix B: If you wish to create sequence input, use "
+                "SequenceFeatures instead of DenseFeatures. "
+                "Given (type {}): {}".format(
+                    self.name,
+                    type(self.categorical_column),
+                    self.categorical_column,
+                )
+            )
+        # Get sparse IDs and weights.
+        sparse_tensors = self.categorical_column.get_sparse_tensors(
+            transformation_cache, state_manager
+        )
+
+        # Look up the embedding from the sparse input
+        sparse_ids = sparse_tensors.id_tensor
+        unique_ids, idx = tf.unique(sparse_ids.values)
+
+        batch_embedding = tf.py_function(
+            self.lookup_embedding, inp=[unique_ids], Tout=tf.float32
+        )
+
+        segment_ids = sparse_ids.indices[:, 0]
+        if segment_ids.dtype != tf.int32:
+            segment_ids = tf.cast(segment_ids, tf.int32)
+
+        # TODO(brightcoder01): Add combine with sparse_weights
+        if self.combiner == "sum":
+            batch_embedding = tf.sparse.segment_sum(
+                batch_embedding, idx, segment_ids
+            )
+        elif self.combiner == "mean":
+            batch_embedding = tf.sparse.segment_mean(
+                batch_embedding, idx, segment_ids
+            )
+        elif self.combiner == "sqrtn":
+            batch_embedding = tf.sparse.segment_sqrt_n(
+                batch_embedding, idx, segment_ids
+            )
+
+        return batch_embedding
+
+    def lookup_embedding(self, unique_ids):
+        raise Exception("Not implemented yet")
+
+    def set_tape(self, tape):
+        self.tape = tape
+
+    def reset(self):
+        self.tape = None

--- a/elasticdl/python/elasticdl/feature_column/feature_column.py
+++ b/elasticdl/python/elasticdl/feature_column/feature_column.py
@@ -120,8 +120,8 @@ class EmbeddingColumn(
 
         # Look up the embedding from the sparse input
         sparse_ids = sparse_tensors.id_tensor
-        unique_ids, idx = tf.unique(sparse_ids.values)
 
+        unique_ids, idx = tf.unique(sparse_ids.values)
         batch_embedding = tf.py_function(
             self.lookup_embedding, inp=[unique_ids], Tout=tf.float32
         )

--- a/elasticdl/python/tests/feature_column_test.py
+++ b/elasticdl/python/tests/feature_column_test.py
@@ -29,8 +29,10 @@ class EmbeddingColumnTest(unittest.TestCase):
             ),
             dimension=dimension,
         )
-        item_id_embedding.lookup_embedding = lambda unique_ids: generate_mock_embedding_vectors(
-            unique_ids, item_id_embedding.dimension
+        item_id_embedding.lookup_embedding = lambda unique_ids: (
+            generate_mock_embedding_vectors(
+                unique_ids, item_id_embedding.dimension
+            )
         )
 
         output = call_feature_columns(

--- a/elasticdl/python/tests/feature_column_test.py
+++ b/elasticdl/python/tests/feature_column_test.py
@@ -3,9 +3,7 @@ import unittest
 import numpy as np
 import tensorflow as tf
 
-from elasticdl.python.elasticdl.feature_column import (
-    feature_column as edl_feature_column,
-)
+from elasticdl.python.elasticdl.feature_column import feature_column
 
 
 def call_feature_columns(feature_columns, input):
@@ -23,7 +21,7 @@ class EmbeddingColumnTest(unittest.TestCase):
     def test_feature_column_call(self):
         dimension = 32
 
-        item_id_embedding = edl_feature_column.embedding_column(
+        item_id_embedding = feature_column.embedding_column(
             tf.feature_column.categorical_column_with_identity(
                 "item_id", num_buckets=128
             ),

--- a/elasticdl/python/tests/feature_column_test.py
+++ b/elasticdl/python/tests/feature_column_test.py
@@ -1,0 +1,48 @@
+import unittest
+
+import numpy as np
+import tensorflow as tf
+
+from elasticdl.python.elasticdl.feature_column import (
+    feature_column as edl_feature_column,
+)
+
+
+def call_feature_columns(feature_columns, input):
+    dense_features = tf.keras.layers.DenseFeatures(feature_columns)
+    return dense_features(input)
+
+
+def generate_mock_embedding_vectors(ids, dimension):
+    return np.array(
+        [np.array([id] * dimension, dtype=np.float32) for id in ids]
+    )
+
+
+class EmbeddingColumnTest(unittest.TestCase):
+    def test_feature_column_call(self):
+        dimension = 32
+
+        item_id_embedding = edl_feature_column.embedding_column(
+            tf.feature_column.categorical_column_with_identity(
+                "item_id", num_buckets=128
+            ),
+            dimension=dimension,
+        )
+        item_id_embedding.lookup_embedding = lambda unique_ids: generate_mock_embedding_vectors(
+            unique_ids, item_id_embedding.dimension
+        )
+
+        output = call_feature_columns(
+            [item_id_embedding], {"item_id": [1, 2, 3]}
+        )
+        self.assertTrue(
+            (
+                output.numpy()
+                == generate_mock_embedding_vectors([1, 2, 3], dimension)
+            ).all()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
TensorFlow Native embedding_column contains a embedding variable to store the embedding table. It can't leverage the embedding table partition from ElasticDL parameter server.
We choose to customized an elasticdl embedding column. Its signature is the same with the native embedding column.