### PR TITLE
support mixed priority of worker pods

### DIFF
--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -161,7 +161,10 @@ def add_common_params(parser):
     parser.add_argument(
         "--worker_pod_priority",
         default="",
-        help="The requested priority of worker pod",
+        help="The requested priority of worker pod, we support following"
+        "configs: high/low/high=0.5. The high=0.5 means that half"
+        "worker pods have high priority, and half worker pods have"
+        "low priority. The default value is low",
     )
     parser.add_argument(
         "--num_ps_pods", type=int, help="Number of PS pods", default=1

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -12,13 +12,22 @@ _SERVICE_ADDR_SEP = ","
 def _parse_worker_pod_priority(num_workers, worker_pod_priority):
     res = {}
     if isinstance(worker_pod_priority, str) and "high=" in worker_pod_priority:
-        fraction = float(worker_pod_priority.split("=")[1])
-        high_count = int(num_workers * fraction)
-        for i in range(num_workers):
-            if i < high_count:
-                res[i] = "high"
-            else:
-                res[i] = "low"
+        try:
+            fraction = float(worker_pod_priority.split("=")[1])
+            high_count = int(num_workers * fraction)
+            for i in range(num_workers):
+                if i < high_count:
+                    res[i] = "high"
+                else:
+                    res[i] = "low"
+        except Exception:
+            logger.warning(
+                "Please check the input worker pod priority format,"
+                "e.g. high=0.5  The config is no use, and ElasticDL sets"
+                "low priority for all worker pods by default."
+            )
+            for i in range(num_workers):
+                res[i] = None
     else:
         for i in range(num_workers):
             res[i] = worker_pod_priority

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -11,8 +11,11 @@ _SERVICE_ADDR_SEP = ","
 
 def _parse_worker_pod_priority(num_workers, worker_pod_priority):
     res = {}
-    if "high=" in worker_pod_priority:
-        fraction = float(worker_pod_priority.spllit("=")[1])
+    if worker_pod_priority is None:
+        for i in range(num_workers):
+            res[i] = None
+    elif "high=" in worker_pod_priority:
+        fraction = float(worker_pod_priority.split("=")[1])
         high_count = int(num_workers * fraction)
         for i in range(num_workers):
             if i < high_count:
@@ -22,9 +25,12 @@ def _parse_worker_pod_priority(num_workers, worker_pod_priority):
     elif worker_pod_priority == "high":
         for i in range(num_workers):
             res[i] = "high"
-    else:
+    elif worker_pod_priority == "low":
         for i in range(num_workers):
             res[i] = "low"
+    else:
+        for i in range(num_workers):
+            res[i] = worker_pod_priority
     return res
 
 

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -23,7 +23,7 @@ def _parse_worker_pod_priority(num_workers, worker_pod_priority):
         except Exception:
             logger.warning(
                 "Please check the input worker pod priority format,"
-                "e.g. high=0.5  The config is no use, and ElasticDL sets"
+                "e.g. high=0.5  The config is no use, and ElasticDL sets "
                 "low priority for all worker pods by default."
             )
             for i in range(num_workers):

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -11,10 +11,7 @@ _SERVICE_ADDR_SEP = ","
 
 def _parse_worker_pod_priority(num_workers, worker_pod_priority):
     res = {}
-    if worker_pod_priority is None:
-        for i in range(num_workers):
-            res[i] = None
-    elif "high=" in worker_pod_priority:
+    if isinstance(worker_pod_priority, str) and "high=" in worker_pod_priority:
         fraction = float(worker_pod_priority.split("=")[1])
         high_count = int(num_workers * fraction)
         for i in range(num_workers):
@@ -22,12 +19,6 @@ def _parse_worker_pod_priority(num_workers, worker_pod_priority):
                 res[i] = "high"
             else:
                 res[i] = "low"
-    elif worker_pod_priority == "high":
-        for i in range(num_workers):
-            res[i] = "high"
-    elif worker_pod_priority == "low":
-        for i in range(num_workers):
-            res[i] = "low"
     else:
         for i in range(num_workers):
             res[i] = worker_pod_priority


### PR DESCRIPTION
This PR aims to support mixed priority of worker pods. For example, one user wants to launch 10 worker pods, and sets  worker pod priority to `high=0.5`, the master will create 5 worker pods with high priority and 5 worker pods with low priority.

This mechanism ensures that an elasticdl job could keep running, even when most worker pods with low priority are preempted.