### PR TITLE
fix model version intialized more than one time

### DIFF
--- a/elasticdl/pkg/ps/model.go
+++ b/elasticdl/pkg/ps/model.go
@@ -67,7 +67,7 @@ func (model *Model) InitFromModelPB(pb *proto.Model) error {
 			return err
 		}
 	}
-	if pb.Version >= 0 {
+	if pb.Version >= 1 {
 		model.Version = pb.Version
 	}
 	return nil


### PR DESCRIPTION
The `InitFromModelPB` will be called in `PushEmbeddingTableInfos` and `PushModel` rpc service. And the default value of `pb.Version` is 0, because of default value mechanism of Golang.

For example, the first worker calls `PushEmbeddingTableInfos` and `PushModel`, and begin to push gradient. The model version in PS will be increased. Then, the second worker calls `PushEmbeddingTableInfos`, the model version in PS will be reset to 0. `PushModel` is protected by Initialized flag, but `PushEmbeddingTableInfos` is not.

Change the condition to `if pb.Version >= 1` will fix this bug.

 