### PR TITLE
Yield data from odps reader

### DIFF
--- a/elasticdl/python/data/odps_io.py
+++ b/elasticdl/python/data/odps_io.py
@@ -226,17 +226,14 @@ class ODPSReader(object):
             columns = self._odps_table.schema.names
         while retry_count < max_retries:
             try:
-                batch_record = []
                 with self._odps_table.open_reader(
-                    partition=self._partition, reopen=True
+                    partition=self._partition, reopen=False
                 ) as reader:
                     for record in reader.read(
                         start=start, count=end - start, columns=columns
                     ):
-                        batch_record.append(
-                            [str(record[column]) for column in columns]
-                        )
-                return batch_record
+                        yield [str(record[column]) for column in columns]
+                    return
             except Exception as e:
                 if retry_count >= max_retries:
                     raise Exception("Exceeded maximum number of retries")

--- a/elasticdl/python/data/reader/odps_reader.py
+++ b/elasticdl/python/data/reader/odps_reader.py
@@ -21,9 +21,7 @@ class ODPSDataReader(AbstractDataReader):
         )
 
         for record in reader.read_batch(
-            start=task.start,
-            end=task.end,
-            columns=self._metadata.column_names
+            start=task.start, end=task.end, columns=self._metadata.column_names
         ):
             yield record
 

--- a/elasticdl/python/data/reader/odps_reader.py
+++ b/elasticdl/python/data/reader/odps_reader.py
@@ -19,7 +19,6 @@ class ODPSDataReader(AbstractDataReader):
         reader = self._get_reader(
             table_name=self._get_odps_table_name(task.shard_name)
         )
-        self._init_odps_config_if_needed(reader)
 
         for record in reader.read_batch(
             start=task.start,

--- a/elasticdl/python/data/reader/odps_reader.py
+++ b/elasticdl/python/data/reader/odps_reader.py
@@ -19,16 +19,14 @@ class ODPSDataReader(AbstractDataReader):
         reader = self._get_reader(
             table_name=self._get_odps_table_name(task.shard_name)
         )
-        if self._metadata.column_names is None:
-            columns = self._kwargs.get("columns")
-            self._metadata.column_names = (
-                reader._odps_table.schema.names if columns is None else columns
-            )
-        records = reader.read_batch(
-            start=task.start, end=task.end, columns=self._metadata.column_names
-        )
-        for batch in records:
-            yield batch
+        self._init_odps_config_if_needed(reader)
+
+        for record in reader.read_batch(
+            start=task.start,
+            end=task.end,
+            columns=self._metadata.column_names
+        ):
+            yield record
 
     def create_shards(self):
         check_required_kwargs(["table", "records_per_task"], self._kwargs)


### PR DESCRIPTION
Fix #1601 
We can yield the records from ODPS tunnel rather than caching the records to a list. We can reduce the used memory and utilize the overlap of download and computation to speed up. 