### PR TITLE
add debug_params arg for benchmark experiments

### DIFF
--- a/elasticdl/docker/Dockerfile
+++ b/elasticdl/docker/Dockerfile
@@ -74,9 +74,6 @@ RUN python /var/frappe_recordio_gen.py --data /root/.keras/datasets --output_dir
 # Copy heart dataset
 COPY elasticdl/python/data/recordio_gen/heart_recordio_gen.py /var/heart_recordio_gen.py
 RUN python /var/heart_recordio_gen.py --data_dir /root/.keras/datasets --output_dir /data/heart
-# Copy census dataset
-COPY elasticdl/python/data/recordio_gen/census_recordio_gen.py /var/census_recordio_gen.py
-RUN python /var/census_recordio_gen.py --data_dir /root/.keras/datasets --output_dir /data/census
 
 RUN rm -rf /root/.keras/datasets
 

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -281,12 +281,13 @@ def add_common_params(parser):
         help="True for Go-based PS, False for Python-based PS",
     )
     parser.add_argument(
-        "--debug_params",
+        "--aux_params",
         type=str,
         default="",
-        help="Only for debug. The debug parameters in a string separated "
+        help="Auxiliary parameters for misc purposes such as debugging."
+        "The auxiliary parameters in a string separated "
         'by semi-colon used to debug , e.g. "param1=1; param2=2" '
-        "Supported debug parameters: disable_relaunch",
+        "Supported auxiliary parameters: disable_relaunch",
     )
 
 

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -280,13 +280,12 @@ def add_common_params(parser):
         default=False,
         help="True for Go-based PS, False for Python-based PS",
     )
-    add_bool_param(
-        parser=parser,
-        name="--disable_relanuch_mechanism",
-        default=False,
-        help="Only for benchmark experiments. It disables relaunching "
-        "mechanism. So, worker pod will not be relaunched if killed "
-        "by some reason.",
+    parser.add_argument(
+        "--debug_params",
+        type=str,
+        default="",
+        help="Only for debug. The debug parameters in a string separated "
+        'by semi-colon used to debug , e.g. "param1=1; param2=2"',
     )
 
 

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -285,7 +285,8 @@ def add_common_params(parser):
         type=str,
         default="",
         help="Only for debug. The debug parameters in a string separated "
-        'by semi-colon used to debug , e.g. "param1=1; param2=2"',
+        'by semi-colon used to debug , e.g. "param1=1; param2=2" '
+        "Supported debug parameters: disable_relaunch",
     )
 
 

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -280,6 +280,14 @@ def add_common_params(parser):
         default=False,
         help="True for Go-based PS, False for Python-based PS",
     )
+    add_bool_param(
+        parser=parser,
+        name="--disable_relanuch_mechanism",
+        default=False,
+        help="Only for benchmark experiments. It disables relaunching "
+        "mechanism. So, worker pod will not be relaunched if killed "
+        "by some reason.",
+    )
 
 
 def add_train_params(parser):

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -55,6 +55,7 @@ class InstanceManager(object):
         restart_policy="Never",
         envs=None,
         expose_ports=False,
+        disable_relanuch_mechanism=False,
         **kwargs
     ):
         self._num_workers = num_workers
@@ -104,7 +105,12 @@ class InstanceManager(object):
 
         self._failed_pods = []
 
-        self._k8s_client = k8s.Client(event_callback=self._event_cb, **kwargs)
+        if disable_relanuch_mechanism:
+            self._k8s_client = k8s.Client(**kwargs)
+        else:
+            self._k8s_client = k8s.Client(
+                event_callback=self._event_cb, **kwargs
+            )
         self._ps_addrs = self._get_addrs(
             self._num_ps, self._k8s_client.get_ps_service_address
         )

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -55,7 +55,7 @@ class InstanceManager(object):
         restart_policy="Never",
         envs=None,
         expose_ports=False,
-        disable_relanuch_mechanism=False,
+        disable_relaunch=False,
         **kwargs
     ):
         self._num_workers = num_workers
@@ -105,7 +105,7 @@ class InstanceManager(object):
 
         self._failed_pods = []
 
-        if disable_relanuch_mechanism:
+        if disable_relaunch:
             self._k8s_client = k8s.Client(**kwargs)
         else:
             self._k8s_client = k8s.Client(

--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -455,6 +455,11 @@ class Master(object):
             for key in env_dict:
                 env.append(V1EnvVar(name=key, value=env_dict[key]))
 
+            kwargs = get_dict_from_params_str(args.debug_params)
+            disable_relaunch = (
+                kwargs.get("disable_relaunch", False) if kwargs else False
+            )
+
             instance_manager = InstanceManager(
                 self.task_d,
                 job_name=args.job_name,
@@ -479,7 +484,7 @@ class Master(object):
                 envs=env,
                 expose_ports=self.distribution_strategy
                 == DistributionStrategy.ALLREDUCE,
-                disable_relanuch_mechanism=args.disable_relanuch_mechanism,
+                disable_relaunch=disable_relaunch,
             )
 
         return instance_manager

--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -456,9 +456,7 @@ class Master(object):
                 env.append(V1EnvVar(name=key, value=env_dict[key]))
 
             kwargs = get_dict_from_params_str(args.aux_params)
-            disable_relaunch = (
-                kwargs.get("disable_relaunch", False) if kwargs else False
-            )
+            disable_relaunch = kwargs.get("disable_relaunch", False)
 
             instance_manager = InstanceManager(
                 self.task_d,

--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -455,7 +455,7 @@ class Master(object):
             for key in env_dict:
                 env.append(V1EnvVar(name=key, value=env_dict[key]))
 
-            kwargs = get_dict_from_params_str(args.debug_params)
+            kwargs = get_dict_from_params_str(args.aux_params)
             disable_relaunch = (
                 kwargs.get("disable_relaunch", False) if kwargs else False
             )

--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -479,6 +479,7 @@ class Master(object):
                 envs=env,
                 expose_ports=self.distribution_strategy
                 == DistributionStrategy.ALLREDUCE,
+                disable_relanuch_mechanism=args.disable_relanuch_mechanism,
             )
 
         return instance_manager


### PR DESCRIPTION
In benchmark experiments, we need to create a control group case that running ElasticDL jobs without relaunching mechanism. It is designed for compare with the study group.

This PR add a debug_params for ElasticDL, it supports key-value pair config. So we could add any needed params conveniently.