### PR TITLE
Rethink end-to-end feature derivation syntax

### DIFF
--- a/docs/designs/data_transform.md
+++ b/docs/designs/data_transform.md
@@ -199,14 +199,30 @@ SELECT *
 FROM census_income
 TO TRAIN WideAndDeepClassifier
 COLUMN
-    EMBEDDING(CONCAT(VOCABULARIZE(workclass), BUCKETIZE(capital_gain, num_buckets=5), BUCKETIZE(capital_loss, num_buckets=5), BUCKTIZE(hours_per_week, num_buckets=6)) AS group_1, 8),
-    EMBEDDING(CONCAT(HASH(education), HASH(occupation), VOCABULARIZE(martial_status), VOCABULARIZE(relationship)) AS group_2, 8),
-    EMBEDDING(CONCAT(BUCKETIZE(age, num_buckets=5), HASH(native_country), VOCABULARIZE(race), VOCABULARIZE(sex)) AS group_3, 8)
-    FOR deep_embeddings
-COLUMN
+  pan(
+    EMBEDDING(
+        CONCAT(VOCABULARIZE(workclass), 
+               BUCKETIZE(capital_gain, num_buckets=5), 
+               BUCKETIZE(capital_loss, num_buckets=5), 
+               BUCKETIZE(hours_per_week, num_buckets=6)) AS group_1, 
+        8),
+    EMBEDDING(
+        CONCAT(HASH(education), 
+               HASH(occupation), 
+               VOCABULARIZE(martial_status), 
+               VOCABULARIZE(relationship)) AS group_2, 
+        8),
+    EMBEDDING(
+        CONCAT(BUCKETIZE(age, num_buckets=5), 
+               HASH(native_country), 
+               VOCABULARIZE(race), 
+               VOCABULARIZE(sex)) AS group_3, 
+        8)
+    ) AS deep_embeddings
+  pan(
     EMBEDDING(group1, 1),
     EMBEDDING(group2, 1)
-    FOR wide_embeddings
+  ) AS wide_embeddings
 LABEL label
 ```
 


### PR DESCRIPTION
We used to think that each COLUMN clause maps to a TensorFlow feature column API call.  However, feature column API is TF-only, and indeed, future versions of TF might not longer support them.

Considering that we want this end-to-end ML work portable to PyTorch, XGBoost, and other ML toolkit, how about we abstract the model as a Python function with one or more input parameters: 

```python
def forward_pass_of_a_model(x, y, z=[0]):
    return do_something_with(x,y,z)
```

We hope that given only one COLUMN clause, but maybe more than one AS sub-clauses, each AS maps to a named Python function parameter like x, y, or z.


For example, the following COLUMN clause

```sql
COLUMN embedding(...) AS x, embedding(...) AS y, embedding(...) AS z
```
 maps the outputs of the three embedding layers to x, y, and z respectively.

And the following clause

```sql
COLUMN embedding(...), embedding(...), embedding(...)
```

maps the three outputs to x, y, and z respectively too, but by their positions.

The following case

```sql
COLUMN embedding(...), embedding(...)
```

maps the outputs of the two embeddings to x and y, and leaves z to its default value `[0]`.