### PR TITLE
Avoid creating PS pods under allreduce strategy

### DIFF
--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -199,7 +199,8 @@ class Master(object):
         # Start the worker manager if requested
         if self.instance_manager:
             self.instance_manager.update_status(InstanceManagerStatus.PENDING)
-            self.instance_manager.start_parameter_servers()
+            if self.distribution_strategy != DistributionStrategy.ALLREDUCE:
+                self.instance_manager.start_parameter_servers()
             self.instance_manager.start_workers()
             self.instance_manager.update_status(InstanceManagerStatus.RUNNING)
 


### PR DESCRIPTION
Currently PS pods will be created even under allreduce strategy (example below). This PR fixes that.
```
elasticdl-test-train-master     1/1     Running   0          13m
elasticdl-test-train-ps-0       0/1     Pending   0          13m
elasticdl-test-train-worker-0   0/1     Pending   0          13m
elasticdl-test-train-worker-1   0/1     Pending   0          13m
```
Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>