### PR TITLE
fix a worker relaunch bug when worker is relaunched after all training tasks are done

### DIFF
--- a/elasticdl/python/worker/task_data_service.py
+++ b/elasticdl/python/worker/task_data_service.py
@@ -1,4 +1,5 @@
 import threading
+import time
 from collections import deque
 
 import tensorflow as tf
@@ -153,11 +154,22 @@ class TaskDataService(object):
             # sure `read_records()` is executed without iterating all the
             # records so this should not be time consuming.
             if self._warm_up_task is None and not self._has_warmed_up:
-                task = self._worker.get_task()
-                self._warm_up_task = task
-                for _ in self.data_reader.read_records(task):
-                    break
-                self._has_warmed_up = True
+                while True:
+                    task = self._worker.get_task()
+                    if task.type != elasticdl_pb2.WAIT:
+                        break
+                    time.sleep(2)
+                if task.type == elasticdl_pb2.SAVE_MODEL:
+                    self._pending_save_model_task = task
+                    return None
+                elif not task.shard_name:
+                    logger.info("No more task, stopping")
+                    return None
+                else:
+                    self._warm_up_task = task
+                    for _ in self.data_reader.read_records(task):
+                        break
+                    self._has_warmed_up = True
             ds = tf.data.Dataset.from_generator(
                 self._gen, self.data_reader.records_output_types
             )
@@ -182,7 +194,7 @@ class TaskDataService(object):
                 if task.type == elasticdl_pb2.WAIT:
                     self._pending_dataset = True
                     logger.info(
-                        "Finish current dataset, maybe more data later"
+                        "No tasks for now, maybe more later"
                     )
                 else:
                     logger.info("No more task, stopping")

--- a/elasticdl/python/worker/task_data_service.py
+++ b/elasticdl/python/worker/task_data_service.py
@@ -193,9 +193,7 @@ class TaskDataService(object):
             if not task.shard_name:
                 if task.type == elasticdl_pb2.WAIT:
                     self._pending_dataset = True
-                    logger.info(
-                        "No tasks for now, maybe more later"
-                    )
+                    logger.info("No tasks for now, maybe more later")
                 else:
                     logger.info("No more task, stopping")
                 break

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -967,6 +967,7 @@ class Worker(object):
         while True:
             dataset = self._task_data_service.get_dataset()
             if not dataset:
+                self._process_save_model_task_if_needed()
                 break
             dataset = self._dataset_fn(
                 dataset,


### PR DESCRIPTION
Need to handle the case that when a worker pod is relaunched, there are no more tasks or only WAIT or SAVE_MODEL tasks.
