### PR TITLE
variables from different ps have its own model_version

### DIFF
--- a/elasticdl/proto/elasticdl.proto
+++ b/elasticdl/proto/elasticdl.proto
@@ -111,6 +111,10 @@ service Master {
     rpc report_version(ReportVersionRequest) returns (google.protobuf.Empty);
 }
 
+message PullVariableRequest {
+    int32 current_model_version = 1;
+}
+
 message PullVariableResponse {
     bool model_init_status = 1;
     Model model = 2;
@@ -133,7 +137,7 @@ message PushGradientResponse {
 
 // PS service
 service Pserver {
-    rpc pull_variable(google.protobuf.Empty) returns (PullVariableResponse);
+    rpc pull_variable(PullVariableRequest) returns (PullVariableResponse);
     rpc pull_embedding_vector(PullEmbeddingVectorRequest) returns (Tensor);
     rpc push_model(Model) returns (google.protobuf.Empty);
     rpc push_embedding_info(Model) returns (google.protobuf.Empty);

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -319,6 +319,14 @@ def add_train_params(parser):
 
     add_bool_param(
         parser=parser,
+        name="--sync_version_tolerance",
+        type=int,
+        help="The maximum model version difference between reported gradients "
+        "and PS that synchronous SGD can accepts.",
+        default=0,
+    )
+    add_bool_param(
+        parser=parser,
         name="--use_async",
         default=False,
         help="True for asynchronous SGD, False for synchronous SGD",

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -316,10 +316,8 @@ def add_train_params(parser):
         default="",
         help="The path to save the final trained model",
     )
-
-    add_bool_param(
-        parser=parser,
-        name="--sync_version_tolerance",
+    parser.add_argument(
+        "--sync_version_tolerance",
         type=int,
         help="The maximum model version difference between reported gradients "
         "and PS that synchronous SGD can accepts.",

--- a/elasticdl/python/ps/parameter_server.py
+++ b/elasticdl/python/ps/parameter_server.py
@@ -25,6 +25,7 @@ class ParameterServer(object):
 
         self.grads_to_wait = args.grads_to_wait
         self.lr_staleness_modulation = args.lr_staleness_modulation
+        self.sync_version_tolerance = args.sync_version_tolerance
         self.use_async = args.use_async
         self.port = args.port
         model_module = load_module(
@@ -113,6 +114,7 @@ class ParameterServer(object):
             self.optimizer,
             self.lr_scheduler,
             lr_staleness_modulation=self.lr_staleness_modulation,
+            sync_version_tolerance=self.sync_version_tolerance,
             use_async=self.use_async,
             evaluation_steps=self.evaluation_steps,
             master_channel=self.master_channel,

--- a/elasticdl/python/ps/parameters.py
+++ b/elasticdl/python/ps/parameters.py
@@ -131,7 +131,7 @@ class Parameters(object):
             embeddings_pb = model_pb.embedding_table_info
             self.init_embedding_params(embeddings_pb)
             self._restore_params_from_pb(tensors_pb)
-            self.version = model_pb.version
+            self.version = max(0, model_pb.version)
             self.init_status = True
             return True
         return False

--- a/elasticdl/python/tests/pserver_servicer_test.py
+++ b/elasticdl/python/tests/pserver_servicer_test.py
@@ -169,7 +169,8 @@ class PserverServicerTest(unittest.TestCase):
             "v0": np.random.rand(3, 2).astype(np.float32),
             "v1": np.random.rand(10, 32).astype(np.float32),
         }
-        pull_req = empty_pb2.Empty()
+        pull_req = elasticdl_pb2.PullVariableRequest()
+        pull_req.current_model_version = -1
         # try to pull variable
         res = self._stub.pull_variable(pull_req)
         # not initialized
@@ -191,6 +192,13 @@ class PserverServicerTest(unittest.TestCase):
             name = param.name
             tensor = tensor_pb_to_ndarray(param)
             self.assertTrue(np.allclose(param0[name], tensor))
+
+        # pull variable again, no param as no updated version
+        pull_req.current_model_version = res.model.version
+        res = self._stub.pull_variable(pull_req)
+        self.assertTrue(res.model_init_status)
+        self.assertEqual(res.model.version, pull_req.current_model_version)
+        self.assertTrue(not res.model.param)
 
     def test_pull_embedding_vector(self):
         self.create_default_server_and_stub()

--- a/elasticdl/python/tests/test_utils.py
+++ b/elasticdl/python/tests/test_utils.py
@@ -40,6 +40,7 @@ class PserverArgs(object):
         grads_to_wait=8,
         lr_scheduler="learning_rate_scheduler",
         lr_staleness_modulation=0,
+        sync_version_tolerance=0,
         use_async=False,
         model_zoo=None,
         model_def=None,
@@ -61,6 +62,7 @@ class PserverArgs(object):
         self.grads_to_wait = grads_to_wait
         self.learning_rate_scheduler = lr_scheduler
         self.lr_staleness_modulation = lr_staleness_modulation
+        self.sync_version_tolerance = sync_version_tolerance
         self.use_async = use_async
         self.model_zoo = model_zoo
         self.model_def = model_def

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -99,6 +99,8 @@ class Worker(object):
                 ]
                 self._var_to_ps = {}
                 self._ps_num = len(self._ps_stubs)
+        else:
+            self._ps_num = 0
         self._distribution_strategy = args.distribution_strategy
         if (
             self._distribution_strategy

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -320,13 +320,10 @@ class Worker(object):
                         "PS pod %d cannot be initialized" % ps_id
                     )
 
-            if res.model.version > self._model_versions_from_ps[ps_id]:
-                for tensor_pb in res.model.param:
-                    tensor = Tensor.from_tensor_pb(tensor_pb)
-                    self._non_embed_vars[tensor.name].assign(
-                        tensor.to_ndarray()
-                    )
-                self._model_versions_from_ps[ps_id] = res.model.version
+            for tensor_pb in res.model.param:
+                tensor = Tensor.from_tensor_pb(tensor_pb)
+                self._non_embed_vars[tensor.name].assign(tensor.to_ndarray())
+            self._model_versions_from_ps[ps_id] = res.model.version
 
         self._model_version = max(self._model_versions_from_ps)
         self._timing.end_record_time("get_model")

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -409,6 +409,7 @@ class Worker(object):
 
     def report_variable_to_ps(self, ps_id):
         model = elasticdl_pb2.Model()
+        model.version = self._model_versions_from_ps[ps_id]
         if ps_id in self._ps_vars:
             vars = self._ps_vars[ps_id]
             for var in vars:


### PR DESCRIPTION
1. variables from different PS have their own model_version in workers.

2. add `sync_version_tolerance` arg so that sync-SGD can accept gradients with different versions from PS (default is 0 to only accept gradients with the same version as PS).

3.  `pull_variable` grpc does not need to return variable values if PS model version is the same as the requested worker.