### PR TITLE
Split labels and preds to small chunks and update metrics with those chunks

### DIFF
--- a/elasticdl/python/master/evaluation_service.py
+++ b/elasticdl/python/master/evaluation_service.py
@@ -111,9 +111,7 @@ class _EvaluationJob(object):
         with those small chunks. The [issue 35044](https://github.com/
         tensorflow/tensorflow/issues/35044) has been submitted to tensorflow.
         """
-        chunk_boundaries = np.asarray(
-            range(0, len(labels), chunk_length)
-        )
+        chunk_boundaries = np.asarray(range(0, len(labels), chunk_length))
         label_chunks = np.array_split(labels, chunk_boundaries)
         output_chunks = np.array_split(outputs, chunk_boundaries)
         for label, output in zip(label_chunks, output_chunks):

--- a/elasticdl/python/master/evaluation_service.py
+++ b/elasticdl/python/master/evaluation_service.py
@@ -105,7 +105,7 @@ class _EvaluationJob(object):
     def _update_metric_by_small_chunk(
         metric, labels, outputs, chunk_length=500
     ):
-        """The metric updates state in a thread launched grpc. The memory will
+        """The metric updates state in a thread launched by grpc. The memory will
         increase greatly if we update the metric with large size outputs. So
         we split the outputs and labels to small chunks then update the metric
         with those small chunks. The [issue 35044](https://github.com/

--- a/elasticdl/python/master/evaluation_service.py
+++ b/elasticdl/python/master/evaluation_service.py
@@ -78,7 +78,6 @@ class _EvaluationJob(object):
                 self._update_metric_by_small_chunk(
                     metric_inst, labels, outputs
                 )
-                # metric_inst.update_state(labels, outputs)
 
     def get_evaluation_summary(self):
         if self._model_have_multiple_outputs:

--- a/elasticdl/python/tests/evaluation_service_test.py
+++ b/elasticdl/python/tests/evaluation_service_test.py
@@ -179,6 +179,20 @@ class EvaluationServiceTest(unittest.TestCase):
             evaluation_service._eval_checkpoint_versions, [20, 30]
         )
 
+    def test_update_metric_by_small_chunks(self):
+        labels = np.random.randint(0, 2, 1234)
+        preds = np.random.random(1234)
+        auc = tf.keras.metrics.AUC()
+        auc.update_state(labels, preds)
+        auc_value_0 = auc.result()
+
+        auc.reset_states()
+        _EvaluationJob._update_metric_by_small_chunk(
+            auc, labels, preds
+        )
+        auc_value_1 = auc.result()
+        self.assertEquals(auc_value_0, auc_value_1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/elasticdl/python/tests/evaluation_service_test.py
+++ b/elasticdl/python/tests/evaluation_service_test.py
@@ -187,9 +187,7 @@ class EvaluationServiceTest(unittest.TestCase):
         auc_value_0 = auc.result()
 
         auc.reset_states()
-        _EvaluationJob._update_metric_by_small_chunk(
-            auc, labels, preds
-        )
+        _EvaluationJob._update_metric_by_small_chunk(auc, labels, preds)
         auc_value_1 = auc.result()
         self.assertEquals(auc_value_0, auc_value_1)
 


### PR DESCRIPTION
The metric updates state in a thread launched grpc. The memory will increase greatly if we update the metric with a large size of predictions and labels. So we split the predictions and labels to small chunks then update the metric with those small chunks. The [issue 35044](https://github.com/tensorflow/tensorflow/issues/35044) has been submitted to tensorflow.