### PR TITLE
Reuse the variables created for embedding vectors and gradients in OptimizerWrapper.

### DIFF
--- a/elasticdl/python/ps/optimizer_wrapper.py
+++ b/elasticdl/python/ps/optimizer_wrapper.py
@@ -155,7 +155,7 @@ class OptimizerWrapper(object):
         if not hasattr(self._tls, "_embed_variables"):
             self._init_thread_local()
 
-        if self._has_embedding:
+        if True or self._has_embedding:
             with self._update_gradient_lock:
                 self._update_parameters_by_gradients(grads_and_vars)
         else:
@@ -308,13 +308,14 @@ class OptimizerWrapper(object):
                 self._update_embedding_func(slot_table_name, ids, value)
 
     def _delete_slots_and_weights_in_optimizer(self):
-        """Delete the slots and weights in the optimizer according
+        """Clear the slots and weights in the optimizer according
         to Embedding layers.
         """
         for layer_name, slots in self._tls._slot_variables.items():
             embed_var = self._get_embedding_variable(layer_name)
             embed_var_key = _var_key(embed_var)
-            del self._opt._slots[embed_var_key]
+            if embed_var_key in self._opt.slots:
+                del self._opt._slots[embed_var_key]
             for _, var in slots.items():
                 opt_weight_iter = 0
                 while opt_weight_iter < len(self._opt._weights):

--- a/elasticdl/python/ps/optimizer_wrapper.py
+++ b/elasticdl/python/ps/optimizer_wrapper.py
@@ -314,7 +314,7 @@ class OptimizerWrapper(object):
         for layer_name, slots in self._tls._slot_variables.items():
             embed_var = self._get_embedding_variable(layer_name)
             embed_var_key = _var_key(embed_var)
-            if embed_var_key in self._opt.slots:
+            if embed_var_key in self._opt._slots:
                 del self._opt._slots[embed_var_key]
             for _, var in slots.items():
                 opt_weight_iter = 0

--- a/elasticdl/python/ps/optimizer_wrapper.py
+++ b/elasticdl/python/ps/optimizer_wrapper.py
@@ -71,10 +71,6 @@ class OptimizerWrapper(object):
         update_embedding_func=None,
     ):
         """
-        Note:
-            If `lookup_embedding_func`/`update_embedding_func`
-            is not None, use parameter server to lookup/update embedding.
-
         Arguments:
             opt: A TensorFlow optimizer instance.
             kv_store_endpoint: The endpoint to kv store.
@@ -83,7 +79,7 @@ class OptimizerWrapper(object):
                 name of ElasticDL embedding layer and `embedding_dim`
                 is the output dimension of corresponding embedding layer.
             use_async: A python bool. True if using asynchronous updates. When
-                using asynchronoues updates, `OptimizerWrapper` is thread-safe
+                using asynchronous updates, `OptimizerWrapper` is thread-safe
                 for non-embedding variables and is not thread-safe for
                 embedding table.
             lookup_embedding_func: The function to lookup embeddings. The

--- a/elasticdl/python/tests/optimizer_wrapper_test.py
+++ b/elasticdl/python/tests/optimizer_wrapper_test.py
@@ -320,7 +320,7 @@ class OptimizerWrapperTest(unittest.TestCase):
         for slot_dict in opt._slots.values():
             self.assertTrue(len(slot_dict) == 2)
 
-        opt_wrapper._delete_variables()
+        opt_wrapper._delete_slots_and_weights_in_optimizer()
         self.assertTrue(len(opt._weights) == 0)
         self.assertTrue(len(opt._slots) == 0)
 


### PR DESCRIPTION
It is inefficient and slow to create variables for each mini-batch gradients. We can only create variables for the first mini-batch and reuse those variables by assigning new values in PS. So, we can speed up the `apply_gradient` in the OptimizerWrapper.