### PR TITLE
Fix pod env when `--envs` is used

### DIFF
--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -1,3 +1,4 @@
+import copy
 import itertools
 import threading
 from collections import Counter
@@ -99,7 +100,7 @@ class InstanceManager(object):
                 + ["--ps_addrs", self._ps_addrs],
                 restart_policy=self._restart_policy,
                 ps_addrs=self._ps_addrs,
-                envs=self._envs,
+                envs=copy.deepcopy(self._envs),
             )
             name = pod.metadata.name
             self._worker_pod_name_to_id[name] = worker_id
@@ -119,7 +120,7 @@ class InstanceManager(object):
                 command=self._ps_command,
                 args=self._ps_args + ["--ps_id", str(ps_id)],
                 restart_policy=self._restart_policy,
-                envs=self._envs,
+                envs=copy.deepcopy(self._envs),
             )
             name = pod.metadata.name
             self._ps_pod_name_to_id[name] = ps_id


### PR DESCRIPTION
When `--envs` is set, `InstanceManager` will have `self._envs` generated from the argument. `self._envs` may be modified by `cluster_spec` by adding env.

For example, PS pod does not use GPU, `cluster_spec` may add `NVIDIA_VISIBLE_DEVICES=""` env to `self._envs`. 
Then worker pods will have env `NVIDIA_VISIBLE_DEVICES=""`, and GPU cannot be used even worker pods request GPUs.

Use a copy of `self._envs` in pod launch to avoid this issue.
