### PR TITLE
Remove the extra "/model_zoo" when copy the model zoo files. 

### DIFF
--- a/docs/tutorials/elasticdl_local.md
+++ b/docs/tutorials/elasticdl_local.md
@@ -71,7 +71,7 @@ elasticdl train \
 ```
 
 We can also use the pre-built docker image to run the ElasticDL job.
-In the following command, the pre-built image name is `elasticdl:mnist`, the absolute model zoo path inside the docker is `/model_zoo/model_zoo`.
+In the following command, the pre-built image name is `elasticdl:mnist`, the absolute model zoo path inside the docker is `/model_zoo`.
 
 ```bash
 elasticdl train \
@@ -79,7 +79,7 @@ elasticdl train \
   --docker_base_url=${DOCKER_BASE_URL} \
   --docker_tlscert=${DOCKER_TLSCERT} \
   --docker_tlskey=${DOCKER_TLSKEY} \
-  --model_zoo=/model_zoo/model_zoo \
+  --model_zoo=/model_zoo \
   --model_def=mnist_functional_api.mnist_functional_api.custom_model \
   --training_data=/data/mnist/train \
   --validation_data=/data/mnist/test \

--- a/docs/tutorials/elasticdl_on_prem_cluster.md
+++ b/docs/tutorials/elasticdl_on_prem_cluster.md
@@ -49,7 +49,7 @@ By the way, we can also use the pre-built image to submit the ElasticDL job.
 ```bash
 elasticdl train \
  --image_base=reg.docker.com/user/elasticdl:mnist \
- --model_zoo=/model_zoo/model_zoo \
+ --model_zoo=/model_zoo \
  --model_def=mnist_functional_api.mnist_functional_api.custom_model \
  --training_data=/data/mnist/train \
  --validation_data=/data/mnist/test \

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -201,7 +201,7 @@ def _model_zoo_in_docker(model_zoo, image_pre_built):
     if image_pre_built:
         return model_zoo
 
-    MODEL_ROOT_PATH = "/model_zoo"
+    MODEL_ROOT_PATH = "/"
     return os.path.join(MODEL_ROOT_PATH, os.path.basename(model_zoo))
 
 

--- a/elasticdl/python/elasticdl/image_builder.py
+++ b/elasticdl/python/elasticdl/image_builder.py
@@ -139,7 +139,7 @@ def _create_dockerfile(
 ):
     HEAD = """
 FROM {BASE_IMAGE} as base
-ENV PYTHONPATH=/:/model_zoo
+ENV PYTHONPATH=/
 """
     if elasticdl:
         HEAD = """
@@ -154,14 +154,14 @@ COPY %s/elasticdl /elasticdl
 RUN pip install -r /elasticdl/requirements.txt \
   --extra-index-url="${EXTRA_PYPI_INDEX}"
 RUN make -f /elasticdl/Makefile
-COPY {MODEL_ZOO} /model_zoo/{MODEL_ZOO}
+COPY {MODEL_ZOO} /{MODEL_ZOO}
 """
     REMOTE_ZOO = """
 RUN pip install -r /elasticdl/requirements.txt \
   --extra-index-url="${EXTRA_PYPI_INDEX}"
 RUN make -f /elasticdl/Makefile
 RUN apt-get update && apt-get install -y git
-RUN git clone --recursive {MODEL_ZOO} /model_zoo
+RUN git clone --recursive {MODEL_ZOO} /
 """
     pr = urlparse(model_zoo)
     if not pr.path:
@@ -187,7 +187,7 @@ COPY %s /cluster_spec/%s
     tmpl = (
         """
 %s
-ARG REQS=/model_zoo/{MODEL_ZOO}/requirements.txt
+ARG REQS=/{MODEL_ZOO}/requirements.txt
 RUN if [ -f $REQS ]; then \
       pip install -r $REQS --extra-index-url="${EXTRA_PYPI_INDEX}"; \
     fi

--- a/scripts/client_test.sh
+++ b/scripts/client_test.sh
@@ -42,7 +42,7 @@ elif [[ "$JOB_TYPE" == "evaluate" ]]; then
       --image_base=elasticdl:ci \
       --model_zoo=model_zoo \
       --model_def=mnist_functional_api.mnist_functional_api.custom_model \
-      --checkpoint_dir_for_init=model_zoo/${MNIST_CKPT_DIR}/version-100  \
+      --checkpoint_dir_for_init=/${MNIST_CKPT_DIR}/version-100  \
       --validation_data=/data/mnist/test \
       --num_epochs=1 \
       --master_resource_request="cpu=0.3,memory=1024Mi" \
@@ -65,7 +65,7 @@ elif [[ "$JOB_TYPE" == "predict" ]]; then
       --image_base=elasticdl:ci \
       --model_zoo=model_zoo \
       --model_def=mnist_functional_api.mnist_functional_api.custom_model \
-      --checkpoint_dir_for_init=model_zoo/${MNIST_CKPT_DIR}/version-100 \
+      --checkpoint_dir_for_init=/${MNIST_CKPT_DIR}/version-100 \
       --prediction_data=/data/mnist/test \
       --master_resource_request="cpu=0.2,memory=1024Mi" \
       --master_resource_limit="cpu=1,memory=2048Mi" \


### PR DESCRIPTION
Fix #1740