### PR TITLE
add a local records queue in worker

### DIFF
--- a/elasticdl/proto/elasticdl.proto
+++ b/elasticdl/proto/elasticdl.proto
@@ -9,7 +9,7 @@ enum TaskType {
     TRAINING = 0;
     EVALUATION = 1;
     PREDICTION = 2;
-    WAIT = 3;
+    END = 3;
     SAVE_MODEL = 4;
 }
 

--- a/elasticdl/python/data/reader/data_reader.py
+++ b/elasticdl/python/data/reader/data_reader.py
@@ -23,6 +23,10 @@ class AbstractDataReader(ABC):
         pass
 
     def preprocess_records(self, records):
+        """This method does transformation to the input records. We could implement
+        some customized data preprocessing logic here. Then, the output records
+        will be used to create a `tf.data.Dataset` instance in further.
+        """
         return records
 
     @abstractmethod

--- a/elasticdl/python/data/reader/data_reader.py
+++ b/elasticdl/python/data/reader/data_reader.py
@@ -22,6 +22,9 @@ class AbstractDataReader(ABC):
         """
         pass
 
+    def preprocess_records(self, records):
+        return records
+
     @abstractmethod
     def create_shards(self):
         """This method creates the dictionary of shards where the keys

--- a/elasticdl/python/worker/task_data_service.py
+++ b/elasticdl/python/worker/task_data_service.py
@@ -113,13 +113,12 @@ class TaskDataService(object):
         """
         if not task:
             return None
-        tasks = [task]
 
         def gen():
-            for task in tasks:
-                for data in self.data_reader.read_records(task):
-                    if data:
-                        yield data
+            records = self.data_reader.read_records(task)
+            for data in self.data_reader.preprocess_records(records):
+                if data:
+                    yield data
 
         return gen
 

--- a/elasticdl/python/worker/task_data_service.py
+++ b/elasticdl/python/worker/task_data_service.py
@@ -164,6 +164,10 @@ class TaskDataService(object):
         )
         return ds
 
+    def finish(self):
+        self._get_records_thread.join()
+        self._get_records_thread = None
+
     def _get_records_fn(self):
         while True:
             # Make sure we also generate data from the warm-up task.

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -991,8 +991,7 @@ class Worker(object):
                 self._timing.report_timing(reset=True)
                 self._timing.start_record_time("task_process")
         del dataset
-        self._task_data_service._get_records_thread.join()
-        self._task_data_service._get_records_thread = None
+        self._task_data_service.finish()
         # New evaluation tasks may be created after this worker's
         # training tasks are done, as other workers' may still
         # have pending training tasks.

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -943,66 +943,63 @@ class Worker(object):
         local_update_count = self._get_model_steps
         last_training_minibatch_failed = False
         evaluation_task_executed = False
-        while True:
-            dataset = self._task_data_service.get_dataset()
-            if not dataset:
-                break
-            dataset = self._dataset_fn(
-                dataset,
-                Mode.TRAINING,
-                self._task_data_service.data_reader.metadata,
-            )
-            dataset = dataset.batch(self._minibatch_size).prefetch(1)
-            self._timing.start_record_time("task_process")
-            for dataset_batch in dataset:
-                if self._job_type == JobType.TRAINING_WITH_EVALUATION:
-                    # Give the worker a chance to process an evaluation task
-                    # during training if the task exists
-                    evaluation_task_executed = (
-                        True
-                        if self._evaluate_only()
-                        else evaluation_task_executed
-                    )
-
-                task = self._task_data_service.get_current_task()
-                if (
-                    evaluation_task_executed
-                    or last_training_minibatch_failed
-                    or local_update_count >= self._get_model_steps
-                ):
-                    local_update_count = 0
-                    train_with_local_model = False
-                else:
-                    train_with_local_model = True
-
-                err_msg = self._process_minibatch_and_report(
-                    dataset_batch,
-                    task.type,
-                    task.model_version,
-                    train_with_local_model,
+        dataset = self._task_data_service.get_dataset()
+        dataset = self._dataset_fn(
+            dataset,
+            Mode.TRAINING,
+            self._task_data_service.data_reader.metadata,
+        )
+        dataset = dataset.batch(self._minibatch_size).prefetch(1)
+        self._timing.start_record_time("task_process")
+        for dataset_batch in dataset:
+            if self._job_type == JobType.TRAINING_WITH_EVALUATION:
+                # Give the worker a chance to process an evaluation task
+                # during training if the task exists
+                evaluation_task_executed = (
+                    True if self._evaluate_only() else evaluation_task_executed
                 )
 
-                local_update_count += 1
-                if err_msg:
-                    last_training_minibatch_failed = True
-                else:
-                    last_training_minibatch_failed = False
-                    if local_update_count < self._get_model_steps:
-                        self._update_local_model()
-                if self._task_data_service.report_record_done(
-                    self._minibatch_size, err_msg
-                ):
-                    self._timing.end_record_time("task_process")
-                    self._timing.report_timing(reset=True)
-                    self._timing.start_record_time("task_process")
-            del dataset
-            # New evaluation tasks may be created after this worker's
-            # training tasks are done, as other workers' may still
-            # have pending training tasks.
-            if self._job_type == JobType.TRAINING_WITH_EVALUATION:
-                evaluation_task_executed = self._evaluate_only()
+            task = self._task_data_service.get_current_task()
+            if (
+                evaluation_task_executed
+                or last_training_minibatch_failed
+                or local_update_count >= self._get_model_steps
+            ):
+                local_update_count = 0
+                train_with_local_model = False
+            else:
+                train_with_local_model = True
 
-            self._process_save_model_task_if_needed()
+            err_msg = self._process_minibatch_and_report(
+                dataset_batch,
+                task.type,
+                task.model_version,
+                train_with_local_model,
+            )
+
+            local_update_count += 1
+            if err_msg:
+                last_training_minibatch_failed = True
+            else:
+                last_training_minibatch_failed = False
+                if local_update_count < self._get_model_steps:
+                    self._update_local_model()
+            if self._task_data_service.report_record_done(
+                self._minibatch_size, err_msg
+            ):
+                self._timing.end_record_time("task_process")
+                self._timing.report_timing(reset=True)
+                self._timing.start_record_time("task_process")
+        del dataset
+        self._task_data_service._get_records_thread.join()
+        self._task_data_service._get_records_thread = None
+        # New evaluation tasks may be created after this worker's
+        # training tasks are done, as other workers' may still
+        # have pending training tasks.
+        if self._job_type == JobType.TRAINING_WITH_EVALUATION:
+            evaluation_task_executed = self._evaluate_only()
+
+        self._process_save_model_task_if_needed()
 
     def _evaluate_only(self):
         """


### PR DESCRIPTION
There are three stages in a training job:
- get data from some data source
- preprocess data
- training data

Usually,  the data source is at a remote node and could be time consuming. For example, the data source could be an ODPS table in another cluster.

We want to make these three stages overlapped to maximize the throughput of the whole system. This PR creates a DoubleBuffer for getting data from ODPS stage. So it could overlap with the preprocessing data stage.

In an internal case, the PR saves about 15% time for the whole system.



- Before:


```
[2019-12-25 05:36:23,170] [INFO] [worker.py:1005:_train_and_evaluate] 40 total time 13.315297842025757 153.7411448955536
[2019-12-25 05:36:25,498] [INFO] [worker.py:1005:_train_and_evaluate] 41 total time 2.327730417251587 156.06887531280518
[2019-12-25 05:36:27,989] [INFO] [worker.py:1005:_train_and_evaluate] 42 total time 2.4908671379089355 158.5597424507141
[2019-12-25 05:36:30,564] [INFO] [worker.py:1005:_train_and_evaluate] 43 total time 2.5748515129089355 161.13459396362305
[2019-12-25 05:36:33,161] [INFO] [worker.py:1005:_train_and_evaluate] 44 total time 2.597399950027466 163.7319939136505
[2019-12-25 05:36:35,478] [INFO] [worker.py:1005:_train_and_evaluate] 45 total time 2.3167355060577393 166.04872941970825
[2019-12-25 05:36:38,039] [INFO] [worker.py:1005:_train_and_evaluate] 46 total time 2.560838460922241 168.6095678806305
[2019-12-25 05:36:40,456] [INFO] [worker.py:1005:_train_and_evaluate] 47 total time 2.4172215461730957 171.0267894268036
[2019-12-25 05:36:42,835] [INFO] [worker.py:1005:_train_and_evaluate] 48 total time 2.378854990005493 173.40564441680908
[2019-12-25 05:36:45,360] [INFO] [worker.py:1005:_train_and_evaluate] 49 total time 2.5253021717071533 175.93094658851624
[2019-12-25 05:36:47,719] [INFO] [worker.py:1005:_train_and_evaluate] 50 total time 2.358886957168579 178.28983354568481
[2019-12-25 05:36:50,158] [INFO] [worker.py:1005:_train_and_evaluate] 51 total time 2.439385414123535 180.72921895980835
[2019-12-25 05:36:52,775] [INFO] [worker.py:1005:_train_and_evaluate] 52 total time 2.6171317100524902 183.34635066986084
[2019-12-25 05:36:55,149] [INFO] [worker.py:1005:_train_and_evaluate] 53 total time 2.373945474624634 185.72029614448547
[2019-12-25 05:36:57,748] [INFO] [worker.py:1005:_train_and_evaluate] 54 total time 2.5991268157958984 188.31942296028137
[2019-12-25 05:37:00,258] [INFO] [worker.py:1005:_train_and_evaluate] 55 total time 2.509453296661377 190.82887625694275
[2019-12-25 05:37:02,730] [INFO] [worker.py:1005:_train_and_evaluate] 56 total time 2.471768617630005 193.30064487457275
[2019-12-25 05:37:05,230] [INFO] [worker.py:1005:_train_and_evaluate] 57 total time 2.50042724609375 195.8010721206665
[2019-12-25 05:37:07,528] [INFO] [worker.py:1005:_train_and_evaluate] 58 total time 2.2983503341674805 198.09942245483398
[2019-12-25 05:37:09,050] [DEBUG] [timing_utils.py:41:report_timing] task_process time is 59.1952 seconds
[2019-12-25 05:37:09,050] [DEBUG] [timing_utils.py:41:report_timing] batch_process time is 40.6943 seconds
[2019-12-25 05:37:09,050] [DEBUG] [timing_utils.py:41:report_timing] get_model time is 0.348275 seconds
[2019-12-25 05:37:09,050] [DEBUG] [timing_utils.py:41:report_timing] report_gradient time is 26.1337
```


- After:

```
2019-12-25 06:14:46,175] [INFO] [worker.py:1005:_train_and_evaluate] 40 total time 2.823925018310547 137.75708532333374
[2019-12-25 06:14:48,737] [INFO] [worker.py:1005:_train_and_evaluate] 41 total time 2.5618369579315186 140.31892228126526
[2019-12-25 06:14:52,237] [INFO] [worker.py:1005:_train_and_evaluate] 42 total time 3.500702381134033 143.8196246623993
[2019-12-25 06:14:55,439] [INFO] [worker.py:1005:_train_and_evaluate] 43 total time 3.2017669677734375 147.02139163017273
[2019-12-25 06:14:58,631] [INFO] [worker.py:1005:_train_and_evaluate] 44 total time 3.191495180130005 150.21288681030273
[2019-12-25 06:15:00,805] [INFO] [worker.py:1005:_train_and_evaluate] 45 total time 2.174799680709839 152.38768649101257
[2019-12-25 06:15:02,941] [INFO] [worker.py:1005:_train_and_evaluate] 46 total time 2.1353678703308105 154.52305436134338
[2019-12-25 06:15:05,036] [INFO] [worker.py:1005:_train_and_evaluate] 47 total time 2.095182180404663 156.61823654174805
[2019-12-25 06:15:07,133] [INFO] [worker.py:1005:_train_and_evaluate] 48 total time 2.0971157550811768 158.71535229682922
[2019-12-25 06:15:09,309] [INFO] [worker.py:1005:_train_and_evaluate] 49 total time 2.176305055618286 160.8916573524475
[2019-12-25 06:15:11,342] [INFO] [worker.py:1005:_train_and_evaluate] 50 total time 2.0331177711486816 162.9247751235962
[2019-12-25 06:15:13,731] [INFO] [worker.py:1005:_train_and_evaluate] 51 total time 2.3885574340820312 165.31333255767822
[2019-12-25 06:15:16,235] [INFO] [worker.py:1005:_train_and_evaluate] 52 total time 2.504328727722168 167.8176612854004
[2019-12-25 06:15:18,719] [INFO] [worker.py:1005:_train_and_evaluate] 53 total time 2.4840338230133057 170.3016951084137
[2019-12-25 06:15:21,183] [INFO] [worker.py:1005:_train_and_evaluate] 54 total time 2.46379017829895 172.76548528671265
[2019-12-25 06:15:23,860] [INFO] [worker.py:1005:_train_and_evaluate] 55 total time 2.6764276027679443 175.4419128894806
[2019-12-25 06:15:26,221] [INFO] [worker.py:1005:_train_and_evaluate] 56 total time 2.3616371154785156 177.8035500049591
[2019-12-25 06:15:28,633] [INFO] [worker.py:1005:_train_and_evaluate] 57 total time 2.412222385406494 180.2157723903656
[2019-12-25 06:15:30,956] [INFO] [worker.py:1005:_train_and_evaluate] 58 total time 2.322301149368286 182.5380735397339
[2019-12-25 06:15:33,542] [DEBUG] [timing_utils.py:41:report_timing] task_process time is 50.1906 seconds
[2019-12-25 06:15:33,545] [DEBUG] [timing_utils.py:41:report_timing] batch_process time is 44.8018 seconds
[2019-12-25 06:15:33,546] [DEBUG] [timing_utils.py:41:report_timing] get_model time is 0.432535 seconds
[2019-12-25 06:15:33,546] [DEBUG] [timing_utils.py:41:report_timing] report_gradient time is 27.0648 seconds
```


This PR also exposes a `preprocess_records` hook. If users want to implement customized preprocess logic, the customized data reader could override this method.

