### PR TITLE
Don't use tf ops in __init__

### DIFF
--- a/elasticdl_preprocessing/layers/round_identity.py
+++ b/elasticdl_preprocessing/layers/round_identity.py
@@ -30,8 +30,8 @@ class RoundIdentity(tf.keras.layers.Layer):
 
     def __init__(self, num_buckets, default_value=0):
         super(RoundIdentity, self).__init__()
-        self.num_buckets = tf.cast(num_buckets, tf.int64)
-        self.default_value = tf.cast(default_value, tf.int64)
+        self.num_buckets = num_buckets
+        self.default_value = default_value
 
     def call(self, inputs):
         if isinstance(inputs, tf.SparseTensor):
@@ -52,9 +52,11 @@ class RoundIdentity(tf.keras.layers.Layer):
     def _round_and_truncate(self, values):
         values = tf.keras.backend.round(values)
         values = tf.cast(values, tf.int64)
+        num_buckets = tf.cast(self.num_buckets, tf.int64)
+        default_value = tf.cast(self.default_value, tf.int64)
         values = tf.where(
-            tf.logical_or(values < 0, values > self.num_buckets),
-            x=tf.fill(dims=tf.shape(values), value=self.default_value),
+            tf.logical_or(values < 0, values > num_buckets),
+            x=tf.fill(dims=tf.shape(values), value=default_value),
             y=values,
         )
         return values


### PR DESCRIPTION
`tf.saved_model.save` will raise an error if we use to ops in `__init__`. Because the tensor cannot be seralized.
```python
   chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.6/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/util/serialization.py", line 72, in get_json_type
    raise TypeError('Not JSON Serializable:', obj)
TypeError: ('Not JSON Serializable:', <tf.Tensor: shape=(), dtype=int64, numpy=33333>)
```