### PR TITLE
Add column dtype in metadata

### DIFF
--- a/elasticdl/python/data/reader/data_reader.py
+++ b/elasticdl/python/data/reader/data_reader.py
@@ -2,8 +2,9 @@ from abc import ABC, abstractmethod
 
 
 class Metadata(object):
-    def __init__(self, column_names):
+    def __init__(self, column_names, column_dtypes=None):
         self.column_names = column_names
+        self.column_dtypes = column_dtypes
 
 
 class AbstractDataReader(ABC):

--- a/elasticdl/python/data/reader/odps_reader.py
+++ b/elasticdl/python/data/reader/odps_reader.py
@@ -59,9 +59,10 @@ class ODPSDataReader(AbstractDataReader):
             self._metadata.column_names = (
                 reader._odps_table.schema.names if columns is None else columns
             )
-            column_dtypes = []
-            for column_name in self._metadata.column_names:
-                column_dtypes.append(reader._odps_table.schema[column_name])
+            self._metadata.column_names = [
+                reader._odps_table.schema[column_name]
+                for column_name in self._metadata.column_names
+            ]
 
         for record in reader.record_generator_with_retry(
             start=task.start, end=task.end, columns=self._metadata.column_names

--- a/elasticdl/python/data/reader/odps_reader.py
+++ b/elasticdl/python/data/reader/odps_reader.py
@@ -59,8 +59,10 @@ class ODPSDataReader(AbstractDataReader):
             self._metadata.column_names = (
                 reader._odps_table.schema.names if columns is None else columns
             )
-            self._metadata.column_names = [
-                reader._odps_table.schema[column_name]
+
+        if self._metadata.column_names:
+            self._metadata.column_dtypes = [
+                reader._odps_table.schema[column_name].type
                 for column_name in self._metadata.column_names
             ]
 

--- a/elasticdl/python/data/reader/odps_reader.py
+++ b/elasticdl/python/data/reader/odps_reader.py
@@ -59,6 +59,9 @@ class ODPSDataReader(AbstractDataReader):
             self._metadata.column_names = (
                 reader._odps_table.schema.names if columns is None else columns
             )
+            column_dtypes = []
+            for column_name in self._metadata.column_names:
+                column_dtypes.append(reader._odps_table.schema[column_name])
 
         for record in reader.record_generator_with_retry(
             start=task.start, end=task.end, columns=self._metadata.column_names

--- a/elasticdl/python/tests/data_reader_test.py
+++ b/elasticdl/python/tests/data_reader_test.py
@@ -6,6 +6,7 @@ import unittest
 from collections import namedtuple
 
 import numpy as np
+import odps
 import tensorflow as tf
 from odps import ODPS
 
@@ -146,6 +147,16 @@ class ODPSDataReaderTest(unittest.TestCase):
         )
         self.assertEqual(
             self.reader.metadata.column_names, IRIS_TABLE_COLUMN_NAMES
+        )
+        self.assertListEqual(
+            self.reader.metadata.column_dtypes,
+            [
+                odps.types.double,
+                odps.types.double,
+                odps.types.double,
+                odps.types.double,
+                odps.types.bigint,
+            ],
         )
 
     def test_create_data_reader(self):


### PR DESCRIPTION
In the #1926, we may need the column dtypes to create tensor with the same dtype as column schema in a MaxCompute table.