### PR TITLE
implement a parallel transform for data preprocessing

### DIFF
--- a/elasticdl/python/data/parallel_transform.py
+++ b/elasticdl/python/data/parallel_transform.py
@@ -1,0 +1,91 @@
+import itertools
+import os
+from multiprocessing import Process, Queue
+
+
+class ManagerWatchdog(object):
+    def __init__(self):
+        self.manager_pid = os.getppid()
+        self.manager_dead = False
+
+    def is_alive(self):
+        if not self.manager_dead:
+            self.manager_dead = os.getppid() != self.manager_pid
+        return not self.manager_dead
+
+
+def worker_loop(records, index_q, result_q, transform_fn):
+    watchdog = ManagerWatchdog()
+    while watchdog.is_alive():
+        index = index_q.get()
+        record = records[index]
+        res = transform_fn(record)
+        result_q.put((index, res))
+
+
+class ParallelTransform(object):
+    def __init__(self, records, num_workers, transform_fn):
+        self._records = records
+        self._num_workers = num_workers
+        self._transform_fn = transform_fn
+
+        self._result_queue = Queue()
+        self._index_queues = []
+        self._workers = []
+
+        self._worker_id_cycle = itertools.cycle(range(self._num_workers))
+        self._put_record_it = iter(range(len(self._records)))
+        self._get_record_it = iter(range(len(self._records)))
+        self._cache_dict = {}
+
+        for i in range(self._num_workers):
+            index_queue = Queue()
+            self._index_queues.append(index_queue)
+            p = Process(
+                target=worker_loop,
+                args=(
+                    self._records,
+                    self._index_queues[i],
+                    self._result_queue,
+                    self._transform_fn,
+                ),
+            )
+            p.daemon = True
+            p.start()
+            self._workers.append(p)
+
+        for i in range(2 * self._num_workers):
+            self._put_index()
+
+    def _next_index(self):
+        try:
+            idx = next(self._put_record_it)
+            return idx
+        except StopIteration:
+            return None
+
+    def _put_index(self):
+        worker_id = next(self._worker_id_cycle)
+        idx = self._next_index()
+        if idx is not None:
+            self._index_queues[worker_id].put(idx)
+
+    def next_data(self):
+        try:
+            index = next(self._get_record_it)
+        except StopIteration:
+            for w in self._workers:
+                w.join()
+            return None
+        while True:
+            data = self._cache_dict.pop(index, None)
+            if data:
+                self._put_index()
+                return data
+
+            data_id, data = self._result_queue.get()
+            if data_id == index:
+                self._put_index()
+                return data
+            else:
+                self._cache_dict[data_id] = data

--- a/elasticdl/python/tests/parallel_transform_test.py
+++ b/elasticdl/python/tests/parallel_transform_test.py
@@ -12,7 +12,7 @@ class ParallelTransformTest(unittest.TestCase):
 
         records = [k for k in range(100)]
         pt = ParallelTransform(
-            records=records, num_workers=2, transform_fn=transform
+            records=records, num_parallel_processes=2, transform_fn=transform
         )
         results = []
         while True:
@@ -31,7 +31,9 @@ class ParallelTransformTest(unittest.TestCase):
         def gen():
             records = [k for k in range(100)]
             pt = ParallelTransform(
-                records=records, num_workers=4, transform_fn=transform
+                records=records,
+                num_parallel_processes=4,
+                transform_fn=transform,
             )
             while True:
                 data = pt.next_data()

--- a/elasticdl/python/tests/parallel_transform_test.py
+++ b/elasticdl/python/tests/parallel_transform_test.py
@@ -1,0 +1,47 @@
+import unittest
+
+import tensorflow as tf
+
+from elasticdl.python.data.parallel_transform import ParallelTransform
+
+
+class ParallelTransformTest(unittest.TestCase):
+    def test_transform_int(self):
+        def transform(record):
+            return record + 1
+
+        records = [k for k in range(100)]
+        pt = ParallelTransform(
+            records=records, num_workers=2, transform_fn=transform
+        )
+        results = []
+        for i in range(len(records)):
+            results.append(pt.next_data())
+
+        expect_results = [k + 1 for k in range(100)]
+        self.assertListEqual(results, expect_results)
+
+    def test_create_tf_dataset(self):
+        def transform(record):
+            return record + 1
+
+        def gen():
+            records = [k for k in range(100)]
+            pt = ParallelTransform(
+                records=records, num_workers=4, transform_fn=transform
+            )
+            for i in range(100):
+                yield pt.next_data()
+
+        ds = tf.data.Dataset.from_generator(gen, tf.int64)
+        ds = ds.batch(10).prefetch(1)
+        results = []
+        for data in ds:
+            results.extend(data.numpy().tolist())
+
+        expect_results = [k + 1 for k in range(100)]
+        self.assertListEqual(results, expect_results)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/elasticdl/python/tests/parallel_transform_test.py
+++ b/elasticdl/python/tests/parallel_transform_test.py
@@ -15,8 +15,11 @@ class ParallelTransformTest(unittest.TestCase):
             records=records, num_workers=2, transform_fn=transform
         )
         results = []
-        for i in range(len(records)):
-            results.append(pt.next_data())
+        while True:
+            data = pt.next_data()
+            if data is None:
+                break
+            results.append(data)
 
         expect_results = [k + 1 for k in range(100)]
         self.assertListEqual(results, expect_results)
@@ -30,8 +33,11 @@ class ParallelTransformTest(unittest.TestCase):
             pt = ParallelTransform(
                 records=records, num_workers=4, transform_fn=transform
             )
-            for i in range(100):
-                yield pt.next_data()
+            while True:
+                data = pt.next_data()
+                if data is None:
+                    break
+                yield data
 
         ds = tf.data.Dataset.from_generator(gen, tf.int64)
         ds = ds.batch(10).prefetch(1)


### PR DESCRIPTION
Using py_function in `tf.data.Dataset` could not be parallelized due to "GIL" of Python Interpreter. For more details, please refer to this [issue](https://github.com/tensorflow/tensorflow/issues/15694#issuecomment-401857127) and [question](https://stackoverflow.com/questions/48484689/parallelism-isnt-reducing-the-time-in-dataset-map).

The implementation of ParallelTransform takes the [DataLoader](https://github.com/pytorch/pytorch/blob/master/torch/utils/data/dataloader.py) of PyTorch as a reference. It could parallelize the data transform process with low latency.