### PR TITLE
Only check PS channels when not under allreduce strategy

### DIFF
--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -694,6 +694,8 @@ def parse_worker_args(worker_args=None):
     print_args(args, groups=ALL_ARGS_GROUPS)
     if unknown_args:
         logger.warning("Unknown arguments: %s", unknown_args)
+    if args.distribution_strategy == DistributionStrategy.ALLREDUCE:
+        args.ps_addrs = ""
     return args
 
 

--- a/elasticdl/python/worker/main.py
+++ b/elasticdl/python/worker/main.py
@@ -2,7 +2,6 @@ import grpc
 
 from elasticdl.python.common import log_utils
 from elasticdl.python.common.args import parse_worker_args
-from elasticdl.python.common.constants import DistributionStrategy
 from elasticdl.python.common.grpc_utils import build_channel
 from elasticdl.python.worker.worker import Worker
 
@@ -20,10 +19,7 @@ def main():
     master_channel = build_channel(args.master_addr)
 
     ps_channels = []
-    if (
-        args.ps_addrs
-        and args.distribution_strategy != DistributionStrategy.ALLREDUCE
-    ):
+    if args.ps_addrs:
         ps_addrs = args.ps_addrs.split(",")
 
         for addr in ps_addrs:

--- a/elasticdl/python/worker/main.py
+++ b/elasticdl/python/worker/main.py
@@ -2,6 +2,7 @@ import grpc
 
 from elasticdl.python.common import log_utils
 from elasticdl.python.common.args import parse_worker_args
+from elasticdl.python.common.constants import DistributionStrategy
 from elasticdl.python.common.grpc_utils import build_channel
 from elasticdl.python.worker.worker import Worker
 
@@ -19,7 +20,10 @@ def main():
     master_channel = build_channel(args.master_addr)
 
     ps_channels = []
-    if args.ps_addrs:
+    if (
+        args.ps_addrs
+        and args.distribution_strategy != DistributionStrategy.ALLREDUCE
+    ):
         ps_addrs = args.ps_addrs.split(",")
 
         for addr in ps_addrs:


### PR DESCRIPTION
This `TimeoutError` happens even under allreduce strategy. This PR fixes this so we only check PS channels when not under allreduce strategy.

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/elasticdl/python/worker/main.py", line 63, in <module>
    main()
  File "/elasticdl/python/worker/main.py", line 50, in main
    % addr.split(".")[0]
TimeoutError: Time out to connect pod elasticdl-test-train-ps-0 with 3 retries
```

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>