### PR TITLE
Set dtype for SparseEmbedding

### DIFF
--- a/elasticdl/python/keras/layers/sparse_embedding.py
+++ b/elasticdl/python/keras/layers/sparse_embedding.py
@@ -28,7 +28,7 @@ class SparseEmbedding(tf.keras.layers.Layer):
         combiner="mean",
         **kwargs
     ):
-        dtype = kwargs.pop('dtype', K.floatx())
+        dtype = kwargs.pop("dtype", K.floatx())
         super(SparseEmbedding, self).__init__(dtype=dtype, **kwargs)
 
         self.input_dim = input_dim

--- a/elasticdl/python/keras/layers/sparse_embedding.py
+++ b/elasticdl/python/keras/layers/sparse_embedding.py
@@ -28,7 +28,8 @@ class SparseEmbedding(tf.keras.layers.Layer):
         combiner="mean",
         **kwargs
     ):
-        super(SparseEmbedding, self).__init__(**kwargs)
+        dtype = kwargs.pop('dtype', K.floatx())
+        super(SparseEmbedding, self).__init__(dtype=dtype, **kwargs)
 
         self.input_dim = input_dim
         self.output_dim = output_dim


### PR DESCRIPTION
The default dtype is `tf.int32` in TF 1.15.2, so we need to set the dtype.