### PR TITLE
Use /bin/bash to execute the python command

### DIFF
--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -289,6 +289,12 @@ def add_common_params(parser):
         'by semi-colon used to debug , e.g. "param1=1; param2=2" '
         "Supported auxiliary parameters: disable_relaunch",
     )
+    parser.add_argument(
+        "--log_file_path",
+        type=str,
+        default="",
+        help="The path to save logs",
+    )
 
 
 def add_train_params(parser):
@@ -721,6 +727,7 @@ def build_arguments_from_parsed_result(args, filter_args=None):
         such as ["--foo", "3", "--bar", False]
     """
     items = vars(args).items()
+    items = filter(lambda item: item[1] != "", items)
     if filter_args:
         items = filter(lambda item: item[0] not in filter_args, items)
 

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -290,7 +290,10 @@ def add_common_params(parser):
         "Supported auxiliary parameters: disable_relaunch",
     )
     parser.add_argument(
-        "--log_file_path", type=str, default="", help="The path to save logs",
+        "--log_file_path",
+        type=str,
+        default="",
+        help="The path to save logs (e.g. stdout, stderr)",
     )
 
 

--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -290,10 +290,7 @@ def add_common_params(parser):
         "Supported auxiliary parameters: disable_relaunch",
     )
     parser.add_argument(
-        "--log_file_path",
-        type=str,
-        default="",
-        help="The path to save logs",
+        "--log_file_path", type=str, default="", help="The path to save logs",
     )
 
 
@@ -727,7 +724,6 @@ def build_arguments_from_parsed_result(args, filter_args=None):
         such as ["--foo", "3", "--bar", False]
     """
     items = vars(args).items()
-    items = filter(lambda item: item[1] != "", items)
     if filter_args:
         items = filter(lambda item: item[0] not in filter_args, items)
 
@@ -741,3 +737,38 @@ def build_arguments_from_parsed_result(args, filter_args=None):
         "--" + k if i % 2 == 0 else k for i, k in enumerate(arguments)
     ]
     return arguments
+
+
+def wrap_python_args_with_string(args):
+    """Wrap argument values with string
+    Args:
+        args: list like ["--foo", "3", "--bar", False]
+
+    Returns:
+        list of string: like ["--foo", "'3'", "--bar", "'False'"]
+    """
+    result = []
+    for value in args:
+        if "--" not in value:
+            result.append("'{}'".format(value))
+        else:
+            result.append(value)
+    return result
+
+
+def wrap_go_args_with_string(args):
+    """Wrap argument values with string
+    Args:
+        args: list like ["--foo=3", "--bar=False"]
+
+    Returns:
+        list of string: like ["--foo='3'", "--bar='False'"]
+    """
+    result = []
+    for value in args:
+        equal_mark_index = value.index("=")
+        arg_value_index = equal_mark_index + 1
+        result.append(
+            value[0:equal_mark_index] + "='{}'".format(value[arg_value_index:])
+        )
+    return result

--- a/elasticdl/python/common/constants.py
+++ b/elasticdl/python/common/constants.py
@@ -71,3 +71,7 @@ class ReaderType(object):
     CSV_READER = "CSV"
     ODPS_READER = "ODPS"
     RECORDIO_READER = "RecordIO"
+
+
+class BashCommandTemplate(object):
+    REDIRECTION = ">> {} 2>&1"

--- a/elasticdl/python/common/k8s_client.py
+++ b/elasticdl/python/common/k8s_client.py
@@ -295,7 +295,7 @@ class Client(object):
         pod = self._create_master_pod_obj(**kargs)
         pod_dict = self.client.api_client.sanitize_for_serialization(pod)
         with open(kargs["yaml"], "w") as f:
-            yaml.safe_dump(pod_dict, f)
+            yaml.safe_dump(pod_dict, f, default_flow_style=False)
 
     def _create_master_pod_obj(self, **kargs):
         env = []
@@ -308,7 +308,7 @@ class Client(object):
             pod_name=self.get_master_pod_name(),
             job_name=self.job_name,
             image_name=self._image_name,
-            command=["python"],
+            command=["/bin/bash"],
             resource_requests=kargs["resource_requests"],
             resource_limits=kargs["resource_limits"],
             container_args=kargs["args"],

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -179,12 +179,13 @@ def _submit_job(image_name, client_args, container_args):
         force_use_kube_config_file=client_args.force_use_kube_config_file,
     )
 
+    container_args = wrap_python_args_with_string(container_args)
+
+    master_client_command = "python -m elasticdl.python.master.main"
+    container_args.insert(0, master_client_command)
     if client_args.log_file_path:
         container_args.append(">> {} 2>&1".format(client_args.log_file_path))
 
-    master_client_command = "python -m elasticdl.python.master.main"
-    container_args = wrap_python_args_with_string(container_args)
-    container_args.insert(0, master_client_command)
     python_command = " ".join(container_args)
     container_args = ["-c", python_command]
 

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -40,7 +40,7 @@ def train(args):
     )
 
     container_args = [
-        "-m",
+        "python -m",
         "elasticdl.python.master.main",
         "--worker_image",
         image_name,
@@ -57,6 +57,7 @@ def train(args):
                 "cluster_spec",
                 "worker_image",
                 "force_use_kube_config_file",
+                "func",
             ],
         )
     )
@@ -85,7 +86,7 @@ def evaluate(args):
         )
     )
     container_args = [
-        "-m",
+        "python -m",
         "elasticdl.python.master.main",
         "--worker_image",
         image_name,
@@ -102,6 +103,7 @@ def evaluate(args):
                 "cluster_spec",
                 "worker_image",
                 "force_use_kube_config_file",
+                "func",
             ],
         )
     )
@@ -129,7 +131,7 @@ def predict(args):
         )
     )
     container_args = [
-        "-m",
+        "python -m",
         "elasticdl.python.master.main",
         "--worker_image",
         image_name,
@@ -181,6 +183,12 @@ def _submit_job(image_name, client_args, container_args):
         cluster_spec=client_args.cluster_spec,
         force_use_kube_config_file=client_args.force_use_kube_config_file,
     )
+
+    if client_args.log_file_path:
+        container_args.append(">> {} 2>&1".format(client_args.log_file_path))
+
+    python_command = " ".join(container_args)
+    container_args = ["-c", python_command]
 
     if client_args.yaml:
         client.dump_master_yaml(

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -4,6 +4,7 @@ from elasticdl.python.common import k8s_client as k8s
 from elasticdl.python.common.args import (
     build_arguments_from_parsed_result,
     parse_envs,
+    wrap_python_args_with_string,
 )
 from elasticdl.python.common.constants import DistributionStrategy
 from elasticdl.python.common.log_utils import default_logger as logger
@@ -40,8 +41,6 @@ def train(args):
     )
 
     container_args = [
-        "python -m",
-        "elasticdl.python.master.main",
         "--worker_image",
         image_name,
         "--model_zoo",
@@ -86,8 +85,6 @@ def evaluate(args):
         )
     )
     container_args = [
-        "python -m",
-        "elasticdl.python.master.main",
         "--worker_image",
         image_name,
         "--model_zoo",
@@ -131,8 +128,6 @@ def predict(args):
         )
     )
     container_args = [
-        "python -m",
-        "elasticdl.python.master.main",
         "--worker_image",
         image_name,
         "--model_zoo",
@@ -187,6 +182,9 @@ def _submit_job(image_name, client_args, container_args):
     if client_args.log_file_path:
         container_args.append(">> {} 2>&1".format(client_args.log_file_path))
 
+    master_client_command = "python -m elasticdl.python.master.main"
+    container_args = wrap_python_args_with_string(container_args)
+    container_args.insert(0, master_client_command)
     python_command = " ".join(container_args)
     container_args = ["-c", python_command]
 

--- a/elasticdl/python/elasticdl/image_builder.py
+++ b/elasticdl/python/elasticdl/image_builder.py
@@ -145,8 +145,10 @@ ENV PYTHONPATH=/
         HEAD = """
 %s
 COPY %s/elasticdl /elasticdl
+COPY %s/elasticdl_preprocessing /elasticdl_preprocessing
 """ % (
             HEAD,
+            elasticdl,
             elasticdl,
         )
 

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -127,6 +127,10 @@ class InstanceManager(object):
 
     def _start_worker(self, worker_id):
         logger.info("Starting worker: %d" % worker_id)
+        bash_command = self._worker_args[1]
+        bash_command += " --worker_id {}".format(worker_id)
+        bash_command += " --ps_addrs {}".format(self._ps_addrs)
+        worker_args = [self._worker_args[0], bash_command]
         with self._lock:
             pod = self._k8s_client.create_worker(
                 worker_id=worker_id,
@@ -137,9 +141,7 @@ class InstanceManager(object):
                 volume=self._volume,
                 image_pull_policy=self._image_pull_policy,
                 command=self._worker_command,
-                args=self._worker_args
-                + ["--worker_id", str(worker_id)]
-                + ["--ps_addrs", self._ps_addrs],
+                args=worker_args,
                 restart_policy=self._restart_policy,
                 ps_addrs=self._ps_addrs,
                 envs=copy.deepcopy(self._envs),
@@ -152,6 +154,9 @@ class InstanceManager(object):
 
     def _start_ps(self, ps_id):
         logger.info("Starting PS: %d" % ps_id)
+        bash_command = self._ps_args[1]
+        bash_command += " --ps_id {}".format(ps_id)
+        ps_args = [self._ps_args[0], bash_command]
         with self._lock:
             pod = self._k8s_client.create_ps(
                 ps_id=ps_id,
@@ -161,7 +166,7 @@ class InstanceManager(object):
                 volume=self._volume,
                 image_pull_policy=self._image_pull_policy,
                 command=self._ps_command,
-                args=self._ps_args + ["--ps_id", str(ps_id)],
+                args=ps_args,
                 restart_policy=self._restart_policy,
                 envs=copy.deepcopy(self._envs),
                 expose_ports=False,

--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -453,7 +453,7 @@ class Master(object):
                     "--num_minibatches_per_task",
                     str(args.num_minibatches_per_task),
                 ]
-                ps_args = self._wrap_python_args_with_string(ps_args)
+                ps_args = wrap_python_args_with_string(ps_args)
                 ps_args.insert(0, ps_client_command)
 
             if args.log_file_path:

--- a/elasticdl/python/tests/args_test.py
+++ b/elasticdl/python/tests/args_test.py
@@ -5,6 +5,8 @@ from elasticdl.python.common.args import (
     add_bool_param,
     build_arguments_from_parsed_result,
     parse_ps_args,
+    wrap_go_args_with_string,
+    wrap_python_args_with_string,
 )
 
 
@@ -67,3 +69,37 @@ class ArgsTest(unittest.TestCase):
         )
         self.assertEqual(parsed_args.model_zoo, model_zoo)
         self.assertEqual(parsed_args.model_def, model_def)
+
+    def test_wrap_python_args_with_string(self):
+        args = [
+            "--ps_id",
+            str(0),
+            "--job_name",
+            "test_args",
+            "--checkpoint_dir",
+            "",
+        ]
+        args = wrap_python_args_with_string(args)
+        expected_args = [
+            "--ps_id",
+            "'0'",
+            "--job_name",
+            "'test_args'",
+            "--checkpoint_dir",
+            "''",
+        ]
+        self.assertListEqual(args, expected_args)
+
+    def test_wrap_go_args_with_string(self):
+        args = [
+            "-ps_id=0",
+            "-job_name=test_args",
+            "-opt_args=learning_rate=0.1;momentum=0.0;nesterov=False",
+        ]
+        args = wrap_go_args_with_string(args)
+        expected_args = [
+            "-ps_id='0'",
+            "-job_name='test_args'",
+            "-opt_args='learning_rate=0.1;momentum=0.0;nesterov=False'",
+        ]
+        self.assertListEqual(args, expected_args)

--- a/elasticdl/python/tests/k8s_instance_manager_test.py
+++ b/elasticdl/python/tests/k8s_instance_manager_test.py
@@ -22,7 +22,7 @@ class InstanceManagerTest(unittest.TestCase):
             % (int(time.time()), random.randint(1, 101)),
             image_name="gcr.io/google-samples/hello-app:1.0",
             worker_command=["/bin/bash"],
-            worker_args=['-c', 'echo'],
+            worker_args=["-c", "echo"],
             namespace="default",
             num_workers=3,
         )

--- a/elasticdl/python/tests/k8s_instance_manager_test.py
+++ b/elasticdl/python/tests/k8s_instance_manager_test.py
@@ -21,8 +21,8 @@ class InstanceManagerTest(unittest.TestCase):
             job_name="test-create-worker-pod-%d-%d"
             % (int(time.time()), random.randint(1, 101)),
             image_name="gcr.io/google-samples/hello-app:1.0",
-            worker_command=["echo"],
-            worker_args=[],
+            worker_command=["/bin/bash"],
+            worker_args=['-c', 'echo'],
             namespace="default",
             num_workers=3,
         )
@@ -61,8 +61,8 @@ class InstanceManagerTest(unittest.TestCase):
             job_name="test-failed-worker-pod-%d-%d"
             % (int(time.time()), random.randint(1, 101)),
             image_name="gcr.io/google-samples/hello-app:1.0",
-            worker_command=["badcommand"],
-            worker_args=["badargs"],
+            worker_command=["/bin/bash"],
+            worker_args=["-c", "badcommand"],
             namespace="default",
             num_workers=3,
             restart_policy="Never",
@@ -97,8 +97,8 @@ class InstanceManagerTest(unittest.TestCase):
             job_name="test-relaunch-worker-pod-%d-%d"
             % (int(time.time()), random.randint(1, 101)),
             image_name="gcr.io/google-samples/hello-app:1.0",
-            worker_command=["sleep 10"],
-            worker_args=[],
+            worker_command=["/bin/bash"],
+            worker_args=["-c", "sleep 10"],
             namespace="default",
             num_workers=num_workers,
         )
@@ -149,8 +149,8 @@ class InstanceManagerTest(unittest.TestCase):
             job_name="test-relaunch-ps-pod-%d-%d"
             % (int(time.time()), random.randint(1, 101)),
             image_name="gcr.io/google-samples/hello-app:1.0",
-            ps_command=["sleep 10"],
-            ps_args=[],
+            ps_command=["/bin/bash"],
+            ps_args=["-c", "sleep 10"],
             namespace="default",
             num_ps=num_ps,
         )


### PR DESCRIPTION
Sometimes, we need to redirect the pod logs to a file in the disk and we can use bash redirection
command like ">> log.txt 2>&1". So we need to use /bin/bash in the command of the pod container. Then the args of the container is ["-c", "{COMMAND}"]