### PR TITLE
Support reusing the built image while submitting ElasticDL job (#1736)

### DIFF
--- a/docs/tutorials/elasticdl_local.md
+++ b/docs/tutorials/elasticdl_local.md
@@ -2,7 +2,6 @@
 
 This document aims to give a simple example to show how to submit deep learning jobs to a local kubernetes cluster in a local computer. It helps to understand the working process of ElasticDL.
 
-
 ## Environment preparation
 
 Here we should install Minikube first. Please refer to the official [installation guide](https://kubernetes.io/docs/tasks/tools/install-minikube/).
@@ -34,7 +33,6 @@ bash elasticdl/docker/build_all.sh
 
 ### Summit a training job
 
-
 There are other docker settings that you might also want to configure prior to submitting the training job. Please run `minikube docker-env` to get docker host url and docker cert path.
 
 A possible example could be:
@@ -44,7 +42,6 @@ export DOCKER_BASE_URL=tcp://192.168.64.5:2376
 export DOCKER_TLSCERT=${HOME}/.minikube/certs/cert.pem
 export DOCKER_TLSKEY=${HOME}/.minikube/certs/key.pem
 ```
-
 
 ```bash
 elasticdl train \
@@ -73,6 +70,35 @@ elasticdl train \
   --output=model_output
 ```
 
+We can also use the pre-built docker image to run the ElasticDL job.
+In the following command, the pre-built image name is `elasticdl:mnist`, the absolute model zoo path inside the docker is `/model_zoo/model_zoo`.
+
+```bash
+elasticdl train \
+  --image_name=elasticdl:mnist \
+  --docker_base_url=${DOCKER_BASE_URL} \
+  --docker_tlscert=${DOCKER_TLSCERT} \
+  --docker_tlskey=${DOCKER_TLSKEY} \
+  --model_zoo=/model_zoo/model_zoo \
+  --model_def=mnist_functional_api.mnist_functional_api.custom_model \
+  --training_data=/data/mnist/train \
+  --validation_data=/data/mnist/test \
+  --num_epochs=2 \
+  --master_resource_request="cpu=400m,memory=1024Mi" \
+  --master_resource_limit="cpu=1,memory=2048Mi" \
+  --worker_resource_request="cpu=400m,memory=2048Mi" \
+  --worker_resource_limit="cpu=1,memory=3072Mi" \
+  --minibatch_size=64 \
+  --num_minibatches_per_task=2 \
+  --num_workers=2 \
+  --checkpoint_steps=10 \
+  --evaluation_steps=15 \
+  --grads_to_wait=2 \
+  --job_name=test-mnist \
+  --log_level=INFO \
+  --image_pull_policy=Never \
+  --output=model_output
+```
 
 ### Check job status
 
@@ -84,7 +110,7 @@ kubectl get pods
 
 You should see information on each pod like the following:
 
-```
+```bash
 $kubectl get pods
 NAME                            READY   STATUS    RESTARTS   AGE
 elasticdl-test-mnist-master     1/1     Running   0          14s

--- a/docs/tutorials/elasticdl_on_prem_cluster.md
+++ b/docs/tutorials/elasticdl_on_prem_cluster.md
@@ -20,12 +20,11 @@ Following is an exmaple:
 export DOCKER_HUB_REPO=reg.docker.com/user/
 ```
 
-
 ```bash
 elasticdl train \
  --image_base=elasticdl:ci \
- --model_zoo=./model_zoo \
  --docker_image_prefix=$DOCKER_HUB_REPO \
+ --model_zoo=./model_zoo \
  --model_def=mnist_functional_api.mnist_functional_api.custom_model \
  --training_data=/data/mnist/train \
  --validation_data=/data/mnist/test \
@@ -44,3 +43,26 @@ elasticdl train \
 ```
 
 Then the job will be launched on the cluster.
+
+By the way, we can also use the pre-built image to submit the ElasticDL job.
+
+```bash
+elasticdl train \
+ --image_base=reg.docker.com/user/elasticdl:mnist \
+ --model_zoo=/model_zoo/model_zoo \
+ --model_def=mnist_functional_api.mnist_functional_api.custom_model \
+ --training_data=/data/mnist/train \
+ --validation_data=/data/mnist/test \
+ --num_epochs=2 \
+ --master_resource_request="cpu=1,memory=2048Mi,ephemeral-storage=5000Mi" \
+ --worker_resource_request="cpu=1,memory=2048Mi,ephemeral-storage=5000Mi" \
+ --minibatch_size=64 \
+ --num_minibatches_per_task=2 \
+ --num_workers=2 \
+ --checkpoint_steps=10 \
+ --grads_to_wait=2 \
+ --job_name=test-mnist \
+ --log_level=INFO \
+ --image_pull_policy=Always \
+ --namespace=kubemaker
+```

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -107,7 +107,18 @@ def add_common_params(parser):
         help="The repository for generated Docker images, if set, the image "
         "is also pushed to the repository",
     )
-    parser.add_argument("--image_base", help="Base Docker image.")
+    parser.add_argument(
+        "--image_base",
+        default="",
+        help="Base Docker image. If set, a new image will be built each time"
+        "while submitting the Elastic job.",
+    )
+    parser.add_argument(
+        "--image_name",
+        default="",
+        help="The pre-built image for this job. If set, "
+        "use this image instead of building a new one.",
+    )
     parser.add_argument("--job_name", help="ElasticDL job name", required=True)
     parser.add_argument(
         "--master_resource_request",
@@ -226,7 +237,8 @@ def add_common_params(parser):
     )
     parser.add_argument(
         "--cluster_spec",
-        help="The file that contains user-defined cluster specification",
+        help="The file that contains user-defined cluster specification,"
+        "the file path can be accessed by ElasticDL client.",
         default="",
     )
     parser.add_argument(
@@ -442,7 +454,9 @@ def add_common_args_between_master_and_worker(parser):
     parser.add_argument(
         "--model_zoo",
         help="The directory that contains user-defined model files "
-        "or a specific model file",
+        "or a specific model file. If set `image_base`, the path should"
+        "be accessed by ElasticDL client. If set `image_name`, it is"
+        "the path inside this pre-built image.",
         required=True,
     )
     parser.add_argument(


### PR DESCRIPTION
* Reuse the existed image if the image name is passed from the arguments

* Add image_name in the args

* Add default value for image_base and image_name

* Resolve pre-commit issue

* Do some rephrase

* If user set image_name, model_zoo and cluster_spec value is the path inside the docker

* Add the example to use the pre-built image in the tutorial

* Update the model zoo path in the tutorial example

* Add more description for the arguments