### PR TITLE
clean event callback code

### DIFF
--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -234,8 +234,6 @@ class InstanceManager(object):
             # No need to care about master pod
             return
 
-        relaunch_worker = False
-        relaunch_ps = False
         with self._lock:
             if pod_name in self._failed_pods:
                 return
@@ -272,11 +270,6 @@ class InstanceManager(object):
                 pods_phase[pod_name][1] = phase
                 if self._relaunch_deleted_live_worker and phase != "Succeeded":
                     relaunch_fn(pod_name)
-
-        if relaunch_worker:
-            self.relaunch_worker(pod_name)
-        elif relaunch_ps:
-            self.relaunch_ps(pod_name)
 
     @property
     def ps_addrs(self):

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -241,10 +241,12 @@ class InstanceManager(object):
                 pods_phase = self._worker_pods_phase
                 relaunch_fn = self.relaunch_worker
                 remove_fn = self._remove_worker
+                relaunch_flag = self._relaunch_deleted_live_worker
             elif pod_name in self._ps_pods_phase:
                 pods_phase = self._ps_pods_phase
                 relaunch_fn = self._relaunch_ps
                 remove_fn = self._remove_ps
+                relaunch_flag = self._relaunch_deleted_live_ps
             else:
                 logger.error("Unknown pod name: %s" % pod_name)
                 return
@@ -263,12 +265,12 @@ class InstanceManager(object):
             ):
                 self._failed_pods.append(pod_name)
                 pods_phase[pod_name][1] = phase
-                if self._relaunch_deleted_live_worker:
+                if relaunch_flag:
                     remove_fn(pods_phase[pod_name][0])
                     relaunch_fn(pod_name)
             elif evt_type == "DELETED":
                 pods_phase[pod_name][1] = phase
-                if self._relaunch_deleted_live_worker and phase != "Succeeded":
+                if relaunch_flag and phase != "Succeeded":
                     relaunch_fn(pod_name)
 
     @property

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -207,11 +207,11 @@ class InstanceManager(object):
 
     def relaunch_ps(self, pod_name):
         logger.info("Relaunching ps.")
+        ps_id = self._ps_pods_phase[pod_name][0]
         del self._ps_pods_phase[pod_name]
         # Note: the ID and service address for relaunched parameter
         # server are intentionally left unchanged to support fault
         # tolerance.
-        ps_id = self._ps_pods_phase[pod_name][0]
         self._start_ps(ps_id)
 
     def _event_cb(self, event):

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -13,7 +13,6 @@ class InstanceManager(object):
     def __init__(
         self,
         task_d,
-        job_name,
         num_workers=1,
         worker_command=None,
         worker_args=None,
@@ -32,7 +31,6 @@ class InstanceManager(object):
         envs=None,
         **kwargs
     ):
-        self._job_name = job_name
         self._num_workers = num_workers
         self._worker_command = worker_command
         self._worker_args = worker_args

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -270,7 +270,6 @@ class InstanceManager(object):
                 del pods_phase[pod_name]
                 if recover_fn:
                     recover_fn(pod_id)
-                self._task_d.recover_tasks(pod_id)
                 if relaunch_flag:
                     remove_fn(pod_id)
                     relaunch_fn(pod_id)

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -172,13 +172,13 @@ class InstanceManager(object):
     def stop_relaunch_and_remove_workers(self):
         with self._lock:
             self._relaunch_deleted_live_worker = False
-            for worker_id in self._worker_pods_phase:
+            for _, (worker_id, _) in self._worker_pods_phase.items():
                 self._k8s_client.delete_worker(worker_id)
 
     def stop_relaunch_and_remove_all_ps(self):
         with self._lock:
             self._relaunch_deleted_live_ps = False
-            for ps_id in self._ps_pods_phase:
+            for _, (ps_id, _) in self._ps_pods_phase.items():
                 self._k8s_client.delete_ps(ps_id)
 
     def get_worker_counter(self):

--- a/elasticdl/python/tests/k8s_instance_manager_test.py
+++ b/elasticdl/python/tests/k8s_instance_manager_test.py
@@ -9,10 +9,10 @@ from elasticdl.python.master.task_dispatcher import _TaskDispatcher
 
 
 class InstanceManagerTest(unittest.TestCase):
-    @unittest.skipIf(
-        os.environ.get("K8S_TESTS", "True") == "False",
-        "No Kubernetes cluster available",
-    )
+    # @unittest.skipIf(
+    #     os.environ.get("K8S_TESTS", "True") == "False",
+    #     "No Kubernetes cluster available",
+    # )
     def testCreateDeleteWorkerPod(self):
         task_d = _TaskDispatcher({"f": (0, 10)}, {}, {}, 1, 1)
         task_d.recover_tasks = MagicMock()

--- a/elasticdl/python/tests/k8s_instance_manager_test.py
+++ b/elasticdl/python/tests/k8s_instance_manager_test.py
@@ -9,10 +9,10 @@ from elasticdl.python.master.task_dispatcher import _TaskDispatcher
 
 
 class InstanceManagerTest(unittest.TestCase):
-    # @unittest.skipIf(
-    #     os.environ.get("K8S_TESTS", "True") == "False",
-    #     "No Kubernetes cluster available",
-    # )
+    @unittest.skipIf(
+        os.environ.get("K8S_TESTS", "True") == "False",
+        "No Kubernetes cluster available",
+    )
     def testCreateDeleteWorkerPod(self):
         task_d = _TaskDispatcher({"f": (0, 10)}, {}, {}, 1, 1)
         task_d.recover_tasks = MagicMock()

--- a/elasticdl/python/tests/k8s_instance_manager_test.py
+++ b/elasticdl/python/tests/k8s_instance_manager_test.py
@@ -116,7 +116,7 @@ class InstanceManagerTest(unittest.TestCase):
         current_workers = set()
         live_workers = set()
         with instance_manager._lock:
-            for k, (_, phase) in instance_manager._worker_pods_phase.items():
+            for _, (k, phase) in instance_manager._worker_pods_phase.items():
                 current_workers.add(k)
                 if phase in ["Running", "Pending"]:
                     live_workers.add(k)
@@ -130,7 +130,7 @@ class InstanceManagerTest(unittest.TestCase):
                 break
             time.sleep(1)
             with instance_manager._lock:
-                for k in instance_manager._worker_pods_phase:
+                for _, (k, _) in instance_manager._worker_pods_phase.items():
                     if k not in range(num_workers, num_workers * 2):
                         found = True
         else:
@@ -178,7 +178,7 @@ class InstanceManagerTest(unittest.TestCase):
         all_current_ps = set()
         all_live_ps = set()
         with instance_manager._lock:
-            for k, (_, phase) in instance_manager._ps_pods_phase.items():
+            for _, (k, phase) in instance_manager._ps_pods_phase.items():
                 all_current_ps.add(k)
                 if phase in ["Running", "Pending"]:
                     all_live_ps.add(k)
@@ -194,7 +194,7 @@ class InstanceManagerTest(unittest.TestCase):
                 break
             time.sleep(1)
             with instance_manager._lock:
-                for k in instance_manager._ps_pods_phase:
+                for _, (k, _) in instance_manager._ps_pods_phase.items():
                     if k not in all_current_ps:
                         found = True
         else:


### PR DESCRIPTION
This PR cleans event callback code and exposes two interfaces,  `relaunch_worker` and `relaunch_ps`. We could reuse these two interfaces for the further [timeout feature](https://github.com/sql-machine-learning/elasticdl/issues/1592) development.

