### PR TITLE
Refine embedding table info

### DIFF
--- a/elasticdl/pkg/ps/model.go
+++ b/elasticdl/pkg/ps/model.go
@@ -49,7 +49,7 @@ func (model *Model) SetEmbeddingTableInfo(info *proto.EmbeddingTableInfo) {
 
 // InitFromModelPB inits the model from model PB
 func (model *Model) InitFromModelPB(pb *proto.Model) error {
-	for _, v := range pb.EmbeddingTableInfo {
+	for _, v := range pb.EmbeddingTableInfos {
 		model.SetEmbeddingTableInfo(v)
 	}
 	for name, v := range pb.DenseParameters {

--- a/elasticdl/pkg/ps/model_test.go
+++ b/elasticdl/pkg/ps/model_test.go
@@ -31,9 +31,9 @@ func TestModelInit(t *testing.T) {
 
 func TestModelInitFrom(t *testing.T) {
 	var modelPB = proto.Model{
-		Version:            int32(1),
-		EmbeddingTables:    make(map[string]*proto.IndexedSlicesProto),
-		EmbeddingTableInfo: []*proto.EmbeddingTableInfo{},
+		Version:             int32(1),
+		EmbeddingTables:     make(map[string]*proto.IndexedSlicesProto),
+		EmbeddingTableInfos: []*proto.EmbeddingTableInfo{},
 	}
 	d1 := []int64{3, 2}
 	v1 := []float32{1.0, 2.0, 3.0, 4.0, 5.0, 6.0}
@@ -53,7 +53,7 @@ func TestModelInitFrom(t *testing.T) {
 		Initializer: "zero",
 		Dtype:       common.Float32,
 	}
-	modelPB.EmbeddingTableInfo = append(modelPB.EmbeddingTableInfo, &epb)
+	modelPB.EmbeddingTableInfos = append(modelPB.EmbeddingTableInfos, &epb)
 
 	model := NewModel()
 	assert.NotNil(t, model)

--- a/elasticdl/pkg/ps/optimizer.go
+++ b/elasticdl/pkg/ps/optimizer.go
@@ -165,7 +165,7 @@ func (opt *AdamOptimizer) InitOptimizer(pb *proto.Model) error {
 			opt.maxSquare.DenseParameters[name] = common.NewEmptyTensor(dims, dtype)
 		}
 	}
-	for _, info := range pb.EmbeddingTableInfo {
+	for _, info := range pb.EmbeddingTableInfos {
 		opt.m.SetEmbeddingTableInfo(info)
 		opt.v.SetEmbeddingTableInfo(info)
 		opt.maxSquare.SetEmbeddingTableInfo(info)

--- a/elasticdl/pkg/ps/optimizer_test.go
+++ b/elasticdl/pkg/ps/optimizer_test.go
@@ -120,7 +120,7 @@ func TestAdamOptimizer(t *testing.T) {
 	grad2 := common.NewTensor(gv2, d2) //t2
 	pbModel := &proto.Model{
 		DenseParameters: map[string]*tensor_go_proto.TensorProto{"t1": grad1.SerializeToTensorProto(), "t2": grad2.SerializeToTensorProto()},
-		EmbeddingTableInfo: []*proto.EmbeddingTableInfo{
+		EmbeddingTableInfos: []*proto.EmbeddingTableInfo{
 			&proto.EmbeddingTableInfo{
 				Name:        "t3",
 				Dim:         2,

--- a/elasticdl/pkg/ps/server.go
+++ b/elasticdl/pkg/ps/server.go
@@ -139,8 +139,8 @@ func (s *Server) PushModel(ctx context.Context, in *proto.Model) (*empty.Empty, 
 	return &empty.Empty{}, err
 }
 
-// PushEmbeddingInfo pushes embedding info to server
-func (s *Server) PushEmbeddingInfo(ctx context.Context, in *proto.Model) (*empty.Empty, error) {
+// PushEmbeddingTableInfos pushes embedding table infos to server
+func (s *Server) PushEmbeddingTableInfos(ctx context.Context, in *proto.Model) (*empty.Empty, error) {
 	s.lock.Lock()
 	err := s.Model.InitFromModelPB(in)
 	s.lock.Unlock()

--- a/elasticdl/pkg/ps/server_test.go
+++ b/elasticdl/pkg/ps/server_test.go
@@ -101,7 +101,7 @@ func TestPushModel(t *testing.T) {
 	var request = &proto.Model{
 		DenseParameters: make(map[string]*tensor_go_proto.TensorProto),
 		EmbeddingTables: make(map[string]*proto.IndexedSlicesProto),
-		EmbeddingTableInfo: []*proto.EmbeddingTableInfo{&proto.EmbeddingTableInfo{
+		EmbeddingTableInfos: []*proto.EmbeddingTableInfo{&proto.EmbeddingTableInfo{
 			Name:        "e1",
 			Dim:         2,
 			Initializer: "zero",
@@ -150,7 +150,7 @@ func TestPullEmbeddingVectors(t *testing.T) {
 	var request = &proto.Model{
 		DenseParameters: make(map[string]*tensor_go_proto.TensorProto),
 		EmbeddingTables: make(map[string]*proto.IndexedSlicesProto),
-		EmbeddingTableInfo: []*proto.EmbeddingTableInfo{&proto.EmbeddingTableInfo{
+		EmbeddingTableInfos: []*proto.EmbeddingTableInfo{&proto.EmbeddingTableInfo{
 			Name:        "e1",
 			Dim:         10,
 			Initializer: "zero",
@@ -202,7 +202,7 @@ func TestPullDenseParameters(t *testing.T) {
 	var request = &proto.Model{
 		DenseParameters: make(map[string]*tensor_go_proto.TensorProto),
 		EmbeddingTables: make(map[string]*proto.IndexedSlicesProto),
-		EmbeddingTableInfo: []*proto.EmbeddingTableInfo{&proto.EmbeddingTableInfo{
+		EmbeddingTableInfos: []*proto.EmbeddingTableInfo{&proto.EmbeddingTableInfo{
 			Name:        "e1",
 			Dim:         10,
 			Initializer: "zero",
@@ -256,7 +256,7 @@ func TestPushGradients(t *testing.T) {
 	var request = &proto.Model{
 		DenseParameters: make(map[string]*tensor_go_proto.TensorProto),
 		EmbeddingTables: make(map[string]*proto.IndexedSlicesProto),
-		EmbeddingTableInfo: []*proto.EmbeddingTableInfo{&proto.EmbeddingTableInfo{
+		EmbeddingTableInfos: []*proto.EmbeddingTableInfo{&proto.EmbeddingTableInfo{
 			Name:        "e1",
 			Dim:         10,
 			Initializer: "zero",

--- a/elasticdl/proto/elasticdl.proto
+++ b/elasticdl/proto/elasticdl.proto
@@ -50,26 +50,6 @@ message Task {
   map<string, string> extended_config = 8;
 }
 
-message Tensor {
-  // Tensor name
-  string name = 1;
-
-  // Dimensions of the tensor. The first entry in "dim" is the outermost
-  // dimension used to layout the values, the last entry is the innermost
-  // dimension.
-  repeated int64 dim = 2;
-
-  // ndarray's buffer dump. Each element must be a 32 bit float value.
-  bytes content = 3;
-
-  // Indices will be tf.IndexedSlices.indices if the tensor is in the form
-  // of tf.IndexedSlices. Otherwise indices will be None.
-  repeated int64 indices = 4;
-
-  // Dtype of the tensor, e.g. "int64", "float32".
-  tensorflow.DataType dtype = 5;
-}
-
 message IndexedSlicesProto {
   tensorflow.TensorProto concat_tensors = 1;
   repeated int64 ids = 2;
@@ -84,10 +64,9 @@ message EmbeddingTableInfo {
 
 message Model {
   int32 version = 1;
-  repeated Tensor param = 2;
-  repeated EmbeddingTableInfo embedding_table_info = 3;
-  map<string, tensorflow.TensorProto> dense_parameters = 4;
-  map<string, IndexedSlicesProto> embedding_tables = 5;
+  repeated EmbeddingTableInfo embedding_table_infos = 2;
+  map<string, tensorflow.TensorProto> dense_parameters = 3;
+  map<string, IndexedSlicesProto> embedding_tables = 4;
 }
 
 message GetTaskRequest {
@@ -124,15 +103,6 @@ service Master {
   rpc report_version(ReportVersionRequest) returns (google.protobuf.Empty);
 }
 
-message PullVariableRequest {
-  int32 current_model_version = 1;
-}
-
-message PullVariableResponse {
-  bool model_init_status = 1;
-  Model model = 2;
-}
-
 message PullEmbeddingVectorRequest {
   string name = 1;
   repeated int64 ids = 2;
@@ -160,12 +130,8 @@ message PushGradientsResponse {
 
 // PS service
 service Pserver {
-  rpc pull_variable(PullVariableRequest) returns (PullVariableResponse);
-  rpc pull_embedding_vector(PullEmbeddingVectorRequest) returns (Tensor);
   rpc push_model(Model) returns (google.protobuf.Empty);
-  rpc push_embedding_info(Model) returns (google.protobuf.Empty);
-  // Following is the new rpc service described in concepts doc, after the
-  // refactoring work old rpc service will be removed safely.
+  rpc push_embedding_table_infos(Model) returns (google.protobuf.Empty);
   rpc pull_dense_parameters(PullDenseParametersRequest)
       returns (PullDenseParametersResponse);
   rpc pull_embedding_vectors(PullEmbeddingVectorsRequest)

--- a/elasticdl/python/common/save_utils.py
+++ b/elasticdl/python/common/save_utils.py
@@ -239,7 +239,7 @@ class CheckpointSaver(object):
                     "The versions in model shards are not consistency"
                 )
 
-            for embedding_info_pb in model_pb.embedding_table_info:
+            for embedding_info_pb in model_pb.embedding_table_infos:
                 embedding_table = create_embedding_table(embedding_info_pb)
                 embedding_tables.setdefault(
                     embedding_table.name, embedding_table

--- a/elasticdl/python/ps/embedding_table.py
+++ b/elasticdl/python/ps/embedding_table.py
@@ -2,6 +2,7 @@ import numpy as np
 import tensorflow as tf
 
 from elasticdl.proto.elasticdl_pb2 import EmbeddingTableInfo
+from elasticdl.python.common.dtypes import dtype_numpy_to_tensor
 
 
 class EmbeddingTable(object):
@@ -31,6 +32,8 @@ class EmbeddingTable(object):
         self.name = name
         self.dim = dim
         self.initializer_value = initializer
+        # set dtype to float32
+        self.dtype = np.float32
         if is_slot:
             self.initializer = tf.keras.initializers.Constant(
                 float(self.initializer_value)
@@ -79,6 +82,7 @@ class EmbeddingTable(object):
         embedding_pb.name = self.name
         embedding_pb.dim = self.dim
         embedding_pb.initializer = str(self.initializer_value)
+        embedding_pb.dtype = dtype_numpy_to_tensor[self.dtype]
         return embedding_pb
 
     def get_table_size(self):

--- a/elasticdl/python/ps/embedding_table.py
+++ b/elasticdl/python/ps/embedding_table.py
@@ -82,7 +82,7 @@ class EmbeddingTable(object):
         embedding_pb.name = self.name
         embedding_pb.dim = self.dim
         embedding_pb.initializer = str(self.initializer_value)
-        embedding_pb.dtype = dtype_numpy_to_tensor[self.dtype]
+        embedding_pb.dtype = dtype_numpy_to_tensor(self.dtype)
         return embedding_pb
 
     def get_table_size(self):

--- a/elasticdl/python/ps/embedding_table.py
+++ b/elasticdl/python/ps/embedding_table.py
@@ -33,7 +33,7 @@ class EmbeddingTable(object):
         self.dim = dim
         self.initializer_value = initializer
         # set dtype to float32
-        self.dtype = np.float32
+        self.dtype = np.dtype("float32")
         if is_slot:
             self.initializer = tf.keras.initializers.Constant(
                 float(self.initializer_value)

--- a/elasticdl/python/ps/parameters.py
+++ b/elasticdl/python/ps/parameters.py
@@ -126,7 +126,7 @@ class Parameters(object):
             A bool indicates whether `Parameters` accepts this model pb or not.
         """
         if not self.initialized:
-            infos = model_pb.embedding_table_info
+            infos = model_pb.embedding_table_infos
             self.init_embedding_params(infos)
             for name, pb in model_pb.dense_parameters.items():
                 # Please note that `tf.Variable` will do something with magic.
@@ -187,7 +187,7 @@ class Parameters(object):
                     model_pb.embedding_tables[name],
                 )
                 embedding_info = embedding_table.to_embedding_table_info_pb()
-                model_pb.embedding_table_info.append(embedding_info)
+                model_pb.embedding_table_infos.append(embedding_info)
         return model_pb
 
     def debug_info(self):

--- a/elasticdl/python/ps/servicer.py
+++ b/elasticdl/python/ps/servicer.py
@@ -97,10 +97,10 @@ class PserverServicer(elasticdl_pb2_grpc.PserverServicer):
             self.wrap_optimizer_and_set_slot()
         return empty_pb2.Empty()
 
-    def push_embedding_info(self, request, _):
+    def push_embedding_table_infos(self, request, _):
         with self._lock:
             self._parameters.init_embedding_params(
-                request.embedding_table_info
+                request.embedding_table_infos
             )
             self.wrap_optimizer_and_set_slot()
         return empty_pb2.Empty()

--- a/elasticdl/python/tests/parameters_test.py
+++ b/elasticdl/python/tests/parameters_test.py
@@ -18,7 +18,7 @@ class ParametersTest(unittest.TestCase):
         self.params = Parameters()
 
         self.model_pb = Model()
-        self.infos_pb = self.model_pb.embedding_table_info
+        self.infos_pb = self.model_pb.embedding_table_infos
         self.tensors_pb = self.model_pb.dense_parameters
         self.embedding_tables_pb = self.model_pb.embedding_tables
 

--- a/elasticdl/python/tests/pserver_servicer_test.py
+++ b/elasticdl/python/tests/pserver_servicer_test.py
@@ -116,7 +116,7 @@ class PserverServicerTest(unittest.TestCase):
             req.version = idx + 1
             for name in model:
                 serialize_ndarray(model[name], req.dense_parameters[name])
-            req.embedding_table_info.append(self._embedding_info)
+            req.embedding_table_infos.append(self._embedding_info)
             res = self._stub.push_model(req)
             self.assertEqual(res, empty_pb2.Empty())
             # self._parameters is initialized with the first push_model call
@@ -206,12 +206,12 @@ class PserverServicerTest(unittest.TestCase):
 
         req = elasticdl_pb2.Model()
         req.version = 1
-        req.embedding_table_info.append(self._embedding_info)
+        req.embedding_table_infos.append(self._embedding_info)
         another_embedding_info = elasticdl_pb2.EmbeddingTableInfo()
         another_embedding_info.name = "layer_b"
         another_embedding_info.dim = 16
         another_embedding_info.initializer = "normal"
-        req.embedding_table_info.append(another_embedding_info)
+        req.embedding_table_infos.append(another_embedding_info)
         res = self._stub.push_model(req)
         self.assertEqual(res, empty_pb2.Empty())
 
@@ -279,7 +279,7 @@ class PserverServicerTest(unittest.TestCase):
         push_model_req.version = self._parameters.version
         for name, value in zip(self.var_names, self.var_values):
             serialize_ndarray(value, push_model_req.dense_parameters[name])
-        push_model_req.embedding_table_info.append(self._embedding_info)
+        push_model_req.embedding_table_infos.append(self._embedding_info)
         self._stub.push_model(push_model_req)
 
         for name, var in zip(self.var_names, self.var_values):

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -408,7 +408,9 @@ class Worker(object):
                 embedding_info.dim = layer.output_dim
                 embedding_info.initializer = layer.embeddings_initializer
                 # set to float32
-                embedding_info.dtype = dtype_numpy_to_tensor(np.float32)
+                embedding_info.dtype = dtype_numpy_to_tensor(
+                    np.dtype("float32")
+                )
 
         if self._embedding_columns:
             embedding_infos = model.embedding_table_infos

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -421,7 +421,9 @@ class Worker(object):
                 # tf.keras.initializers. Keep aligned between these two.
                 embedding_info.initializer = "uniform"
                 # set to float32
-                embedding_info.dtype = dtype_numpy_to_tensor(np.float32)
+                embedding_info.dtype = dtype_numpy_to_tensor(
+                    np.dtype("float32")
+                )
 
         for ps_id in range(self._ps_num):
             self._ps_stubs[ps_id].push_embedding_table_infos(model)

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -5,7 +5,6 @@ import traceback
 import numpy as np
 import tensorflow as tf
 
-import elasticdl.python.common.tensor_utils as tensor_utils
 from elasticdl.proto import elasticdl_pb2, elasticdl_pb2_grpc
 from elasticdl.python.collective_ops.communicator import CollectiveCommunicator
 from elasticdl.python.common.constants import (
@@ -15,6 +14,7 @@ from elasticdl.python.common.constants import (
     MetricsDictKey,
     Mode,
 )
+from elasticdl.python.common.dtypes import dtype_numpy_to_tensor
 from elasticdl.python.common.hash_utils import (
     int_to_id,
     scatter_embedding_vector,
@@ -30,6 +30,7 @@ from elasticdl.python.common.model_utils import (
     set_callback_parameters,
 )
 from elasticdl.python.common.tensor_utils import (
+    Tensor,
     deduplicate_indexed_slices,
     merge_indexed_slices,
     pb_to_ndarray,
@@ -400,15 +401,17 @@ class Worker(object):
     def report_embedding_info(self):
         model = elasticdl_pb2.Model()
         if self._embedding_layers:
-            embedding_infos = model.embedding_table_info
+            embedding_infos = model.embedding_table_infos
             for layer in self._embedding_layers:
                 embedding_info = embedding_infos.add()
                 embedding_info.name = layer.name
                 embedding_info.dim = layer.output_dim
                 embedding_info.initializer = layer.embeddings_initializer
+                # set to float32
+                embedding_info.dtype = dtype_numpy_to_tensor(np.float32)
 
         if self._embedding_columns:
-            embedding_infos = model.embedding_table_info
+            embedding_infos = model.embedding_table_infos
             for column in self._embedding_columns:
                 embedding_info = embedding_infos.add()
                 embedding_info.name = column.name
@@ -417,9 +420,11 @@ class Worker(object):
                 # a variable initializer function. For embedding layer, it's a
                 # tf.keras.initializers. Keep aligned between these two.
                 embedding_info.initializer = "uniform"
+                # set to float32
+                embedding_info.dtype = dtype_numpy_to_tensor(np.float32)
 
         for ps_id in range(self._ps_num):
-            self._ps_stubs[ps_id].push_embedding_info(model)
+            self._ps_stubs[ps_id].push_embedding_table_infos(model)
 
     def report_variable_to_ps(self, ps_id):
         model = elasticdl_pb2.Model()
@@ -493,9 +498,7 @@ class Worker(object):
                 # but an indexed slices type gradient
                 if isinstance(g, tf.IndexedSlices):
                     serialize_indexed_slices(
-                        tensor_utils.Tensor(
-                            None, g.values.numpy(), g.indices.numpy()
-                        ),
+                        Tensor(None, g.values.numpy(), g.indices.numpy()),
                         req.embedding_tables[name],
                     )
                 else:
@@ -547,8 +550,7 @@ class Worker(object):
                     req = reqs[ps_id]
                     gv, gi = results[ps_id]
                     serialize_indexed_slices(
-                        tensor_utils.Tensor(None, gv, gi),
-                        req.embedding_tables[name],
+                        Tensor(None, gv, gi), req.embedding_tables[name],
                     )
 
         report_futures = []


### PR DESCRIPTION
This PR does two things:
- rename `EmbeddingTableInfo` to `EmbeddingTableDesc` in Model messge
- set dtype to float32 when worker pushing embedding table desc. Otherwise, GO PS could not create an embedding table correctly.