### PR TITLE
Add warmup period for FTLib consensus service to detect the worker

### DIFF
--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -199,14 +199,13 @@ class Master(object):
         # Start the worker manager if requested
         if self.instance_manager:
             self.instance_manager.update_status(InstanceManagerStatus.PENDING)
-            if self.distribution_strategy != DistributionStrategy.ALLREDUCE:
+            if self.distribution_strategy == DistributionStrategy.ALLREDUCE:
+                # Exposes the consensus service for allreduce-based training
+                self.instance_manager.start_ftlib_consensus_service()
+            else:
                 self.instance_manager.start_parameter_servers()
             self.instance_manager.start_workers()
             self.instance_manager.update_status(InstanceManagerStatus.RUNNING)
-
-        # Exposes the consensus service for allreduce-based training
-        if self.distribution_strategy == DistributionStrategy.ALLREDUCE:
-            self.instance_manager.start_ftlib_consensus_service()
 
         # Start TensorBoard k8s Service if requested
         if self.tb_service and self.tb_client:

--- a/elasticdl/python/worker/main.py
+++ b/elasticdl/python/worker/main.py
@@ -1,12 +1,18 @@
+import time
+
 import grpc
 
 from elasticdl.python.common import log_utils
 from elasticdl.python.common.args import parse_worker_args
+from elasticdl.python.common.constants import DistributionStrategy
 from elasticdl.python.common.grpc_utils import build_channel
 from elasticdl.python.worker.worker import Worker
 
 CONNECT_PS_MAX_RETRIES = 3
 CONNECT_PS_TIMEOUT = 300
+# The number of seconds we wait for allreduce strategy's
+# FTLib consensus service to detect the worker pod
+_ALLREDUCE_STRATEGY_WARM_UP_SECS = 20
 
 
 def main():
@@ -49,6 +55,13 @@ def main():
                     "Time out to connect pod %s with 3 retries"
                     % addr.split(".")[0]
                 )
+
+    if args.distribution_strategy == DistributionStrategy.ALLREDUCE:
+        logger.info(
+            "Wait for %s seconds for FTLib consensus service to "
+            "detect the worker pod" % str(_ALLREDUCE_STRATEGY_WARM_UP_SECS)
+        )
+        time.sleep(_ALLREDUCE_STRATEGY_WARM_UP_SECS)
 
     worker = Worker(
         args,


### PR DESCRIPTION
This PR includes:
* Add warmup period for FTLib consensus service to detect the worker
* Start FTLib's k8s service before we start the worker pods

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>