### PR TITLE
Only initialize the MaxCompute IO reader once.

### DIFF
--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -676,6 +676,7 @@ def parse_ps_args(ps_args=None):
 def parse_worker_args(worker_args=None):
     parser = argparse.ArgumentParser(description="ElasticDL Worker")
     add_common_args_between_master_and_worker(parser)
+    add_train_params(parser)
     parser.add_argument(
         "--worker_id", help="ID unique to the worker", type=int, required=True
     )

--- a/elasticdl/python/data/reader/data_reader_factory.py
+++ b/elasticdl/python/data/reader/data_reader_factory.py
@@ -13,7 +13,8 @@ def create_data_reader(data_origin, records_per_task=None, **kwargs):
         data_origin: The origin of the data, e.g. location to files,
             table name in the database, etc.
         records_per_task: The number of records to create a task
-        kwargs: data reader params
+        kwargs: data reader params, the supported keys are
+            "columns", "partition", "reader_type"
     """
     reader_type = kwargs.get("reader_type", None)
     if reader_type is None:

--- a/elasticdl/python/data/reader/odps_reader.py
+++ b/elasticdl/python/data/reader/odps_reader.py
@@ -18,6 +18,7 @@ class ODPSDataReader(AbstractDataReader):
         self._reader = None
         self._table = self._kwargs["table"]
         self._columns = self._kwargs.get("columns")
+        self._init_metadata()
 
     def _init_metadata(self):
         table_schema = self._get_table_schema()

--- a/elasticdl/python/data/reader/odps_reader.py
+++ b/elasticdl/python/data/reader/odps_reader.py
@@ -23,8 +23,7 @@ class ODPSDataReader(AbstractDataReader):
         table_schema = self._get_table_schema()
         if self._metadata.column_names is None:
             self._metadata.column_names = (
-                table_schema.names
-                if self._columns is None else self._columns
+                table_schema.names if self._columns is None else self._columns
             )
 
         if self._metadata.column_names:
@@ -133,7 +132,7 @@ class ODPSDataReader(AbstractDataReader):
             access_id=self._kwargs["project"],
             secret_access_key=self._kwargs["access_id"],
             project=self._kwargs.get("partition", None),
-            endpoint=self._kwargs.get("endpoint")
+            endpoint=self._kwargs.get("endpoint"),
         )
         odps_table = odps_client.get_table(self._kwargs["table"])
         return odps_table.schema

--- a/elasticdl/python/data/reader/odps_reader.py
+++ b/elasticdl/python/data/reader/odps_reader.py
@@ -130,9 +130,9 @@ class ODPSDataReader(AbstractDataReader):
 
     def _get_table_schema(self):
         odps_client = ODPS(
-            access_id=self._kwargs["project"],
-            secret_access_key=self._kwargs["access_id"],
-            project=self._kwargs.get("partition", None),
+            access_id=self._kwargs["access_id"],
+            secret_access_key=self._kwargs["access_key"],
+            project=self._kwargs["project"],
             endpoint=self._kwargs.get("endpoint"),
         )
         odps_table = odps_client.get_table(self._kwargs["table"])

--- a/elasticdl/python/tests/data_reader_test.py
+++ b/elasticdl/python/tests/data_reader_test.py
@@ -169,8 +169,7 @@ class ODPSDataReaderTest(unittest.TestCase):
         self.assertEqual(reader._kwargs["label_col"], "class")
         self.assertEqual(reader._kwargs["records_per_task"], 10)
         reader = create_data_reader(
-            data_origin=self.test_table,
-            records_per_task=10
+            data_origin=self.test_table, records_per_task=10
         )
         self.assertEqual(reader._kwargs["records_per_task"], 10)
         self.assertTrue("columns" not in reader._kwargs)

--- a/elasticdl/python/tests/data_reader_test.py
+++ b/elasticdl/python/tests/data_reader_test.py
@@ -161,14 +161,17 @@ class ODPSDataReaderTest(unittest.TestCase):
 
     def test_create_data_reader(self):
         reader = create_data_reader(
-            data_origin="table",
+            data_origin=self.test_table,
             records_per_task=10,
             **{"columns": ["a", "b"], "label_col": "class"}
         )
         self.assertEqual(reader._kwargs["columns"], ["a", "b"])
         self.assertEqual(reader._kwargs["label_col"], "class")
         self.assertEqual(reader._kwargs["records_per_task"], 10)
-        reader = create_data_reader(data_origin="table", records_per_task=10)
+        reader = create_data_reader(
+            data_origin=self.test_table,
+            records_per_task=10
+        )
         self.assertEqual(reader._kwargs["records_per_task"], 10)
         self.assertTrue("columns" not in reader._kwargs)
 
@@ -185,7 +188,7 @@ class ODPSDataReaderTest(unittest.TestCase):
         optimizer = model_spec["optimizer"]()
         loss = model_spec["loss"]
         reader = create_data_reader(
-            data_origin="table",
+            data_origin=self.test_table,
             records_per_task=10,
             **{"columns": IRIS_TABLE_COLUMN_NAMES, "label_col": "class"}
         )

--- a/elasticdl/python/tests/data_reader_test.py
+++ b/elasticdl/python/tests/data_reader_test.py
@@ -163,7 +163,10 @@ class ODPSDataReaderTest(unittest.TestCase):
         reader = create_data_reader(
             data_origin=self.test_table,
             records_per_task=10,
-            **{"columns": ["a", "b"], "label_col": "class"}
+            **{
+                "columns": ["sepal_length", "sepal_width"],
+                "label_col": "class",
+            }
         )
         self.assertEqual(reader._kwargs["columns"], ["a", "b"])
         self.assertEqual(reader._kwargs["label_col"], "class")

--- a/elasticdl/python/tests/data_reader_test.py
+++ b/elasticdl/python/tests/data_reader_test.py
@@ -168,7 +168,9 @@ class ODPSDataReaderTest(unittest.TestCase):
                 "label_col": "class",
             }
         )
-        self.assertEqual(reader._kwargs["columns"], ["a", "b"])
+        self.assertEqual(
+            reader._kwargs["columns"], ["sepal_length", "sepal_width"]
+        )
         self.assertEqual(reader._kwargs["label_col"], "class")
         self.assertEqual(reader._kwargs["records_per_task"], 10)
         reader = create_data_reader(

--- a/elasticdl/python/worker/task_data_service.py
+++ b/elasticdl/python/worker/task_data_service.py
@@ -12,7 +12,11 @@ from elasticdl.python.data.reader.data_reader_factory import create_data_reader
 
 class TaskDataService(object):
     def __init__(
-        self, worker, training_with_evaluation, data_reader_params=None
+        self,
+        worker,
+        training_with_evaluation,
+        data_reader_params=None,
+        data_origin=None,
     ):
         self._worker = worker
         self._create_data_reader_fn = create_data_reader
@@ -24,10 +28,12 @@ class TaskDataService(object):
         self._pending_train_end_callback_task = None
         if data_reader_params:
             self.data_reader = self._create_data_reader_fn(
-                data_origin=None, **data_reader_params
+                data_origin=data_origin, **data_reader_params
             )
         else:
-            self.data_reader = self._create_data_reader_fn(data_origin=None)
+            self.data_reader = self._create_data_reader_fn(
+                data_origin=data_origin
+            )
         self._warm_up_task = None
         self._has_warmed_up = False
         self._failed_record_count = 0

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -174,6 +174,7 @@ class Worker(object):
             data_reader_params=get_dict_from_params_str(
                 args.data_reader_params
             ),
+            data_origin=args.training_data,
         )
         if self._dataset_fn is None:
             if hasattr(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("elasticdl/requirements-dev.txt") as f:
 
 setup(
     name="elasticdl",
-    version="develop",
+    version="0.2.0rc3",
     description="A Kubernetes-native Deep Learning Framework",
     long_description="ElasticDL is a Kubernetes-native deep learning framework"
     " built on top of TensorFlow 2.0 that supports"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("elasticdl/requirements-dev.txt") as f:
 
 setup(
     name="elasticdl",
-    version="0.2.0rc3",
+    version="develop",
     description="A Kubernetes-native Deep Learning Framework",
     long_description="ElasticDL is a Kubernetes-native deep learning framework"
     " built on top of TensorFlow 2.0 that supports"


### PR DESCRIPTION
1. We can only initialize the IO reader once because the shard name is the same for a MaxCompute table.
2. Then, we can get the MaxCompute table schema when initializing the `ODPSDataReader`.
3. Add `set_reader` API to we can use other IO readers.