### PR TITLE
fix worker crash when master stops before worker pods

### DIFF
--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -309,6 +309,8 @@ class Worker(object):
         try:
             res = self._stub.get_task(req)
         except Exception:
+            # Master may have stopped GRPC service when there are no more
+            # tasks. This will result in a GRPC call exception.
             self.logger.info(
                 "Cannot connect to master, assuming no more tasks"
             )

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -306,7 +306,14 @@ class Worker(object):
         if task_type is not None:
             req.task_type = task_type
 
-        return self._stub.get_task(req)
+        try:
+            res = self._stub.get_task(req)
+        except Exception:
+            self.logger.info(
+                "Cannot connect to master, assuming no more tasks"
+            )
+            res = elasticdl_pb2.Task()
+        return res
 
     def get_model(self):
         self._timing.start_record_time("get_model")


### PR DESCRIPTION
On some occasions, when the master stops, workers may still call rpc service `get_task`, which will result in a crash. Avoid the crash by assuming that when the master connection is lost, there are no more tasks.

```
Traceback (most recent call last):

  File "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/ops/script_ops.py", line 236, in __call__
    ret = func(*args)

  File "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/data/ops/dataset_ops.py", line 789, in generator_py_func
    values = next(generator_state.get_iterator(iterator_id))

  File "/elasticdl/python/worker/task_data_service.py", line 192, in _gen
    task = self._worker.get_task()

  File "/elasticdl/python/worker/worker.py", line 293, in get_task
    return self._stub.get_task(req)

  File "/usr/local/lib/python3.6/dist-packages/grpc/_channel.py", line 826, in __call__
    return _end_unary_response_blocking(state, call, False, None)

  File "/usr/local/lib/python3.6/dist-packages/grpc/_channel.py", line 729, in _end_unary_response_blocking
    raise _InactiveRpcError(state)

grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.UNAVAILABLE
        details = "Socket closed"
        debug_error_string = "{"created":"@1582206732.997487772","description":"Error received from peer ipv4:11.146.6.179:50001","file":"src/core/lib/surface/call.cc","file_line":1056,"grpc_message":"Socket closed","grpc_status":14}"
>

```