### PR TITLE
merge redundant push gradients rpc

### DIFF
--- a/elasticdl/pkg/ps/server.go
+++ b/elasticdl/pkg/ps/server.go
@@ -133,12 +133,12 @@ func (s *Server) PushEmbeddingInfo(ctx context.Context, in *pb.Model) (*empty.Em
 	return &empty.Empty{}, err
 }
 
-// PushGradient pushes gradient to server
-func (s *Server) PushGradient(ctx context.Context, in *pb.PushGradientRequest) (*pb.PushGradientResponse, error) {
+// PushGradients pushes gradient to server
+func (s *Server) PushGradients(ctx context.Context, in *pb.Model) (*pb.PushGradientsResponse, error) {
 	// TODO(qijun) only support async now
-	var res pb.PushGradientResponse
+	var res pb.PushGradientsResponse
 	var grads []*common.Tensor
-	for _, gradPB := range in.Gradients {
+	for _, gradPB := range in.Param {
 		grad := common.DeserializeTensorPB(gradPB)
 		grads = append(grads, grad)
 	}
@@ -148,7 +148,7 @@ func (s *Server) PushGradient(ctx context.Context, in *pb.PushGradientRequest) (
 	s.versionLock.Unlock()
 	s.reportModelVersionIfNeeded(s.Param.Version)
 	res.Accepted = true
-	res.ModelVersion = s.Param.Version
+	res.Version = s.Param.Version
 	return &res, err
 }
 

--- a/elasticdl/pkg/ps/server_test.go
+++ b/elasticdl/pkg/ps/server_test.go
@@ -249,7 +249,7 @@ func TestPullEmbeddingVector(t *testing.T) {
 	gs.Stop()
 }
 
-func TestPushGradient(t *testing.T) {
+func TestPushGradients(t *testing.T) {
 	// Create a PS server
 	serverDone := make(chan bool)
 	s := NewServer(0, "SGD", "learning_rate=0.1;momentum=0.0;nesterov=false;", "", 0)
@@ -298,19 +298,19 @@ func TestPushGradient(t *testing.T) {
 	egi1 := []int64{3, 1, 3}
 	eg1 := common.Tensor{"e1", egv1, egd1, egi1}
 
-	var request2 pb.PushGradientRequest
-	request2.ModelVersion = 0
-	request2.Gradients = append(request2.Gradients, common.SerializeTensor(&g1))
-	request2.Gradients = append(request2.Gradients, common.SerializeTensor(&g2))
-	request2.Gradients = append(request2.Gradients, common.SerializeTensor(&eg1))
+	var request2 pb.Model
+	request2.Version = 0
+	request2.Param = append(request2.Param, common.SerializeTensor(&g1))
+	request2.Param = append(request2.Param, common.SerializeTensor(&g2))
+	request2.Param = append(request2.Param, common.SerializeTensor(&eg1))
 
-	res1, err2 := client.PushGradient(ctx, &request2)
+	res1, err2 := client.PushGradients(ctx, &request2)
 	if err2 != nil {
 		t.Errorf("Failed to pull gradients")
 	}
 
 	assert.True(t, res1.Accepted)
-	assert.Equal(t, int32(1), res1.ModelVersion)
+	assert.Equal(t, int32(1), res1.Version)
 
 	assert.Contains(t, s.Param.NonEmbeddingParam, "t1")
 	assert.Contains(t, s.Param.NonEmbeddingParam, "t2")

--- a/elasticdl/proto/elasticdl.proto
+++ b/elasticdl/proto/elasticdl.proto
@@ -137,16 +137,6 @@ message PullEmbeddingVectorRequest {
   repeated int64 ids = 2;
 }
 
-message PushGradientRequest {
-  int32 model_version = 1;
-  repeated Tensor gradients = 2;
-}
-
-message PushGradientResponse {
-  bool accepted = 1;
-  int32 model_version = 2;
-}
-
 message PullDenseParametersRequest {
   int32 version = 1;
 }
@@ -173,7 +163,6 @@ service Pserver {
   rpc pull_embedding_vector(PullEmbeddingVectorRequest) returns (Tensor);
   rpc push_model(Model) returns (google.protobuf.Empty);
   rpc push_embedding_info(Model) returns (google.protobuf.Empty);
-  rpc push_gradient(PushGradientRequest) returns (PushGradientResponse);
   // Following is the new rpc service described in concepts doc, after the
   // refactoring work old rpc service will be removed safely.
   rpc pull_dense_parameters(PullDenseParametersRequest)

--- a/elasticdl/python/tests/pserver_servicer_test.py
+++ b/elasticdl/python/tests/pserver_servicer_test.py
@@ -298,18 +298,18 @@ class PserverServicerTest(unittest.TestCase):
         self.push_gradient_test_setup()
 
         # Test applying gradients to embedding and non-embedding parameters
-        req = elasticdl_pb2.PushGradientRequest()
+        req = elasticdl_pb2.Model()
         for g, name in zip(self.grad_values0, self.var_names):
-            emplace_tensor_pb_from_ndarray(req.gradients, g, name=name)
+            emplace_tensor_pb_from_ndarray(req.param, g, name=name)
         emplace_tensor_pb_from_ndarray(
-            req.gradients,
+            req.param,
             values=self.embedding_grads0.values,
             indices=self.embedding_grads0.indices,
             name=self._embedding_info.name,
         )
-        res = self._stub.push_gradient(req)
+        res = self._stub.push_gradients(req)
         self.assertEqual(res.accepted, True)
-        self.assertEqual(res.model_version, 1)
+        self.assertEqual(res.version, 1)
         expected_values = [
             v - self._lr * g
             for v, g in zip(self.var_values, self.grad_values0)
@@ -336,14 +336,14 @@ class PserverServicerTest(unittest.TestCase):
         # Test applying gradients with same name
         for name, var in zip(self.var_names, self.var_values):
             self._parameters.non_embedding_params[name] = tf.Variable(var)
-        req = elasticdl_pb2.PushGradientRequest()
+        req = elasticdl_pb2.Model()
         for g in self.grad_values1:
             emplace_tensor_pb_from_ndarray(
-                req.gradients, g, name=self.var_names[0]
+                req.param, g, name=self.var_names[0]
             )
-        res = self._stub.push_gradient(req)
+        res = self._stub.push_gradients(req)
         self.assertEqual(res.accepted, True)
-        self.assertEqual(res.model_version, 2)
+        self.assertEqual(res.version, 2)
         expected_values = [
             self.var_values[0]
             - self._lr * self.grad_values1[0]
@@ -364,41 +364,41 @@ class PserverServicerTest(unittest.TestCase):
         )
         self.push_gradient_test_setup()
 
-        req = elasticdl_pb2.PushGradientRequest()
-        req.model_version = 0
+        req = elasticdl_pb2.Model()
+        req.version = 0
         for g, name in zip(self.grad_values0, self.var_names):
-            emplace_tensor_pb_from_ndarray(req.gradients, g, name=name)
+            emplace_tensor_pb_from_ndarray(req.param, g, name=name)
         emplace_tensor_pb_from_ndarray(
-            req.gradients,
+            req.param,
             values=self.embedding_grads0.values,
             indices=self.embedding_grads0.indices,
             name=self._embedding_info.name,
         )
-        res = self._stub.push_gradient(req)
+        res = self._stub.push_gradients(req)
         self.assertEqual(res.accepted, True)
-        self.assertEqual(res.model_version, 0)
+        self.assertEqual(res.version, 0)
 
-        req = elasticdl_pb2.PushGradientRequest()
-        req.model_version = 0
+        req = elasticdl_pb2.Model()
+        req.version = 0
         for g, name in zip(self.grad_values1, self.var_names):
-            emplace_tensor_pb_from_ndarray(req.gradients, g, name=name)
+            emplace_tensor_pb_from_ndarray(req.param, g, name=name)
         emplace_tensor_pb_from_ndarray(
-            req.gradients,
+            req.param,
             values=self.embedding_grads1.values,
             indices=self.embedding_grads1.indices,
             name=self._embedding_info.name,
         )
-        res = self._stub.push_gradient(req)
+        res = self._stub.push_gradients(req)
         self.assertEqual(res.accepted, True)
-        self.assertEqual(res.model_version, 1)
+        self.assertEqual(res.version, 1)
 
-        req = elasticdl_pb2.PushGradientRequest()
-        req.model_version = 0
+        req = elasticdl_pb2.Model()
+        req.version = 0
         for g, name in zip(self.grad_values1, self.var_names):
-            emplace_tensor_pb_from_ndarray(req.gradients, g, name=name)
-        res = self._stub.push_gradient(req)
+            emplace_tensor_pb_from_ndarray(req.param, g, name=name)
+        res = self._stub.push_gradients(req)
         self.assertEqual(res.accepted, False)
-        self.assertEqual(res.model_version, 1)
+        self.assertEqual(res.version, 1)
 
         expected_values = [
             self.var_values[0]

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -460,9 +460,7 @@ class Worker(object):
 
     def report_gradient_to_ps(self, grads):
         self._timing.start_record_time("report_gradient")
-        reqs = [
-            elasticdl_pb2.PushGradientRequest() for i in range(self._ps_num)
-        ]
+        reqs = [elasticdl_pb2.Model() for i in range(self._ps_num)]
         ps_grads = {}
         non_embed_vars_n = len(self._non_embed_vars)
         for g, v in zip(
@@ -477,7 +475,7 @@ class Worker(object):
         for ps_id in ps_grads:
             req = reqs[ps_id]
             for g, name in ps_grads[ps_id]:
-                emplace_tensor_pb_from_ndarray(req.gradients, g, name=name)
+                emplace_tensor_pb_from_ndarray(req.param, g, name=name)
 
         edl_embedding_name_values = self._collect_edl_embedding_name_values()
 
@@ -525,14 +523,14 @@ class Worker(object):
                     req = reqs[ps_id]
                     gv, gi = results[ps_id]
                     emplace_tensor_pb_from_ndarray(
-                        req.gradients, values=gv, indices=gi, name=name
+                        req.param, values=gv, indices=gi, name=name
                     )
 
         report_futures = []
         for ps_id in range(self._ps_num):
             req = reqs[ps_id]
-            req.model_version = self._model_versions_from_ps[ps_id]
-            report_future = self._ps_stubs[ps_id].push_gradient.future(req)
+            req.version = self._model_versions_from_ps[ps_id]
+            report_future = self._ps_stubs[ps_id].push_gradients.future(req)
             report_futures.append(report_future)
 
         accepted = False
@@ -541,8 +539,8 @@ class Worker(object):
             res = report_future.result()
             if res.accepted:
                 accepted = True
-            if res.model_version > max_version:
-                max_version = res.model_version
+            if res.version > max_version:
+                max_version = res.version
         self._timing.end_record_time("report_gradient")
         return accepted, max_version
 


### PR DESCRIPTION
Previously, there are two rpc in elasticdl.proto

https://github.com/sql-machine-learning/elasticdl/blob/0a6858da862f6d3f15f41b2c4693078972f848c4/elasticdl/proto/elasticdl.proto#L171-L184

One is `push_gradient`, the other is `push_gradients`.

The `push_gradients` is new one use `TensorProto` message of TF.  This PR removes the old one, `push_gradient`.