### PR TITLE
avoid worker hang in multi-process

### DIFF
--- a/elasticdl/python/worker/main.py
+++ b/elasticdl/python/worker/main.py
@@ -31,7 +31,12 @@ def main():
             )
             ps_channels.append(channel)
 
-    worker = Worker(args, channel=master_channel, ps_channels=ps_channels)
+    worker = Worker(
+        args,
+        channel=master_channel,
+        ps_channels=ps_channels,
+        set_parallelism=True,
+    )
     worker.run()
 
 

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -75,11 +75,14 @@ class Worker(object):
         self._args = args
         self.logger = get_logger("Worker", level=args.log_level.upper())
 
-        # Explicitly set the parallelism will avoid multi-process hang.
-        # Maybe due to an unknown bug in Tensorflow?
-        num_threads = os.cpu_count()
-        tf.config.threading.set_inter_op_parallelism_threads(num_threads)
-        tf.config.threading.set_intra_op_parallelism_threads(num_threads)
+        if set_parallelism:
+            # Explicitly set the parallelism will avoid multi-process hang.
+            # Maybe due to an unknown bug in Tensorflow?
+            # Must called before any TensorFlow is initialized, so by default
+            # do not set_parallelism to make unittests happy.
+            num_threads = os.cpu_count()
+            tf.config.threading.set_inter_op_parallelism_threads(num_threads)
+            tf.config.threading.set_intra_op_parallelism_threads(num_threads)
 
         if channel is None:
             self._stub = None

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -74,6 +74,13 @@ class Worker(object):
         """
         self._args = args
         self.logger = get_logger("Worker", level=args.log_level.upper())
+
+        # Explicitly set the parallelism will avoid multi-process hang.
+        # Maybe due to an unknown bug in Tensorflow?
+        num_threads = os.cpu_count()
+        tf.config.threading.set_inter_op_parallelism_threads(num_threads)
+        tf.config.threading.set_intra_op_parallelism_threads(num_threads)
+
         if channel is None:
             self._stub = None
         else:

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -79,8 +79,8 @@ class Worker(object):
         if set_parallelism:
             # Explicitly setting the parallelism will avoid multi-process hangs
             # Maybe due to an unknown bug in Tensorflow?
-            # Must called before TensorFlow is initialized. So by default
-            # do not set_parallelism to make unittests happy.
+            # Must called before TensorFlow is initialized.
+            # Not set_parallelism by default to make unittests happy.
             num_threads = os.cpu_count()
             tf.config.threading.set_inter_op_parallelism_threads(num_threads)
             tf.config.threading.set_intra_op_parallelism_threads(num_threads)

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -61,6 +61,7 @@ class Worker(object):
         ps_channels=None,
         max_minibatch_retry_num=DEFAULT_MAX_MINIBATCH_RETRY_NUM,
         max_allreduce_retry_num=DEFAULT_MAX_ALLREDUCE_RETRY_NUM,
+        set_parallelism=False,
     ):
         """
         Arguments:

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -77,9 +77,9 @@ class Worker(object):
         self.logger = get_logger("Worker", level=args.log_level.upper())
 
         if set_parallelism:
-            # Explicitly set the parallelism will avoid multi-process hang.
+            # Explicitly setting the parallelism will avoid multi-process hangs
             # Maybe due to an unknown bug in Tensorflow?
-            # Must called before any TensorFlow is initialized, so by default
+            # Must called before TensorFlow is initialized. So by default
             # do not set_parallelism to make unittests happy.
             num_threads = os.cpu_count()
             tf.config.threading.set_inter_op_parallelism_threads(num_threads)


### PR DESCRIPTION
Explicitly set the parallelism will avoid a multi-process hang.

Magic Tensorflow!