### PR TITLE
Remove @tf.function to create dataset

### DIFF
--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -838,7 +838,6 @@ class Worker(object):
         if not gen:
             return None
 
-        @tf.function
         def create_dataset():
             eval_dataset = tf.data.Dataset.from_generator(
                 gen, self._task_data_service.data_reader.records_output_types


### PR DESCRIPTION
The memory grows slowly if we don't use `tf.strings.split` in dataset https://github.com/tensorflow/tensorflow/issues/35152. I have test that evaluation is very small if we use `tf.function` wrapper to create dataset for evaluation.