### PR TITLE
Skip get model versions from PS if under allreduce strategy

### DIFF
--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -166,7 +166,8 @@ class Worker(object):
         self.set_model(model_inst)
 
         self._model_version = -1
-        self._model_versions_from_ps = [-1 for _ in range(self._ps_num)]
+        if self._distribution_strategy != DistributionStrategy.ALLREDUCE:
+            self._model_versions_from_ps = [-1 for _ in range(self._ps_num)]
         self._task_data_service = TaskDataService(
             self,
             self._job_type == JobType.TRAINING_WITH_EVALUATION,


### PR DESCRIPTION
This PR fixes the error below under allreduce strategy:
```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/elasticdl/python/worker/main.py", line 67, in <module>
    main()
  File "/elasticdl/python/worker/main.py", line 61, in main
    set_parallelism=True,
  File "/elasticdl/python/worker/worker.py", line 122, in __init__
    self._init_from_args(args)
  File "/elasticdl/python/worker/worker.py", line 169, in _init_from_args
    self._model_versions_from_ps = [-1 for _ in range(self._ps_num)]
AttributeError: 'Worker' object has no attribute '_ps_num'
```

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>