### PR TITLE
Retry to read records from MAXCOMPUTE

### DIFF
--- a/elasticdl/python/data/odps_io.py
+++ b/elasticdl/python/data/odps_io.py
@@ -243,8 +243,8 @@ class ODPSReader(object):
     def record_generator_with_retry(
         self, start, end, columns=None, max_retries=3
     ):
-        """Retry to read records from ODPS table by using to avoid
-        the network instability.
+        """Wrap record_generator with retry to avoid ODPS table read failure
+        due to network instability.
         """
         retry_count = 0
         while retry_count < max_retries:

--- a/elasticdl/python/data/odps_io.py
+++ b/elasticdl/python/data/odps_io.py
@@ -240,6 +240,29 @@ class ODPSReader(object):
                 time.sleep(5)
                 retry_count += 1
 
+    def record_generator_with_retry(
+        self, start, end, columns=None, max_retries=3
+    ):
+        """Retry to read records from ODPS table by using to avoid
+        the network instability.
+        """
+        retry_count = 0
+        while retry_count < max_retries:
+            try:
+                for record in self.record_generator(start, end, columns):
+                    yield record
+            except Exception as e:
+                if retry_count >= max_retries:
+                    raise Exception("Exceeded maximum number of retries")
+                logger.warning(
+                    "ODPS read exception {} for {} in {}."
+                    "Retrying time: {}".format(
+                        e, columns, self._table, retry_count
+                    )
+                )
+                time.sleep(5)
+                retry_count += 1
+
     def record_generator(self, start, end, columns=None):
         """Generate records from an ODPS table
         """

--- a/elasticdl/python/data/reader/odps_reader.py
+++ b/elasticdl/python/data/reader/odps_reader.py
@@ -25,7 +25,7 @@ class ODPSDataReader(AbstractDataReader):
                 reader._odps_table.schema.names if columns is None else columns
             )
 
-        for record in reader.record_generator(
+        for record in reader.record_generator_with_retry(
             start=task.start, end=task.end, columns=self._metadata.column_names
         ):
             yield record


### PR DESCRIPTION
The MAXCOMPUTE reader downloads records by https request and the timeout may happen sometimes. So it is better to retry if an error happens.