### PR TITLE
Replace embedding layers whose memory is bigger than 2MB

### DIFF
--- a/elasticdl/python/common/model_handler.py
+++ b/elasticdl/python/common/model_handler.py
@@ -50,7 +50,8 @@ def _need_partition_embedding(layer):
     bigger than 2MB.
     """
     EMBEDDING_SIZE_THRESHOLD_FOR_PARTITION = 2 * 1024 * 1024  # 2MB
-    weights_memory = layer.input_dim * layer.output_dim * 4
+    FLOAT32_BYTES = 4
+    weights_memory = layer.input_dim * layer.output_dim * FLOAT32_BYTES
     return weights_memory > EMBEDDING_SIZE_THRESHOLD_FOR_PARTITION
 
 

--- a/elasticdl/python/common/model_handler.py
+++ b/elasticdl/python/common/model_handler.py
@@ -45,8 +45,8 @@ def _convert_embedding_table_to_numpy_array(embedding_table, embedding_shape):
 
 
 def _is_big_embedding(layer):
-    """Determine whether the embedding is small by the condition that
-    the memory of the layer.train_weights is less than 2MB.
+    """Determine whether the embedding is big by the condition that
+    the memory of the layer.train_weights is bigger than 2MB.
     """
     max_memory = 2 * 1024 * 1024  # 2MB
     weights_memory = layer.input_dim * layer.output_dim * 8

--- a/elasticdl/python/common/model_handler.py
+++ b/elasticdl/python/common/model_handler.py
@@ -50,7 +50,7 @@ def _need_partition_embedding(layer):
     bigger than 2MB.
     """
     EMBEDDING_SIZE_THRESHOLD_FOR_PARTITION = 2 * 1024 * 1024  # 2MB
-    weights_memory = layer.input_dim * layer.output_dim * 8
+    weights_memory = layer.input_dim * layer.output_dim * 4
     return weights_memory > EMBEDDING_SIZE_THRESHOLD_FOR_PARTITION
 
 

--- a/elasticdl/python/tests/model_handler_test.py
+++ b/elasticdl/python/tests/model_handler_test.py
@@ -8,11 +8,13 @@ from elasticdl.python.common.model_handler import ModelHandler
 from elasticdl.python.elasticdl.layers.embedding import Embedding
 from elasticdl.python.keras.layers import SparseEmbedding
 
+EMBEDDING_INPUT_DIM = 200000
+
 
 class CustomModel(tf.keras.models.Model):
     def __init__(self):
         super(CustomModel, self).__init__()
-        self.embedding = tf.keras.layers.Embedding(4, 2)
+        self.embedding = tf.keras.layers.Embedding(EMBEDDING_INPUT_DIM, 2)
         self.dense = tf.keras.layers.Dense(1)
 
     def call(self, inputs):
@@ -23,7 +25,7 @@ class CustomModel(tf.keras.models.Model):
 
 def custom_model_with_embedding():
     inputs = tf.keras.layers.Input(shape=(4,), name="x")
-    embedding = tf.keras.layers.Embedding(4, 2)(inputs)
+    embedding = tf.keras.layers.Embedding(EMBEDDING_INPUT_DIM, 2)(inputs)
     outputs = tf.keras.layers.Dense(1)(embedding)
     return tf.keras.models.Model(inputs, outputs)
 
@@ -32,9 +34,9 @@ def custom_model_with_sparse_embedding():
     sparse_input = tf.keras.layers.Input(
         shape=(4,), dtype="int64", sparse=True, name="sparse_feature"
     )
-    embedding = SparseEmbedding(4, 2, combiner="sum", name="embedding")(
-        sparse_input
-    )
+    embedding = SparseEmbedding(
+        EMBEDDING_INPUT_DIM, 2, combiner="sum", name="embedding"
+    )(sparse_input)
     outputs = tf.keras.layers.Dense(1)(embedding)
     return tf.keras.models.Model(sparse_input, outputs)
 

--- a/elasticdl/python/tests/model_handler_test.py
+++ b/elasticdl/python/tests/model_handler_test.py
@@ -8,7 +8,7 @@ from elasticdl.python.common.model_handler import ModelHandler
 from elasticdl.python.elasticdl.layers.embedding import Embedding
 from elasticdl.python.keras.layers import SparseEmbedding
 
-EMBEDDING_INPUT_DIM = 200000
+EMBEDDING_INPUT_DIM = 300000
 
 
 class CustomModel(tf.keras.models.Model):


### PR DESCRIPTION
It is inefficient to train the small embedding layers using ElasticDL embedding layers. So we only replace the big embedding layers.