### PR TITLE
Use goproxy

### DIFF
--- a/elasticdl/README.md
+++ b/elasticdl/README.md
@@ -21,11 +21,12 @@ docker build \
 
 Note that since ElasticDL depends on TensorFlow, the base image must have TensorFlow installed.
 
-When having difficulties downloading from the main PyPI site, you could pass an extra PyPI index url to `docker build`, such as:
+When having difficulties downloading from the main PyPI site or Golang site, you could pass some extra build arguments to `docker build`, `EXTRA_PYPI_INDEX` for PyPI site and `GO_MIRROR_URL` for the mirror of Golang installation package:
 
 ```bash
 docker build \
     --build-arg EXTRA_PYPI_INDEX=https://mirrors.aliyun.com/pypi/simple \
+    --build-arg GO_MIRROR_URL=http://mirrors.ustc.edu.cn/golang \
     -t elasticdl:dev \
     -f elasticdl/docker/Dockerfile .
 ```

--- a/elasticdl/docker/Dockerfile.dev
+++ b/elasticdl/docker/Dockerfile.dev
@@ -13,6 +13,7 @@ RUN apt update && \
 COPY elasticdl/requirements.txt /requirements.txt
 COPY elasticdl/requirements-dev.txt /requirements-dev.txt
 ARG EXTRA_PYPI_INDEX=https://pypi.org/simple
+ARG GO_MIRROR_URL=https://dl.google.com/go
 RUN pip install -r /requirements.txt --extra-index-url=${EXTRA_PYPI_INDEX}
 RUN pip install -r /requirements-dev.txt --extra-index-url=${EXTRA_PYPI_INDEX}
 
@@ -20,7 +21,7 @@ RUN pip install -r /requirements-dev.txt --extra-index-url=${EXTRA_PYPI_INDEX}
 ENV GOPATH /root/go
 ENV PATH /usr/local/go/bin:$GOPATH/bin:$PATH
 COPY elasticdl/docker/scripts/install-go.bash /
-RUN /install-go.bash && rm /install-go.bash
+RUN /install-go.bash ${GO_MIRROR_URL} && rm /install-go.bash
 
 # Install protobuf and protoc
 COPY elasticdl/docker/scripts/install-protobuf.bash /

--- a/elasticdl/docker/scripts/install-go.bash
+++ b/elasticdl/docker/scripts/install-go.bash
@@ -2,7 +2,12 @@
 
 set -e
 
-curl --silent https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+GO_MIRROR_URL=$1
+
+curl --silent ${GO_MIRROR_URL}/go1.13.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+
+go env -w GO111MODULE=on
+go env -w GOPROXY=https://goproxy.io,direct
 
 go get github.com/golang/protobuf/protoc-gen-go
 go get golang.org/x/lint/golint


### PR DESCRIPTION
Fixes #1701. Changes include:
* Add an build argument which user can specify the url to download Golang installation package.
* Use goproxy to download go packages.