### PR TITLE
Use a lock for `get` and `set` of EmbeddingTable

### DIFF
--- a/elasticdl/python/ps/embedding_table.py
+++ b/elasticdl/python/ps/embedding_table.py
@@ -52,21 +52,20 @@ class EmbeddingTable(object):
         if len(indices) == 0:
             return None
         values = []
-        with self._lock:
-            for i in indices:
-                value = self.embedding_vectors.get(i, None)
-                if value is None:
+        for i in indices:
+            value = self.embedding_vectors.get(i, None)
+            if value is None:
+                with self._lock:
                     value = self.initializer(shape=(self.dim,)).numpy()
                     self.embedding_vectors[i] = value
-                values.append(value)
+            values.append(value)
         return np.stack(values)
 
     def set(self, indices, values):
         # TODO(qijun) need to add a RWLock in Sync-SGD
-        with self._lock:
-            for index, i in enumerate(indices):
-                embedding_vector = values[index]
-                self.embedding_vectors[i] = embedding_vector
+        for index, i in enumerate(indices):
+            embedding_vector = values[index]
+            self.embedding_vectors[i] = embedding_vector
 
     def clear(self):
         self.embedding_vectors.clear()
@@ -93,13 +92,12 @@ class EmbeddingTable(object):
 
     def get_table_size(self):
         """Get the element count of an embedding table"""
-        with self._lock:
-            if len(self.embedding_vectors) > 0:
-                element_size = list(self.embedding_vectors.values())[
-                    0
-                ].itemsize
-                size = self.dim * len(self.embedding_vectors) * element_size
-                return size
+        if len(self.embedding_vectors) > 0:
+            element_size = list(self.embedding_vectors.values())[
+                0
+            ].itemsize
+            size = self.dim * len(self.embedding_vectors) * element_size
+            return size
         return 0
 
     def debug_info(self):

--- a/elasticdl/python/ps/embedding_table.py
+++ b/elasticdl/python/ps/embedding_table.py
@@ -69,9 +69,11 @@ class EmbeddingTable(object):
     def to_indexed_slices(self):
         indices = []
         embedding_vectors = []
-        for id, embedding_vector in self.embedding_vectors.items():
+        embedding_vectors_dict = self.embedding_vectors.copy()
+        for id, embedding_vector in embedding_vectors_dict.items():
             indices.append(id)
             embedding_vectors.append(embedding_vector)
+        del embedding_vectors_dict
         return tf.IndexedSlices(
             values=np.array(embedding_vectors), indices=np.array(indices)
         )

--- a/elasticdl/python/ps/embedding_table.py
+++ b/elasticdl/python/ps/embedding_table.py
@@ -1,4 +1,5 @@
 import threading
+
 import numpy as np
 import tensorflow as tf
 
@@ -94,9 +95,9 @@ class EmbeddingTable(object):
         """Get the element count of an embedding table"""
         with self._lock:
             if len(self.embedding_vectors) > 0:
-                element_size = list(
-                    self.embedding_vectors.values()
-                )[0].itemsize
+                element_size = list(self.embedding_vectors.values())[
+                    0
+                ].itemsize
                 size = self.dim * len(self.embedding_vectors) * element_size
                 return size
         return 0

--- a/elasticdl/python/ps/embedding_table.py
+++ b/elasticdl/python/ps/embedding_table.py
@@ -93,9 +93,7 @@ class EmbeddingTable(object):
     def get_table_size(self):
         """Get the element count of an embedding table"""
         if len(self.embedding_vectors) > 0:
-            element_size = list(self.embedding_vectors.values())[
-                0
-            ].itemsize
+            element_size = list(self.embedding_vectors.values())[0].itemsize
             size = self.dim * len(self.embedding_vectors) * element_size
             return size
         return 0

--- a/elasticdl/python/ps/parameters.py
+++ b/elasticdl/python/ps/parameters.py
@@ -175,10 +175,13 @@ class Parameters(object):
         """
         model_pb = elasticdl_pb2.Model()
         model_pb.version = self.version
-        for name, var in self.non_embedding_params.items():
+        non_embedding_params = self.non_embedding_params.copy()
+        for name, var in non_embedding_params.items():
             serialize_ndarray(var.numpy(), model_pb.dense_parameters[name])
+        del non_embedding_params
 
-        for name, embedding_table in self.embedding_params.items():
+        embedding_params = self.embedding_params.copy()
+        for name, embedding_table in embedding_params.items():
             # Slot embedding table is not weights in the model, so we don't
             # save it to checkpoint.
             if not embedding_table.is_slot:
@@ -188,6 +191,7 @@ class Parameters(object):
                 )
                 embedding_info = embedding_table.to_embedding_table_info_pb()
                 model_pb.embedding_table_infos.append(embedding_info)
+        del embedding_params
         return model_pb
 
     def debug_info(self):

--- a/elasticdl/python/ps/parameters.py
+++ b/elasticdl/python/ps/parameters.py
@@ -175,13 +175,10 @@ class Parameters(object):
         """
         model_pb = elasticdl_pb2.Model()
         model_pb.version = self.version
-        non_embedding_params = self.non_embedding_params.copy()
-        for name, var in non_embedding_params.items():
+        for name, var in self.non_embedding_params.items():
             serialize_ndarray(var.numpy(), model_pb.dense_parameters[name])
-        del non_embedding_params
 
-        embedding_params = self.embedding_params.copy()
-        for name, embedding_table in embedding_params.items():
+        for name, embedding_table in self.embedding_params.items():
             # Slot embedding table is not weights in the model, so we don't
             # save it to checkpoint.
             if not embedding_table.is_slot:
@@ -191,7 +188,6 @@ class Parameters(object):
                 )
                 embedding_info = embedding_table.to_embedding_table_info_pb()
                 model_pb.embedding_table_infos.append(embedding_info)
-        del embedding_params
         return model_pb
 
     def debug_info(self):


### PR DESCRIPTION
Fix #1808 
The parameter dictionary may be updated by other threads during iteration to save it into a checkpoint file.