### PR TITLE
Switch to use assertEqual to avoid deprecation warnings

### DIFF
--- a/elasticdl/python/tests/data_reader_test.py
+++ b/elasticdl/python/tests/data_reader_test.py
@@ -94,8 +94,8 @@ class CSVDataReaderTest(unittest.TestCase):
             )
             dataset = _dataset_fn(dataset, None, None)
             for features, labels in dataset:
-                self.assertEquals(features.shape.as_list(), [10, 4])
-                self.assertEquals(labels.shape.as_list(), [10])
+                self.assertEqual(features.shape.as_list(), [10, 4])
+                self.assertEqual(labels.shape.as_list(), [10])
                 break
 
 


### PR DESCRIPTION
This removes the following warnings:
```
elasticdl/python/tests/data_reader_test.py::CSVDataReaderTest::test_csv_data_reader
  /work/elasticdl/python/tests/data_reader_test.py:97: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(features.shape.as_list(), [10, 4])
elasticdl/python/tests/data_reader_test.py::CSVDataReaderTest::test_csv_data_reader
  /work/elasticdl/python/tests/data_reader_test.py:98: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(labels.shape.as_list(), [10])
```

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>