### PR TITLE
support tf.IndexedSlices gradient for dense param

### DIFF
--- a/elasticdl/docker/Dockerfile.dev
+++ b/elasticdl/docker/Dockerfile.dev
@@ -17,6 +17,26 @@ ARG GO_MIRROR_URL=https://dl.google.com/go
 RUN pip install -r /requirements.txt --extra-index-url=${EXTRA_PYPI_INDEX}
 RUN pip install -r /requirements-dev.txt --extra-index-url=${EXTRA_PYPI_INDEX}
 
+# Copy the data generation package to /var and run them from there.
+# This assumes that the data generation package is independent with the
+# rest part of ElasticDL.  The generated data will be in /data.
+COPY elasticdl/python/data/recordio_gen/image_label.py /var/image_label.py
+RUN python /var/image_label.py --dataset mnist --fraction 0.15 \
+	--records_per_shard 4096 /data
+
+# Copy frappe dataset
+COPY elasticdl/python/data/recordio_gen/frappe_recordio_gen.py /var/frappe_recordio_gen.py
+RUN python /var/frappe_recordio_gen.py --data /root/.keras/datasets --output_dir /data/frappe \
+    --fraction 0.05
+# Copy heart dataset
+COPY elasticdl/python/data/recordio_gen/heart_recordio_gen.py /var/heart_recordio_gen.py
+RUN python /var/heart_recordio_gen.py --data_dir /root/.keras/datasets --output_dir /data/heart
+# Copy census dataset
+COPY elasticdl/python/data/recordio_gen/census_recordio_gen.py /var/census_recordio_gen.py
+RUN python /var/census_recordio_gen.py --data_dir /root/.keras/datasets --output_dir /data/census
+
+RUN rm -rf /root/.keras/datasets
+
 # Install Go and related tools
 ENV GOPATH /root/go
 ENV PATH /usr/local/go/bin:$GOPATH/bin:$PATH
@@ -37,23 +57,3 @@ RUN cd /tmp/elasticdl && make -f elasticdl/Makefile && \
     export GO111MODULE=on && \
     go mod init elasticdl.org/elasticdl && \
     go install ./... && cd / && rm -rf /tmp/elasticdl
-
-# Copy the data generation package to /var and run them from there.
-# This assumes that the data generation package is independent with the
-# rest part of ElasticDL.  The generated data will be in /data.
-COPY elasticdl/python/data/recordio_gen/image_label.py /var/image_label.py
-RUN python /var/image_label.py --dataset mnist --fraction 0.15 \
-	--records_per_shard 4096 /data
-
-# Copy frappe dataset
-COPY elasticdl/python/data/recordio_gen/frappe_recordio_gen.py /var/frappe_recordio_gen.py
-RUN python /var/frappe_recordio_gen.py --data /root/.keras/datasets --output_dir /data/frappe \
-    --fraction 0.05
-# Copy heart dataset
-COPY elasticdl/python/data/recordio_gen/heart_recordio_gen.py /var/heart_recordio_gen.py
-RUN python /var/heart_recordio_gen.py --data_dir /root/.keras/datasets --output_dir /data/heart
-# Copy census dataset
-COPY elasticdl/python/data/recordio_gen/census_recordio_gen.py /var/census_recordio_gen.py
-RUN python /var/census_recordio_gen.py --data_dir /root/.keras/datasets --output_dir /data/census
-
-RUN rm -rf /root/.keras/datasets

--- a/elasticdl/pkg/kernel/capi/kernel_api.cc
+++ b/elasticdl/pkg/kernel/capi/kernel_api.cc
@@ -10,7 +10,7 @@ void AddTo(float* a, float* b, long long size) {
   Eigen::Map<Eigen::Array<float, 1, Eigen::Dynamic>> eb{
       b, static_cast<Eigen::Index>(size)};
 
-  a += b
+  ea += eb;
 }
 
 void SGD(float* grad, float* param, float lr, long long size) {

--- a/elasticdl/pkg/kernel/capi/kernel_api.cc
+++ b/elasticdl/pkg/kernel/capi/kernel_api.cc
@@ -3,6 +3,16 @@
 #include <cmath>
 #include <eigen3/Eigen/Dense>
 
+void AddTo(float* a, float* b, long long size) {
+  Eigen::Map<Eigen::Array<float, 1, Eigen::Dynamic>> ea{
+      a, static_cast<Eigen::Index>(size)};
+
+  Eigen::Map<Eigen::Array<float, 1, Eigen::Dynamic>> eb{
+      b, static_cast<Eigen::Index>(size)};
+
+  a += b
+}
+
 void SGD(float* grad, float* param, float lr, long long size) {
   Eigen::Map<Eigen::Array<float, 1, Eigen::Dynamic>> eg{
       grad, static_cast<Eigen::Index>(size)};

--- a/elasticdl/pkg/kernel/capi/kernel_api.h
+++ b/elasticdl/pkg/kernel/capi/kernel_api.h
@@ -5,6 +5,8 @@
 extern "C" {
 #endif
 
+void AddTo(float* a, float* b, long long size);
+
 void SGD(float* grad, float* param, float lr, long long size);
 
 void Adam(float* grad,

--- a/elasticdl/pkg/ps/optimizer.go
+++ b/elasticdl/pkg/ps/optimizer.go
@@ -29,18 +29,16 @@ func (opt *SGDOptimizer) GetLR() float32 {
 // ApplyGradients applies gradients to parameters
 func (opt *SGDOptimizer) ApplyGradients(grads []*common.Tensor, p *Parameter) error {
 	for _, grad := range grads {
-		if grad.Indices == nil {
-			t := p.GetNonEmbeddingParam(grad.Name)
-			if t == nil {
-				return fmt.Errorf("grad %s not in Parameter", grad.Name)
-			}
-			kernel.SGD(grad, t, opt.GetLR())
+		nonEmbeddingT := p.GetNonEmbeddingParam(grad.Name)
+		if nonEmbeddingT != nil {
+			kernel.SGD(grad, nonEmbeddingT, opt.GetLR())
 		} else {
-			t := p.GetEmbeddingParam(grad.Name)
-			if t == nil {
+			embeddingT := p.GetEmbeddingParam(grad.Name)
+			if embeddingT != nil {
+				kernel.SparseSGD(grad, embeddingT, opt.GetLR())
+			} else {
 				return fmt.Errorf("grad %s not in Parameter", grad.Name)
 			}
-			kernel.SparseSGD(grad, t, opt.GetLR())
 		}
 	}
 	return nil
@@ -69,31 +67,33 @@ type AdamOptimizer struct {
 func (opt *AdamOptimizer) ApplyGradients(grads []*common.Tensor, p *Parameter) error {
 	opt.step++
 	for _, grad := range grads {
-		if grad.Indices == nil {
-			t := p.GetNonEmbeddingParam(grad.Name)
+		nonEmbeddingT := p.GetNonEmbeddingParam(grad.Name)
+		if nonEmbeddingT != nil {
 			m := opt.m.GetNonEmbeddingParam(grad.Name)
 			v := opt.v.GetNonEmbeddingParam(grad.Name)
-			if t == nil || m == nil || v == nil {
-				return fmt.Errorf("grad %s not in Parameter", grad.Name)
-			}
 			if opt.amsgrad {
 				ms := opt.maxSquare.GetNonEmbeddingParam(grad.Name)
-				kernel.Adam(grad, t, m, v, opt.lr, opt.step, opt.beta1, opt.beta2, opt.epsilon, true, ms)
+				kernel.Adam(grad, nonEmbeddingT, m, v, opt.lr, opt.step,
+					opt.beta1, opt.beta2, opt.epsilon, true, ms)
 			} else {
-				kernel.Adam(grad, t, m, v, opt.lr, opt.step, opt.beta1, opt.beta2, opt.epsilon, false, nil)
+				kernel.Adam(grad, nonEmbeddingT, m, v, opt.lr, opt.step,
+					opt.beta1, opt.beta2, opt.epsilon, false, nil)
 			}
 		} else {
-			t := p.GetEmbeddingParam(grad.Name)
-			m := opt.m.GetEmbeddingParam(grad.Name)
-			v := opt.v.GetEmbeddingParam(grad.Name)
-			if t == nil || m == nil || v == nil {
-				return fmt.Errorf("grad %s not in Parameter", grad.Name)
-			}
-			if opt.amsgrad {
-				ms := opt.maxSquare.GetEmbeddingParam(grad.Name)
-				kernel.SparseAdam(grad, t, m, v, opt.lr, opt.step, opt.beta1, opt.beta2, opt.epsilon, true, ms)
+			embeddingT := p.GetEmbeddingParam(grad.Name)
+			if embeddingT != nil {
+				m := opt.m.GetEmbeddingParam(grad.Name)
+				v := opt.v.GetEmbeddingParam(grad.Name)
+				if opt.amsgrad {
+					ms := opt.maxSquare.GetEmbeddingParam(grad.Name)
+					kernel.SparseAdam(grad, embeddingT, m, v, opt.lr, opt.step,
+						opt.beta1, opt.beta2, opt.epsilon, true, ms)
+				} else {
+					kernel.SparseAdam(grad, embeddingT, m, v, opt.lr, opt.step,
+						opt.beta1, opt.beta2, opt.epsilon, false, nil)
+				}
 			} else {
-				kernel.SparseAdam(grad, t, m, v, opt.lr, opt.step, opt.beta1, opt.beta2, opt.epsilon, false, nil)
+				return fmt.Errorf("grad %s not in Parameter", grad.Name)
 			}
 		}
 	}


### PR DESCRIPTION
Current optimizer of Go PS could not handle native keras.embedding layer. It will generate a `tf.IndexedSlice` gradient, but the parameter is in NonEmbeddingParam.

This PR fix it.