### PR TITLE
Switch to use updated flags for mypy check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,4 @@ repos:
     rev: v0.701
     hooks:
     - id: mypy
-      args: [-s]
+      args: [--ignore-missing-imports, --follow-imports=skip]


### PR DESCRIPTION
This is to resolve the following warning:
`Warning: --silent-imports has been replaced by --ignore-missing-imports --follow-imports=skip`