### PR TITLE
Set timeout for channel_ready_future and retry to connect with 3 times.

### DIFF
--- a/elasticdl/python/worker/main.py
+++ b/elasticdl/python/worker/main.py
@@ -39,7 +39,7 @@ def main():
                 except grpc.FutureTimeoutError:
                     logger.warning(
                         "Failed to connect pod %s with %d retry"
-                        % (i, addr.split(".")[0])
+                        % (addr.split(".")[0], i)
                     )
             if not connect_succeed:
                 raise TimeoutError(

--- a/elasticdl/python/worker/main.py
+++ b/elasticdl/python/worker/main.py
@@ -5,6 +5,9 @@ from elasticdl.python.common.args import parse_worker_args
 from elasticdl.python.common.grpc_utils import build_channel
 from elasticdl.python.worker.worker import Worker
 
+CONNECT_PS_MAX_RETRIES = 3
+CONNECT_PS_TIMEOUT = 60
+
 
 def main():
     args = parse_worker_args()
@@ -23,24 +26,25 @@ def main():
             # addr is in the form as "ps-pod-name.namespace.svc:port"
             channel = build_channel(addr)
 
-            # Wait the channel is ready by a Future object.
-            connect_succeed = False
-            for i in range(3):
+            succeeded = False
+            for i in range(CONNECT_PS_MAX_RETRIES):
                 try:
-                    grpc.channel_ready_future(channel).result(timeout=60)
+                    grpc.channel_ready_future(channel).result(
+                        timeout=CONNECT_PS_TIMEOUT
+                    )
                     logger.info(
                         "grpc channel %s to connect pod %s is ready"
                         % (addr, addr.split(".")[0])
                     )
                     ps_channels.append(channel)
-                    connect_succeed = True
+                    succeeded = True
                     break
                 except grpc.FutureTimeoutError:
                     logger.warning(
                         "Failed to connect pod %s with %d retry"
                         % (addr.split(".")[0], i)
                     )
-            if not connect_succeed:
+            if not succeeded:
                 raise TimeoutError(
                     "Time out to connect pod %s with 3 retries"
                     % addr.split(".")[0]

--- a/elasticdl/python/worker/main.py
+++ b/elasticdl/python/worker/main.py
@@ -36,7 +36,7 @@ def main():
                     ps_channels.append(channel)
                     connect_succeed = True
                     break
-                except concurrent.futures.TimeoutError:
+                except grpc.FutureTimeoutError:
                     logger.warning(
                         "Failed to connect pod %s with %d retry"
                         % (i, addr.split(".")[0])

--- a/elasticdl/python/worker/main.py
+++ b/elasticdl/python/worker/main.py
@@ -1,5 +1,4 @@
 import grpc
-import concurrent
 
 from elasticdl.python.common import log_utils
 from elasticdl.python.common.args import parse_worker_args


### PR DESCRIPTION
Fix #1814
If the PS instance is launched after the worker, the result of the `grpc.channel_ready_future` may always wait. 
