### PR TITLE
Workers wait 5s if receiving a WAIT task.

### DIFF
--- a/elasticdl/python/worker/task_data_service.py
+++ b/elasticdl/python/worker/task_data_service.py
@@ -205,6 +205,8 @@ class TaskDataService(object):
                 if task.type == elasticdl_pb2.WAIT:
                     self._pending_dataset = True
                     logger.info("No tasks for now, maybe more later")
+                    # There are too many requests to get task from the master
+                    # if the worker does not sleep.
                     time.sleep(5)
                 else:
                     logger.info("No more task, stopping")

--- a/elasticdl/python/worker/task_data_service.py
+++ b/elasticdl/python/worker/task_data_service.py
@@ -205,6 +205,7 @@ class TaskDataService(object):
                 if task.type == elasticdl_pb2.WAIT:
                     self._pending_dataset = True
                     logger.info("No tasks for now, maybe more later")
+                    time.sleep(5)
                 else:
                     logger.info("No more task, stopping")
                 break


### PR DESCRIPTION
There are too many requests if the worker does not sleep.
Relate #1233 