### PR TITLE
Dynamically update service addresses after worker/ps relaunch

### DIFF
--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -49,8 +49,8 @@ class InstanceManager(object):
         self._image_pull_policy = image_pull_policy
         self._envs = envs
         self._task_d = task_d
-        self._next_worker_id = itertools.count(num_workers).__next__
-        self._next_ps_id = itertools.count(num_ps).__next__
+        self._next_worker_id = itertools.count().__next__
+        self._next_ps_id = itertools.count().__next__
 
         # Protects followed variables, which are accessed from event_cb.
         self._lock = threading.Lock()
@@ -151,8 +151,8 @@ class InstanceManager(object):
             self._start_worker(self._next_worker_id())
 
     def start_all_ps(self):
-        for i in range(self._num_ps):
-            self._start_ps(i)
+        for _ in range(self._num_ps):
+            self._start_ps(self._next_worker_id())
 
     def _remove_worker(self, worker_id):
         logger.info("Removing worker: %d", worker_id)

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -150,9 +150,9 @@ class InstanceManager(object):
         for _ in range(self._num_workers):
             self._start_worker(self._next_worker_id())
 
-    def start_all_ps(self):
+    def start_parameter_servers(self):
         for _ in range(self._num_ps):
-            self._start_ps(self._next_worker_id())
+            self._start_ps(self._next_ps_id())
 
     def _remove_worker(self, worker_id):
         logger.info("Removing worker: %d", worker_id)

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -5,6 +5,8 @@ from collections import Counter
 from elasticdl.python.common import k8s_client as k8s
 from elasticdl.python.common.log_utils import default_logger as logger
 
+_SERVICE_ADDR_SEP = ","
+
 
 class InstanceManager(object):
     def __init__(
@@ -47,7 +49,8 @@ class InstanceManager(object):
         self._image_pull_policy = image_pull_policy
         self._envs = envs
         self._task_d = task_d
-        self._next_worker_id = itertools.count().__next__
+        self._next_worker_id = itertools.count(num_workers).__next__
+        self._next_ps_id = itertools.count(num_ps).__next__
 
         # Protects followed variables, which are accessed from event_cb.
         self._lock = threading.Lock()
@@ -71,10 +74,14 @@ class InstanceManager(object):
         self._relaunch_deleted_live_ps = True
 
         self._k8s_client = k8s.Client(event_callback=self._event_cb, **kwargs)
-        self._ps_addrs = self._get_ps_addrs()
+        self._ps_addrs = self._get_addrs(
+            self._num_ps, self._k8s_client.get_ps_service_address
+        )
         # TODO: Select a worker address to be used for broadcasting model
         # parameters under allreduce-strategy.
-        self._worker_addrs = self._get_worker_addrs()
+        self._worker_addrs = self._get_addrs(
+            self._num_workers, self._k8s_client.get_worker_service_address
+        )
 
     def _start_worker(self, worker_id):
         logger.info("Starting worker: %d" % worker_id)
@@ -119,19 +126,19 @@ class InstanceManager(object):
             self._ps_pods_phase[ps_id] = (name, None)
             self._k8s_client.create_ps_service(ps_id)
 
-    def _get_ps_addrs(self):
+    def _get_addrs(self, num_addrs, addr_get_fn):
         addrs = []
-        for ps_id in range(self._num_ps):
-            addrs.append(self._k8s_client.get_ps_service_address(ps_id))
-        return ",".join(addrs)
+        for addr_id in range(num_addrs):
+            addrs.append(addr_get_fn(addr_id))
+        return _SERVICE_ADDR_SEP.join(addrs)
 
-    def _get_worker_addrs(self):
-        addrs = []
-        for worker_id in range(self._num_workers):
-            addrs.append(
-                self._k8s_client.get_worker_service_address(worker_id)
-            )
-        return ",".join(addrs)
+    @staticmethod
+    def _update_addr(old_addr, new_addr, addrs, addr_get_fn):
+        addrs_list = addrs.split(_SERVICE_ADDR_SEP)
+        addrs_list[addrs_list.index(addr_get_fn(old_addr))] = addr_get_fn(
+            new_addr
+        )
+        return _SERVICE_ADDR_SEP.join(addrs_list)
 
     def update_status(self, status):
         master_name = self._k8s_client.get_master_pod_name()
@@ -208,7 +215,8 @@ class InstanceManager(object):
 
         relaunch_worker = False
         relaunch_ps = False
-        ps_id = -1
+        worker_id = None
+        ps_id = None
         with self._lock:
             if pod_name in self._worker_pod_name_to_id:
                 worker_id = self._worker_pod_name_to_id.get(pod_name)
@@ -232,15 +240,29 @@ class InstanceManager(object):
                     del self._ps_pod_name_to_id[pod_name]
                     relaunch_ps = self._relaunch_deleted_live_ps
             else:
-                logger.error("Unknown worker pod name: %s" % pod_name)
+                logger.error("Unknown pod name: %s" % pod_name)
                 return
 
-        if relaunch_worker:
+        if relaunch_worker and worker_id:
             logger.info("Relaunching worker.")
-            self._start_worker(self._next_worker_id())
-        elif relaunch_ps:
+            new_worker_id = self._next_worker_id()
+            self._start_worker(new_worker_id)
+            self._update_addr(
+                worker_id,
+                new_worker_id,
+                self._worker_addrs,
+                addr_get_fn=self._k8s_client.get_worker_service_address,
+            )
+        elif relaunch_ps and ps_id:
             logger.info("Relaunching ps.")
-            self._start_ps(ps_id)
+            new_ps_id = self._next_ps_id()
+            self._start_ps(new_ps_id)
+            self._update_addr(
+                ps_id,
+                new_ps_id,
+                self._ps_addrs,
+                addr_get_fn=self._k8s_client.get_ps_service_address,
+            )
 
     @property
     def ps_addrs(self):

--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -153,7 +153,7 @@ class Master(object):
         # Start the worker manager if requested
         if self.instance_manager:
             self.instance_manager.update_status(InstanceManagerStatus.PENDING)
-            self.instance_manager.start_all_ps()
+            self.instance_manager.start_parameter_servers()
             self.instance_manager.start_workers()
             self.instance_manager.update_status(InstanceManagerStatus.RUNNING)
 

--- a/elasticdl/python/tests/k8s_instance_manager_test.py
+++ b/elasticdl/python/tests/k8s_instance_manager_test.py
@@ -90,6 +90,7 @@ class InstanceManagerTest(unittest.TestCase):
         "No Kubernetes cluster available",
     )
     def testRelaunchWorkerPod(self):
+        num_workers = 3
         task_d = _TaskDispatcher({"f": (0, 10)}, {}, {}, 1, 1)
         instance_manager = InstanceManager(
             task_d,
@@ -99,7 +100,7 @@ class InstanceManagerTest(unittest.TestCase):
             worker_command=["sleep 10"],
             worker_args=[],
             namespace="default",
-            num_workers=3,
+            num_workers=num_workers,
         )
 
         instance_manager.start_workers()
@@ -130,7 +131,7 @@ class InstanceManagerTest(unittest.TestCase):
             time.sleep(1)
             with instance_manager._lock:
                 for k in instance_manager._worker_pods_phase:
-                    if k not in current_workers:
+                    if k not in range(num_workers, num_workers * 2):
                         found = True
         else:
             self.fail("Failed to find newly launched worker.")
@@ -142,6 +143,7 @@ class InstanceManagerTest(unittest.TestCase):
         "No Kubernetes cluster available",
     )
     def testRelaunchPsPod(self):
+        num_ps = 3
         instance_manager = InstanceManager(
             task_d=None,
             job_name="test-relaunch-ps-pod-%d-%d"
@@ -150,13 +152,13 @@ class InstanceManagerTest(unittest.TestCase):
             ps_command=["sleep 10"],
             ps_args=[],
             namespace="default",
-            num_ps=3,
+            num_ps=num_ps,
         )
 
         instance_manager.start_all_ps()
 
         # Check we also have ps services started
-        for i in range(3):
+        for i in range(num_ps):
             service = instance_manager._k8s_client.get_ps_service(i)
             self.assertTrue(service.metadata.owner_references)
             owner = service.metadata.owner_references[0]
@@ -193,7 +195,7 @@ class InstanceManagerTest(unittest.TestCase):
             time.sleep(1)
             with instance_manager._lock:
                 for k in instance_manager._ps_pods_phase:
-                    if k not in all_current_ps:
+                    if k not in range(num_ps, num_ps * 2):
                         found = True
         else:
             self.fail("Failed to find newly launched ps.")

--- a/elasticdl/python/tests/k8s_instance_manager_test.py
+++ b/elasticdl/python/tests/k8s_instance_manager_test.py
@@ -155,7 +155,7 @@ class InstanceManagerTest(unittest.TestCase):
             num_ps=num_ps,
         )
 
-        instance_manager.start_all_ps()
+        instance_manager.start_parameter_servers()
 
         # Check we also have ps services started
         for i in range(num_ps):


### PR DESCRIPTION
This solves the following issues:
* Currently the ps pod being relaunched uses the same id, which is problematic.
* The worker and ps addresses are not updated when a pod relaunches. Under allreduce strategy, we need to know the updated list of service addresses.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>