### PR TITLE
Clear session before cloning model to train.

### DIFF
--- a/elasticdl/python/common/model_handler.py
+++ b/elasticdl/python/common/model_handler.py
@@ -202,6 +202,8 @@ class ParameterServerModelHandler(ModelHandler):
         """Replace the tf.keras.layers.Embedding layer in the model with
         an elasticdl.layers.Embedding layer in ParameterServerStrategy.
         """
+        # clear keras model session to avoid clutter from old models/layers.
+        tf.keras.backend.clear_session()
         if type(model) == tf.keras.Sequential or model._is_graph_network:
             model = self._clone_model_with_edl_embedding(model)
         else:


### PR DESCRIPTION
The  `tf.keras.models.clone_model` will return a new model instance and the variable name of the new model will be added a `suffix`. For example:
```
import tensorflow as tf
def custom_model_with_embedding_layer():
    inputs = tf.keras.layers.Input(shape=(4,), name="x")
    embedding = tf.keras.layers.Embedding(300, 2)(inputs)
    outputs = tf.keras.layers.Dense(1)(embedding)
    return tf.keras.models.Model(inputs, outputs)


model = custom_model_with_embedding_layer()
print(model.inputs)
    
model_1 = tf.keras.models.clone_model(model)
print(model_1.inputs)
```

[<tf.Tensor 'x:0' shape=(None, 4) dtype=float32>]
[<tf.Tensor 'x_1:0' shape=(None, 4) dtype=float32>]