### PR TITLE
Replace the max_value with the default value

### DIFF
--- a/elasticdl_preprocessing/layers/round_identity.py
+++ b/elasticdl_preprocessing/layers/round_identity.py
@@ -55,7 +55,7 @@ class RoundIdentity(tf.keras.layers.Layer):
         num_buckets = tf.cast(self.num_buckets, tf.int64)
         default_value = tf.cast(self.default_value, tf.int64)
         values = tf.where(
-            tf.logical_or(values < 0, values > num_buckets),
+            tf.logical_or(values < 0, values >= num_buckets),
             x=tf.fill(dims=tf.shape(values), value=default_value),
             y=values,
         )


### PR DESCRIPTION
The value number of `values < 0, values > num_buckets` is `num_buckets + 1` , so we should use `values < 0, values >= num_buckets