### PR TITLE
Use embedding weight name not embedding layer name to get embedding ids.

### DIFF
--- a/elasticdl/python/common/model_handler.py
+++ b/elasticdl/python/common/model_handler.py
@@ -23,10 +23,7 @@ def _get_trained_params_from_checkpoint(checkpoint_dir):
 
     trained_params = parameters.non_embedding_params
     for name, table in parameters.embedding_params.items():
-        # The name of variable in a tf.keras.layers.Embedding layer is
-        # "{layer_name}/embeddings:0"
-        var_name = name + "/embeddings:0"
-        trained_params[var_name] = table
+        trained_params[name] = table
     return trained_params
 
 
@@ -291,6 +288,9 @@ class ParameterServerModelHandler(ModelHandler):
                         name=layer.name,
                         combiner=layer.combiner,
                     )
+                embedding_layer.set_embedding_weight_name(
+                    layer.trainable_weights[0].name
+                )
                 return embedding_layer
             elif type(layer) == tf.keras.layers.DenseFeatures:
                 return _replace_tf_embedding_column_with_edl(layer)
@@ -361,6 +361,13 @@ class ParameterServerModelHandler(ModelHandler):
                     embeddings_initializer=initializer_name,
                     mask_zero=value.mask_zero,
                     input_length=value.input_length,
+                    name=value.name,
+                )
+                # The weights of subclass model is None, so we need to create
+                # the weight name which is "{layer_name}/embeddings:0" in
+                # tf.keras.layers.Embedding.
+                embedding_layer.set_embedding_weight_name(
+                    value.name + "/embeddings:0"
                 )
                 setattr(model, name, embedding_layer)
             elif type(value) == SparseEmbedding and _need_partition_embedding(
@@ -375,6 +382,10 @@ class ParameterServerModelHandler(ModelHandler):
                     input_dim=value.input_dim,
                     embeddings_initializer=initializer_name,
                     combiner=value.combiner,
+                    name=value.name,
+                )
+                embedding_layer.set_embedding_weight_name(
+                    value.name + "/embeddings:0"
                 )
                 setattr(model, name, embedding_layer)
             elif type(value) == tf.keras.layers.DenseFeatures:

--- a/elasticdl/python/elasticdl/embedding_delegate.py
+++ b/elasticdl/python/elasticdl/embedding_delegate.py
@@ -215,7 +215,6 @@ class EmbeddingDelegate(object):
             is_row_empty,
             array_ops.zeros_like(batch_embedding),
             batch_embedding,
-            name=self.name,
         )
         batch_embedding.set_shape((None, self.output_dim))
         return batch_embedding

--- a/elasticdl/python/elasticdl/layers/embedding.py
+++ b/elasticdl/python/elasticdl/layers/embedding.py
@@ -53,6 +53,7 @@ class Embedding(tf.keras.layers.Layer):
         self.combiner = combiner
         self.tape = None
         self._lookup_embedding_func = None
+        self.embedding_weight_name = self.name + "/embeddings:0"
 
         self._embedding_and_ids_eagerly = []
 
@@ -62,7 +63,7 @@ class Embedding(tf.keras.layers.Layer):
         # `tf.Variable` requires initial value if shape has `None` dimension.
         self._embedding_and_ids_graph = []
         self.embedding_delegate = EmbeddingDelegate(
-            self.input_dim, self.output_dim, self.name
+            self.input_dim, self.output_dim, self.embedding_weight_name
         )
 
     @tf_utils.shape_type_conversion
@@ -146,3 +147,6 @@ class Embedding(tf.keras.layers.Layer):
     @property
     def embedding_and_ids(self):
         return self.embedding_delegate.embedding_and_ids
+
+    def set_embedding_weight_name(self, name):
+        self.embedding_weight_name = name

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -413,7 +413,7 @@ class Worker(object):
             embedding_infos = model.embedding_table_infos
             for layer in self._embedding_layers:
                 embedding_info = embedding_infos.add()
-                embedding_info.name = layer.name
+                embedding_info.name = layer.embedding_weight_name
                 embedding_info.dim = layer.output_dim
                 embedding_info.initializer = layer.embeddings_initializer
                 # set to float32

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -468,7 +468,9 @@ class Worker(object):
 
         embedding_name_values = []
         for layer in self._embedding_layers:
-            embedding_name_values.append((layer.name, layer.embedding_and_ids))
+            embedding_name_values.append(
+                (layer.embedding_weight_name, layer.embedding_and_ids)
+            )
         for column in self._embedding_columns:
             embedding_name_values.append(
                 (column.name, column.embedding_and_ids)


### PR DESCRIPTION
Now, we use the embedding layer name to set the embedding table name in `Parameters`. When we restore model weights to Keras model, we need to match the embedding table to embedding layer weights by `layer_name/embedding:0`. But, we cannot use the method to match the embedding table to embedding column weights because the embedding weight name likes `dense_features/education_1_embedding/embedding_weights:0`. 

So, it is better to use the embedding weight name to set the embedding table name in `Parameters`.