### PR TITLE
Sum up the values of the duplicated indices in the grads of the Index…

### DIFF
--- a/elasticdl/python/common/tensor_utils.py
+++ b/elasticdl/python/common/tensor_utils.py
@@ -6,3 +6,21 @@ def merge_indexed_slices(*args):
         tf.concat([i.values for i in args], axis=0),
         tf.concat([i.indices for i in args], axis=0),
     )
+
+
+def deduplicate_indexed_slices(values, indices):
+    """Sums `values` associated with any non-unique `indices`.
+    Args:
+        values: A `Tensor` with rank >= 1.
+        indices: A one-dimensional integer `Tensor`, indexing into the first
+        dimension of `values` (as in an IndexedSlices object).
+    Returns:
+        A tuple of (`summed_values`, `unique_indices`) where `unique_indices`
+        is a de-duplicated version of `indices` and `summed_values` contains
+        the sum of `values` slices associated with each unique index.
+    """
+    unique_indices, new_index_positions = tf.unique(indices)
+    summed_values = tf.unsorted_segment_sum(
+        values, new_index_positions, tf.shape(unique_indices)[0]
+    )
+    return (summed_values, unique_indices)

--- a/elasticdl/python/common/tensor_utils.py
+++ b/elasticdl/python/common/tensor_utils.py
@@ -20,7 +20,7 @@ def deduplicate_indexed_slices(values, indices):
         the sum of `values` slices associated with each unique index.
     """
     unique_indices, new_index_positions = tf.unique(indices)
-    summed_values = tf.unsorted_segment_sum(
+    summed_values = tf.math.unsorted_segment_sum(
         values, new_index_positions, tf.shape(unique_indices)[0]
     )
     return (summed_values, unique_indices)

--- a/elasticdl/python/common/tensor_utils.py
+++ b/elasticdl/python/common/tensor_utils.py
@@ -12,9 +12,10 @@ def deduplicate_indexed_slices(values, indices):
     """
     Sum up the values associated with duplicated indices in the IndexedSlices.
     Args:
-        values: A Tensor with rank >= 1. Particularly IndexedSlices.values.
-        indices: A one-dimension integer of Tensor. Particularly 
-        IndexedSlices.indices.
+        values: A Tensor with rank >= 1.
+            Such as IndexedSlices.values particularly.
+        indices: A one-dimension integer of Tensor.
+            Such as IndexedSlices.indices particularly.
     Returns:
         A tuple of (`sum_combined_values`, `unique_indices`).
         `sum_combined_values` contains the sum of `values` associated

--- a/elasticdl/python/common/tensor_utils.py
+++ b/elasticdl/python/common/tensor_utils.py
@@ -9,18 +9,21 @@ def merge_indexed_slices(*args):
 
 
 def deduplicate_indexed_slices(values, indices):
-    """Sums `values` associated with any non-unique `indices`.
+    """
+    Sum up the values associated with duplicated indices in the IndexedSlices.
     Args:
-        values: A `Tensor` with rank >= 1.
-        indices: A one-dimensional integer `Tensor`, indexing into the first
-        dimension of `values` (as in an IndexedSlices object).
+        values: A Tensor with rank >= 1. Particularly IndexedSlices.values.
+        indices: A one-dimension integer of Tensor. Particularly 
+        IndexedSlices.indices.
     Returns:
-        A tuple of (`summed_values`, `unique_indices`) where `unique_indices`
-        is a de-duplicated version of `indices` and `summed_values` contains
-        the sum of `values` slices associated with each unique index.
+        A tuple of (`sum_combined_values`, `unique_indices`).
+        `sum_combined_values` contains the sum of `values` associated
+        with each unique indice.
+        `unique_indices` is a de-duplicated version of `indices`.
     """
     unique_indices, new_index_positions = tf.unique(indices)
-    summed_values = tf.math.unsorted_segment_sum(
+    sum_combined_values = tf.math.unsorted_segment_sum(
         values, new_index_positions, tf.shape(unique_indices)[0]
     )
-    return (summed_values, unique_indices)
+
+    return (sum_combined_values, unique_indices)

--- a/elasticdl/python/common/tensor_utils.py
+++ b/elasticdl/python/common/tensor_utils.py
@@ -10,12 +10,11 @@ def merge_indexed_slices(*args):
 
 def deduplicate_indexed_slices(values, indices):
     """
-    Sum up the values associated with duplicated indices in the IndexedSlices.
+    Sum up the values associated with duplicated indices and
+    return unique indices with corresponding summed values.
     Args:
         values: A Tensor with rank >= 1.
-            Such as IndexedSlices.values particularly.
         indices: A one-dimension integer of Tensor.
-            Such as IndexedSlices.indices particularly.
     Returns:
         A tuple of (`sum_combined_values`, `unique_indices`).
         `sum_combined_values` contains the sum of `values` associated

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -36,6 +36,7 @@ from elasticdl.python.common.tensor import (
     serialize_tensor,
     tensor_pb_to_ndarray,
 )
+from elasticdl.python.common.tensor_utils import deduplicate_indexed_slices
 from elasticdl.python.common.timing_utils import Timing
 from elasticdl.python.elasticdl.feature_column import feature_column
 from elasticdl.python.elasticdl.layers.embedding import Embedding
@@ -477,6 +478,13 @@ class Worker(object):
                     else:
                         g_values = grad
                         g_indices = ids
+
+                # Sum up the values of the duplicated indices in the
+                # gradients. It can reduce the gradient payload of the
+                # dense embedding.
+                g_values, g_indices = deduplicate_indexed_slices(
+                    values=g_values, indices=g_indices
+                )
 
                 results = scatter_embedding_vector(
                     g_values.numpy(), g_indices.numpy(), len(self._ps_stubs)


### PR DESCRIPTION
For the dense embedding, the gradients from tape is IndexedSlices. If the input_idx of embedding is large, the gradients payload is (input_idx.size, embedding_dim), it will be large with many duplicated indices.
At the stage of sending gradients from worker to parameter server, the scatter and serialization of this payload will be time consuming. We choose to sum up the value of duplicated indices at the worker side. 
From the time profiling (1 Worker with 4 CPU, 1 PS), the time cost for collecting embedding variable and building PushGradientRequest reduce from 0.33 seconds to 0.08 seconds.
