### PR TITLE
Add a fileHandler into logger to write the logs to a file

### DIFF
--- a/elasticdl/python/common/k8s_client.py
+++ b/elasticdl/python/common/k8s_client.py
@@ -9,7 +9,7 @@ from kubernetes.client import V1EnvVar, V1EnvVarSource, V1ObjectFieldSelector
 
 from elasticdl.python.common.k8s_resource import parse as parse_resource
 from elasticdl.python.common.k8s_volume import parse_volume_and_mount
-from elasticdl.python.common.log_utils import default_logger as logger
+from elasticdl.python.common.log_utils import stdout_logger as logger
 from elasticdl.python.common.model_utils import load_module
 
 ELASTICDL_APP_NAME = "elasticdl"
@@ -295,7 +295,7 @@ class Client(object):
         pod = self._create_master_pod_obj(**kargs)
         pod_dict = self.client.api_client.sanitize_for_serialization(pod)
         with open(kargs["yaml"], "w") as f:
-            yaml.safe_dump(pod_dict, f)
+            yaml.safe_dump(pod_dict, f, default_flow_style=False)
 
     def _create_master_pod_obj(self, **kargs):
         env = []

--- a/elasticdl/python/common/log_utils.py
+++ b/elasticdl/python/common/log_utils.py
@@ -2,29 +2,50 @@ import logging
 import sys
 import typing
 
-_DEFAULT_LOGGER = "elastic.logger"
+LOG_FILE = "/home/admin/logs/elasticdl.log"
+
+_DEFAULT_LOGGER = "elasticdl.logger"
+_STDOUT_LOGGER = "elasticdl_stdout.logger"
 
 _DEFAULT_FORMATTER = logging.Formatter(
     "[%(asctime)s] [%(levelname)s] "
     "[%(filename)s:%(lineno)d:%(funcName)s] %(message)s"
 )
 
-_ch = logging.StreamHandler(stream=sys.stderr)
-_ch.setFormatter(_DEFAULT_FORMATTER)
+_STREAM_HANDLER = logging.StreamHandler(stream=sys.stderr)
+_STREAM_HANDLER.setFormatter(_DEFAULT_FORMATTER)
 
-_DEFAULT_HANDLERS = [_ch]
 
 _LOGGER_CACHE = {}  # type: typing.Dict[str, logging.Logger]
 
 
-def get_logger(name, level="INFO", handlers=None, update=False):
+def get_file_hander(filename):
+    file_handler = logging.FileHandler(
+        filename, mode='a', encoding="UTF-8", delay=True
+    )
+    file_handler.setFormatter(_DEFAULT_FORMATTER)
+    return file_handler
+
+
+def get_logger(
+    name, level="INFO", filename=None, handlers=None, update=False
+):
     if name in _LOGGER_CACHE and not update:
         return _LOGGER_CACHE[name]
+
     logger = logging.getLogger(name)
     logger.setLevel(level)
-    logger.handlers = handlers or _DEFAULT_HANDLERS
+    logger.handlers = handlers or [_STREAM_HANDLER]
     logger.propagate = False
+
+    if filename:
+        file_handler = get_file_hander(filename)
+        logger.handlers.append(file_handler)
+
+    _LOGGER_CACHE[name] = logger
     return logger
 
 
-default_logger = get_logger(_DEFAULT_LOGGER)
+stdout_logger = get_logger(_STDOUT_LOGGER)
+
+default_logger = get_logger(_DEFAULT_LOGGER, filename=LOG_FILE)

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -6,7 +6,7 @@ from elasticdl.python.common.args import (
     parse_envs,
 )
 from elasticdl.python.common.constants import DistributionStrategy
-from elasticdl.python.common.log_utils import default_logger as logger
+from elasticdl.python.common.log_utils import stdout_logger as logger
 from elasticdl.python.elasticdl.image_builder import (
     build_and_push_docker_image,
     remove_images,

--- a/elasticdl/python/elasticdl/image_builder.py
+++ b/elasticdl/python/elasticdl/image_builder.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 import docker
 
 from elasticdl.python.common.file_utils import copy_if_not_exists
-from elasticdl.python.common.log_utils import default_logger as logger
+from elasticdl.python.common.log_utils import stdout_logger as logger
 
 
 def build_and_push_docker_image(
@@ -145,8 +145,10 @@ ENV PYTHONPATH=/
         HEAD = """
 %s
 COPY %s/elasticdl /elasticdl
+COPY %s/elasticdl_preprocessing /elasticdl_preprocessing
 """ % (
             HEAD,
+            elasticdl,
             elasticdl,
         )
 

--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -18,7 +18,10 @@ from elasticdl.python.common.constants import (
     JobType,
 )
 from elasticdl.python.common.k8s_tensorboard_client import TensorBoardClient
-from elasticdl.python.common.log_utils import get_logger
+from elasticdl.python.common.log_utils import (
+    get_logger,
+    LOG_FILE
+)
 from elasticdl.python.common.model_utils import (
     get_dict_from_params_str,
     get_module_file_path,
@@ -76,7 +79,9 @@ def _make_task_dispatcher(
 
 class Master(object):
     def __init__(self, args):
-        self.logger = get_logger("master", level=args.log_level.upper())
+        self.logger = get_logger(
+            "master", level=args.log_level.upper(), filename=LOG_FILE
+        )
 
         self.num_ps_pods = args.num_ps_pods
         self.checkpoint_output_path = args.checkpoint_dir

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -21,7 +21,10 @@ from elasticdl.python.common.hash_utils import (
     scatter_embedding_vector,
     string_to_id,
 )
-from elasticdl.python.common.log_utils import get_logger
+from elasticdl.python.common.log_utils import (
+    get_logger,
+    LOG_FILE,
+)
 from elasticdl.python.common.model_handler import ModelHandler
 from elasticdl.python.common.model_utils import (
     find_layer,
@@ -79,7 +82,9 @@ class Worker(object):
                 training strategy is used.
         """
         self._args = args
-        self.logger = get_logger("Worker", level=args.log_level.upper())
+        self.logger = get_logger(
+            "Worker", level=args.log_level.upper(), filename=LOG_FILE
+        )
 
         if set_parallelism:
             # Explicitly setting the parallelism will avoid multi-process hangs


### PR DESCRIPTION
Except outputing the logs to stdout, we also need to write the logs to a file. Then, the log system can collect logs from the file.