### PR TITLE
add debug info for parameters size in PS

### DIFF
--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -381,6 +381,8 @@ class Master(object):
                 str(args.checkpoint_dir_for_init),
                 "--num_workers",
                 str(args.num_workers),
+                "--log_level",
+                str(args.log_level),
             ]
 
             env_dict = parse_envs(args.envs)

--- a/elasticdl/python/ps/embedding_table.py
+++ b/elasticdl/python/ps/embedding_table.py
@@ -86,6 +86,7 @@ class EmbeddingTable(object):
         return embedding_pb
 
     def get_table_size(self):
+        """Get the element count of an embedding table"""
         if len(self.embedding_vectors) > 0:
             element_size = list(self.embedding_vectors.values())[0].itemsize
             size = self.dim * len(self.embedding_vectors) * element_size
@@ -94,7 +95,7 @@ class EmbeddingTable(object):
 
     def debug_info(self):
         return (
-            "embedding param name: %s\n  shape: [%d, %d]\n  size: %d bytes\n"
+            "Embedding param name: %s\n  shape: [%d, %d]\n  size: %d bytes\n"
             % (
                 self.name,
                 len(self.embedding_vectors),

--- a/elasticdl/python/ps/embedding_table.py
+++ b/elasticdl/python/ps/embedding_table.py
@@ -85,7 +85,7 @@ class EmbeddingTable(object):
         embedding_pb.initializer = str(self.initializer_value)
         return embedding_pb
 
-    def table_size(self):
+    def get_table_size(self):
         if len(self.embedding_vectors) > 0:
             element_size = list(self.embedding_vectors.values())[0].itemsize
             size = self.dim * len(self.embedding_vectors) * element_size
@@ -93,11 +93,15 @@ class EmbeddingTable(object):
         return 0
 
     def debug_info(self):
-        info = ""
-        info += "embedding param name: %s\n" % self.name
-        info += "  shape: [%d, %d]\n" % (len(self.embedding_vectors), self.dim)
-        info += "  size: %d bytes\n" % self.table_size()
-        return info
+        return (
+            "embedding param name: %s\n  shape: [%d, %d]\n  size: %d bytes\n"
+            % (
+                self.name,
+                len(self.embedding_vectors),
+                self.dim,
+                self.get_table_size(),
+            )
+        )
 
 
 # TODO(bug): create_embedding_table does not create EmbeddingTable correctly

--- a/elasticdl/python/ps/embedding_table.py
+++ b/elasticdl/python/ps/embedding_table.py
@@ -85,6 +85,20 @@ class EmbeddingTable(object):
         embedding_pb.initializer = str(self.initializer_value)
         return embedding_pb
 
+    def table_size(self):
+        if len(self.embedding_vectors) > 0:
+            element_size = list(self.embedding_vectors.values())[0].itemsize
+            size = self.dim * len(self.embedding_vectors) * element_size
+            return size
+        return 0
+
+    def debug_info(self):
+        info = ""
+        info += "embedding param name: %s\n" % self.name
+        info += "  shape: [%d, %d]\n" % (len(self.embedding_vectors), self.dim)
+        info += "  size: %d bytes\n" % self.table_size()
+        return info
+
 
 # TODO(bug): create_embedding_table does not create EmbeddingTable correctly
 #     if it is a slot table.

--- a/elasticdl/python/ps/parameter_server.py
+++ b/elasticdl/python/ps/parameter_server.py
@@ -22,7 +22,6 @@ from elasticdl.python.ps.servicer import PserverServicer
 class ParameterServer(object):
     def __init__(self, args):
         self.logger = get_logger("PS", level=args.log_level.upper())
-
         self.grads_to_wait = args.grads_to_wait
         self.lr_staleness_modulation = args.lr_staleness_modulation
         self.use_async = args.use_async
@@ -153,6 +152,9 @@ class ParameterServer(object):
                         "master pod is still running tensorboard service"
                     )
                     break
+                self.logger.debug(
+                    "Parameters info:\n %s" % self.parameters.debug_info()
+                )
         except KeyboardInterrupt:
             self.logger.warning("Server stopping")
 

--- a/elasticdl/python/ps/parameter_server.py
+++ b/elasticdl/python/ps/parameter_server.py
@@ -153,7 +153,7 @@ class ParameterServer(object):
                     )
                     break
                 self.logger.debug(
-                    "Parameters info:\n %s" % self.parameters.debug_info()
+                    "Parameters info:\n%s" % self.parameters.debug_info()
                 )
         except KeyboardInterrupt:
             self.logger.warning("Server stopping")

--- a/elasticdl/python/ps/parameter_server.py
+++ b/elasticdl/python/ps/parameter_server.py
@@ -45,6 +45,7 @@ class ParameterServer(object):
         self.namespace = args.namespace
         self._init_checkpoint_saver(args)
         self._restore_params_from_checkpoint(args.checkpoint_dir_for_init)
+        self._debug_info_needed = args.log_level.upper() == "DEBUG"
 
     def _set_lr_scheduler(self, model_module, learning_rate_scheduler_arg):
         if learning_rate_scheduler_arg in model_module:
@@ -152,9 +153,11 @@ class ParameterServer(object):
                         "master pod is still running tensorboard service"
                     )
                     break
-                self.logger.debug(
-                    "Parameters info:\n%s" % self.parameters.debug_info()
-                )
+
+                if self._debug_info_needed:
+                    self.logger.debug(
+                        "Parameters info:\n%s" % self.parameters.debug_info()
+                    )
         except KeyboardInterrupt:
             self.logger.warning("Server stopping")
 

--- a/elasticdl/python/ps/parameters.py
+++ b/elasticdl/python/ps/parameters.py
@@ -203,18 +203,17 @@ class Parameters(object):
         total_size = 0
         for e in self.embedding_params:
             info += self.embedding_params[e].debug_info()
-            total_size += self.embedding_params[e].table_size()
+            total_size += self.embedding_params[e].get_table_size()
         for n in self.non_embedding_params:
-            tmp = ""
-            tmp += "non-embedding param name: %s\n" % n
             shape = self.non_embedding_params[n].get_shape().as_list()
             size = (
                 tf.size(self.non_embedding_params[n])
                 * self.non_embedding_params[n].dtype.size
             )
-            tmp += "  shape: %s\n" % str(shape)
-            tmp += "  size: %d bytes\n" % size
-            info += tmp
+            info += (
+                "non-embedding param name: %s\n  shape: %s\n  size: %d\n"
+                % (n, str(shape), size)
+            )
             total_size += size
         info += "total parameters size: %d bytes" % total_size
         return info

--- a/elasticdl/python/ps/parameters.py
+++ b/elasticdl/python/ps/parameters.py
@@ -211,9 +211,9 @@ class Parameters(object):
                 * self.non_embedding_params[param].dtype.size
             )
             info += (
-                "non-embedding param name: %s\n  shape: %s\n  size: %d\n"
+                "Non-embedding param name: %s\n  shape: %s\n  size: %d\n"
                 % (param, str(shape), size)
             )
             total_size += size
-        info += "total parameters size: %d bytes" % total_size
+        info += "Total parameters size: %d bytes" % total_size
         return info

--- a/elasticdl/python/ps/parameters.py
+++ b/elasticdl/python/ps/parameters.py
@@ -201,18 +201,18 @@ class Parameters(object):
     def debug_info(self):
         info = ""
         total_size = 0
-        for e in self.embedding_params:
-            info += self.embedding_params[e].debug_info()
-            total_size += self.embedding_params[e].get_table_size()
-        for n in self.non_embedding_params:
-            shape = self.non_embedding_params[n].get_shape().as_list()
+        for param in self.embedding_params:
+            info += self.embedding_params[param].debug_info()
+            total_size += self.embedding_params[param].get_table_size()
+        for param in self.non_embedding_params:
+            shape = self.non_embedding_params[param].get_shape().as_list()
             size = (
-                tf.size(self.non_embedding_params[n])
-                * self.non_embedding_params[n].dtype.size
+                tf.size(self.non_embedding_params[param])
+                * self.non_embedding_params[param].dtype.size
             )
             info += (
                 "non-embedding param name: %s\n  shape: %s\n  size: %d\n"
-                % (n, str(shape), size)
+                % (param, str(shape), size)
             )
             total_size += size
         info += "total parameters size: %d bytes" % total_size

--- a/elasticdl/python/ps/parameters.py
+++ b/elasticdl/python/ps/parameters.py
@@ -197,3 +197,24 @@ class Parameters(object):
             model_pb.embedding_table_info.append(embedding_info)
 
         return model_pb
+
+    def debug_info(self):
+        info = ""
+        total_size = 0
+        for e in self.embedding_params:
+            info += self.embedding_params[e].debug_info()
+            total_size += self.embedding_params[e].table_size()
+        for n in self.non_embedding_params:
+            tmp = ""
+            tmp += "non-embedding param name: %s\n" % n
+            shape = self.non_embedding_params[n].get_shape().as_list()
+            size = (
+                tf.size(self.non_embedding_params[n])
+                * self.non_embedding_params[n].dtype.size
+            )
+            tmp += "  shape: %s\n" % str(shape)
+            tmp += "  size: %d bytes\n" % size
+            info += tmp
+            total_size += size
+        info += "total parameters size: %d bytes" % total_size
+        return info


### PR DESCRIPTION
This PR aims to print the parameter size in each PS, which helps us to check if the model shard in each PS is balance or not.

The debug log could be

```
[2020-01-02 03:21:48,015] [DEBUG] [parameter_server.py:156:run] Parameters info:
 embedding param name: embedding
  shape: [72344, 8]
  size: 2315008 bytes
embedding param name: embedding_2
  shape: [5, 8]
  size: 160 bytes
embedding param name: embedding_3
  shape: [20, 8]
  size: 640 bytes
embedding param name: embedding_14
  shape: [3, 8]
  size: 96 bytes
embedding param name: embedding_16
  shape: [5337, 8]
  size: 170784 bytes
embedding param name: embedding_17
  shape: [1993, 8]
  size: 63776 bytes
embedding param name: embedding_19
  shape: [419, 8]
  size: 13408 bytes
embedding param name: embedding_20
  shape: [658, 8]
  size: 21056 bytes
embedding param name: embedding_21
  shape: [5, 8]
  size: 160 bytes
embedding param name: embedding_22
  shape: [2, 8]
  size: 64 bytes
embedding param name: embedding-m
  shape: [71278, 8]
  size: 2280896 bytes
embedding param name: embedding-v
  shape: [71278, 8]
  size: 2280896 bytes
embedding param name: embedding_2-m
  shape: [5, 8]
  size: 160 bytes
embedding param name: embedding_2-v
  shape: [5, 8]
  size: 160 bytes
embedding param name: embedding_3-m
  shape: [20, 8]
  size: 640 bytes
embedding param name: embedding_3-v
  shape: [20, 8]
  size: 640 bytes
embedding param name: embedding_14-m
  shape: [3, 8]
  size: 96 bytes
embedding param name: embedding_14-v
  shape: [3, 8]
  size: 96 bytes
embedding param name: embedding_16-m
  shape: [5215, 8]
  size: 166880 bytes
embedding param name: embedding_16-v
  shape: [5215, 8]
  size: 166880 bytes
embedding param name: embedding_17-m
  shape: [1944, 8]
  size: 62208 bytes
embedding param name: embedding_17-v
  shape: [1944, 8]
  size: 62208 bytes
embedding param name: embedding_19-m
  shape: [414, 8]
  size: 13248 bytes
embedding param name: embedding_19-v
  shape: [414, 8]
  size: 13248 bytes
embedding param name: embedding_20-m
  shape: [656, 8]
  size: 20992 bytes
embedding param name: embedding_20-v
  shape: [656, 8]
  size: 20992 bytes
embedding param name: embedding_21-m
  shape: [5, 8]
  size: 160 bytes
embedding param name: embedding_21-v
  shape: [5, 8]
  size: 160 bytes
embedding param name: embedding_22-m
  shape: [2, 8]
  size: 64 bytes
embedding param name: embedding_22-v
  shape: [2, 8]
  size: 64 bytes
non-embedding param name: embedding_15/embeddings:0
  shape: [1000, 8]
  size: 32000 bytes
non-embedding param name: embedding_18/embeddings:0
  shape: [1000, 8]
  size: 32000 bytes
non-embedding param name: embedding_23/embeddings:0
  shape: [1000, 8]
  size: 32000 bytes
non-embedding param name: embedding_25/embeddings:0
  shape: [1000, 8]
  size: 32000 bytes
non-embedding param name: embedding_27/embeddings:0
  shape: [1000, 8]
  size: 32000 bytes
non-embedding param name: embedding_31/embeddings:0
  shape: [301000, 1]
  size: 1204000 bytes
non-embedding param name: embedding_33/embeddings:0
  shape: [1000, 1]
  size: 4000 bytes
non-embedding param name: embedding_36/embeddings:0
  shape: [1000, 1]
  size: 4000 bytes
non-embedding param name: embedding_37/embeddings:0
  shape: [1000, 1]
  size: 4000 bytes
non-embedding param name: embedding_41/embeddings:0
  shape: [1000, 1]
  size: 4000 bytes
non-embedding param name: embedding_47/embeddings:0
  shape: [1000, 1]
  size: 4000 bytes
non-embedding param name: embedding_48/embeddings:0
  shape: [301000, 1]
  size: 1204000 bytes
non-embedding param name: embedding_50/embeddings:0
  shape: [301000, 1]
  size: 1204000 bytes
non-embedding param name: multi_head_attention/WK:0
  shape: [8, 8]
  size: 256 bytes
non-embedding param name: multi_head_attention/WV:0
  shape: [8, 8]
  size: 256 bytes
non-embedding param name: dense_1/kernel:0
  shape: [16, 8]
  size: 512 bytes
non-embedding param name: dense_1/bias:0
  shape: [8]
  size: 32 bytes
non-embedding param name: dense_2/kernel:0
  shape: [8, 4]
  size: 128 bytes
non-embedding param name: dense_2/bias:0
  shape: [4]
  size: 16 bytes
total parameters size: 11469040 bytes
```