### PR TITLE
fix kubernetes client version of ci

### DIFF
--- a/elasticdl/requirements.txt
+++ b/elasticdl/requirements.txt
@@ -1,5 +1,5 @@
 grpcio-tools
-kubernetes
+kubernetes==10.1.0
 docker
 pyrecordio>=0.0.6
 odps


### PR DESCRIPTION
Kubernetes client library has update the pip package to version 11.0.0 in 12 March. This will casue such error in CI:

```
AttributeError: module 'kubernetes.client.api_client' has no attribute 'ApiException'
```

This PR fix the kubernetes client package version to 10.1.0