### PR TITLE
Support learning rate scheduler

### DIFF
--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -458,6 +458,14 @@ def add_common_args_between_master_and_worker(parser):
         help="The name of the optimizer defined in the model file",
     )
     parser.add_argument(
+        "--learning_rate_scheduler",
+        type=str,
+        default="learning_rate_scheduler",
+        help="Optional callable learning rate scheduler defined in"
+        "the model file, which takes model version as its input and"
+        "returns a learning rate value",
+    )
+    parser.add_argument(
         "--eval_metrics_fn",
         type=str,
         default="eval_metrics_fn",

--- a/elasticdl/python/common/lr_scheduler.py
+++ b/elasticdl/python/common/lr_scheduler.py
@@ -1,0 +1,47 @@
+import threading
+
+
+class LearningRateScheduler:
+    def __init__(self, learning_rate=0.001, model_version=0):
+        """Constructs a `LearningRateScheduler` instance.
+        Args:
+            learning_rate: The learning rate to be modulated.
+                This can be either a numeric value or a callable.
+                If callable, it takes model_version as input.
+            model_version: the initial model version
+        """
+        self._learning_rate = learning_rate
+        self._tls = threading.local()
+        self._tls.model_version = model_version
+
+    def set_model_version(self, model_version):
+        """Sets the model version
+        Args:
+            model_version: the model version to set
+        """
+        self._tls.model_version = model_version
+
+    def get_learning_rate(self):
+        """Gets the current learning rate accordingn to scheduler..
+        Returns:
+            The learning rate modulated by the multiplier.
+        """
+        lr = self._learning_rate
+        if callable(lr):
+            lr = lr(self._tls.model_version)
+        return lr
+
+
+def add_lr_scheduler_to_optimizer(optimizer, lr_scheduler):
+    """Adds learning rate scheduler to the given optimizer.
+    Args:
+      optimizer: The optimizer to add learning rate scheduler to.
+      lr_scheduler: learning rate scheduler
+    Returns:
+      A `LearningRateScheduler` instance.
+    """
+    # Replace the learning rate in optimizer with a callable
+    lr_scheduler = LearningRateScheduler(lr_scheduler)
+    optimizer.learning_rate = lr_scheduler.get_learning_rate
+
+    return lr_scheduler

--- a/elasticdl/python/ps/servicer.py
+++ b/elasticdl/python/ps/servicer.py
@@ -20,7 +20,7 @@ class PserverServicer(elasticdl_pb2_grpc.PserverServicer):
         parameters,
         grads_to_wait,
         optimizer,
-        lr_scheduler,
+        lr_scheduler="",
         lr_staleness_modulation=False,
         use_async=False,
         evaluation_steps=0,

--- a/elasticdl/python/tests/lr_scheduler_test.py
+++ b/elasticdl/python/tests/lr_scheduler_test.py
@@ -1,0 +1,93 @@
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+
+import tensorflow as tf
+
+from elasticdl.python.common.lr_scheduler import add_lr_scheduler_to_optimizer
+
+
+def lr_scheduler_func(model_version):
+    if model_version < 1:
+        return 1
+    elif model_version < 2:
+        return 0.5
+    else:
+        return 0.1
+
+
+class LearningRateTest(unittest.TestCase):
+    @staticmethod
+    def get_lr(lr_scheduler, opt, model_version):
+        lr_scheduler.set_model_version(model_version)
+        # sleep 1s to wait that all threads are in this method call
+        time.sleep(1)
+        return opt.learning_rate
+
+    @staticmethod
+    def apply_gradients_with_scheduler(
+        lr_scheduler, opt, model_version, variables, grads
+    ):
+        grads_and_vars = zip(grads, variables)
+        lr_scheduler.set_model_version(model_version)
+        # sleep 1s to wait that all threads are in this method call
+        time.sleep(1)
+        opt.apply_gradients(grads_and_vars)
+        return [v.numpy() for v in variables]
+
+    def test_lr_scheduler(self):
+        opt = tf.optimizers.SGD(0.1)
+        lr_scheduler = add_lr_scheduler_to_optimizer(opt, lr_scheduler_func)
+
+        model_versions = [0, 1, 2]
+        counts = len(model_versions)
+        executor = ThreadPoolExecutor(max_workers=counts)
+        tasks = [
+            executor.submit(self.get_lr, lr_scheduler, opt, v)
+            for v in model_versions
+        ]
+        results = [tasks[i].result() for i in range(counts)]
+        for i in range(counts):
+            self.assertAlmostEqual(
+                results[i], lr_scheduler_func(model_versions[i])
+            )
+
+        variables = []
+        grads = []
+        original_values = [1.2, 0.8]
+        grad_values = [0.2, 0.1]
+
+        for i in range(counts):
+            variables.append([tf.Variable(v) for v in original_values])
+            grads.append([tf.convert_to_tensor(g) for g in grad_values])
+
+        tasks = [
+            executor.submit(
+                self.apply_gradients_with_scheduler,
+                lr_scheduler,
+                opt,
+                model_versions[i],
+                variables[i],
+                grads[i],
+            )
+            for i in range(counts)
+        ]
+        results = [tasks[i].result() for i in range(counts)]
+        place = 5
+        for i in range(0, counts):
+            i_diff = [
+                original_values[j] - results[i][j]
+                for j in range(len(original_values))
+            ]
+            for j in range(len(original_values)):
+                # variable value change ratio equals the learning rate ratio
+                # for SGD without momentum
+                self.assertAlmostEqual(
+                    i_diff[j],
+                    grad_values[j] * lr_scheduler_func(model_versions[i]),
+                    place,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/elasticdl/python/tests/pserver_servicer_test.py
+++ b/elasticdl/python/tests/pserver_servicer_test.py
@@ -53,6 +53,7 @@ class PserverServicerTest(unittest.TestCase):
     ):
         args = PserverArgs(
             grads_to_wait=grads_to_wait,
+            lr_scheduler="learning_rate_scheduler",
             lr_staleness_modulation=lr_staleness_modulation,
             use_async=use_async,
             port=self._port,
@@ -480,6 +481,7 @@ class PserverServicerTest(unittest.TestCase):
             model_zoo=_test_model_zoo_path,
             model_def="test_module.custom_model",
             checkpoint_dir_for_init=checkpoint_dir_for_init,
+            lr_scheduler="learning_rate_scheduler",
         )
         pserver_0 = ParameterServer(args)
 
@@ -507,6 +509,7 @@ class PserverServicerTest(unittest.TestCase):
             model_zoo=_test_model_zoo_path,
             model_def="test_module.custom_model",
             checkpoint_dir_for_init=checkpoint_dir_for_init,
+            lr_scheduler="learning_rate_scheduler",
         )
         pserver_1 = ParameterServer(args)
 

--- a/elasticdl/python/tests/test_utils.py
+++ b/elasticdl/python/tests/test_utils.py
@@ -37,6 +37,7 @@ class PserverArgs(object):
     def __init__(
         self,
         grads_to_wait=8,
+        lr_scheduler="learning_rate_scheduler",
         lr_staleness_modulation=0,
         use_async=False,
         model_zoo=None,
@@ -56,6 +57,7 @@ class PserverArgs(object):
         checkpoint_dir_for_init=None,
     ):
         self.grads_to_wait = grads_to_wait
+        self.learning_rate_scheduler = lr_scheduler
         self.lr_staleness_modulation = lr_staleness_modulation
         self.use_async = use_async
         self.model_zoo = model_zoo

--- a/model_zoo/cifar10_functional_api/cifar10_functional_api.py
+++ b/model_zoo/cifar10_functional_api/cifar10_functional_api.py
@@ -113,6 +113,7 @@ def loss(labels, predictions):
 def optimizer(lr=0.1):
     return tf.optimizers.SGD(lr)
 
+
 def learning_rate_scheduler(model_version):
     if model_version < 5000:
         return 0.1

--- a/model_zoo/cifar10_functional_api/cifar10_functional_api.py
+++ b/model_zoo/cifar10_functional_api/cifar10_functional_api.py
@@ -113,6 +113,14 @@ def loss(labels, predictions):
 def optimizer(lr=0.1):
     return tf.optimizers.SGD(lr)
 
+def learning_rate_scheduler(model_version):
+    if model_version < 5000:
+        return 0.1
+    elif model_version < 15000:
+        return 0.01
+    else:
+        return 0.001
+
 
 def dataset_fn(dataset, mode, _):
     def _parse_data(record):


### PR DESCRIPTION
The user can optionally provide a learning rate scheduler method, which takes a model version as its input,  and returns a corresponding learning rate value.