### PR TITLE
Add pkg/kernel/cpi to build package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,13 @@ setup(
     python_requires=">=3.5",
     packages=find_packages(exclude=["*test*"]),
     package_data={
-        "": ["proto/*.proto", "docker/*", "Makefile", "requirements.txt"]
+        "": [
+            "proto/*.proto",
+            "docker/*",
+            "Makefile",
+            "requirements.txt",
+            "pkg/kernel/capi/*",
+        ]
     },
     entry_points={
         "console_scripts": ["elasticdl=elasticdl.python.elasticdl.client:main"]


### PR DESCRIPTION
When we build the image using `elasticdl.client`, we copy the ElasticDL folder in site-packages of python to image. But the files in `pkg/kernel/cpi` are not in this ElasticDL folder, so the kernel stage in Makefile will fail.