### PR TITLE
Convert metric tensor to a numeric value

### DIFF
--- a/elasticdl/python/master/evaluation_service.py
+++ b/elasticdl/python/master/evaluation_service.py
@@ -89,13 +89,13 @@ class EvaluationJob(object):
         if self._model_have_multiple_outputs:
             return {
                 output_name: {
-                    metric_name: metric_inst.result()
+                    metric_name: metric_inst.result().numpy()
                     for metric_name, metric_inst in metrics.items()
                 }
                 for output_name, metrics in self._metrics_dict.items()
             }
         return {
-            metric_name: metric_inst.result()
+            metric_name: metric_inst.result().numpy()
             for metric_name, metric_inst in self._metrics_dict[
                 MetricsDictKey.MODEL_OUTPUT
             ].items()

--- a/elasticdl/python/tests/evaluation_service_test.py
+++ b/elasticdl/python/tests/evaluation_service_test.py
@@ -78,13 +78,9 @@ class EvaluationServiceTest(unittest.TestCase):
         )
         expected_acc = 0.25
         evaluation_metrics = job.get_evaluation_summary()
-        self.assertAlmostEqual(
-            expected_acc, evaluation_metrics.get("acc").numpy()
-        )
-        self.assertAlmostEqual(
-            expected_acc, evaluation_metrics.get("acc_fn").numpy()
-        )
-        self.assertAlmostEqual(10.125, evaluation_metrics.get("mse").numpy())
+        self.assertAlmostEqual(expected_acc, evaluation_metrics.get("acc"))
+        self.assertAlmostEqual(expected_acc, evaluation_metrics.get("acc_fn"))
+        self.assertAlmostEqual(10.125, evaluation_metrics.get("mse"))
 
     def testEvaluationService(self):
         task_d = _TaskDispatcher(


### PR DESCRIPTION
It is better to convert the metric tensors to numeric values for the evaluation summary.  The metrics logs will be more clear and simple.