### PR TITLE
Add log_loss_steps to control the loss log frequency.

### DIFF
--- a/elasticdl/python/common/args.py
+++ b/elasticdl/python/common/args.py
@@ -357,6 +357,13 @@ def add_train_params(parser):
         "and PS that synchronous SGD can accepts.",
         default=0,
     )
+    parser.add_argument(
+        "--log_loss_steps",
+        type=int,
+        help="The frequency, in number of global steps, that the global step "
+        "and the loss will be logged during training.",
+        default=100,
+    )
     add_bool_param(
         parser=parser,
         name="--use_async",

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -130,6 +130,7 @@ class Worker(object):
         self._worker_id = args.worker_id
         self._job_type = args.job_type
         self._minibatch_size = args.minibatch_size
+        self._log_loss_steps = args.log_loss_steps
         (
             model_inst,
             self._dataset_fn,
@@ -876,8 +877,12 @@ class Worker(object):
                 *accepted, min_model_version, loss = self._run_training_task(
                     features, labels
                 )
-                if accepted:
-                    self.logger.info("Loss is {}".format(loss.numpy()))
+                if accepted and min_model_version % self._log_loss_steps == 0:
+                    self.logger.info(
+                        "Loss = {}, steps = {}:".format(
+                            loss.numpy(), min_model_version
+                        )
+                    )
                     break
             elif task_type == elasticdl_pb2.PREDICTION:
                 if self._model_version != min_model_version:

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -877,12 +877,14 @@ class Worker(object):
                 *accepted, min_model_version, loss = self._run_training_task(
                     features, labels
                 )
-                if accepted and min_model_version % self._log_loss_steps == 0:
+                if min_model_version % self._log_loss_steps == 0:
                     self.logger.info(
                         "Loss = {}, steps = {}:".format(
                             loss.numpy(), min_model_version
                         )
                     )
+
+                if accepted:
                     break
             elif task_type == elasticdl_pb2.PREDICTION:
                 if self._model_version != min_model_version:

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -879,7 +879,7 @@ class Worker(object):
                 )
                 if min_model_version % self._log_loss_steps == 0:
                     self.logger.info(
-                        "Loss = {}, steps = {}:".format(
+                        "Loss = {}, steps = {}".format(
                             loss.numpy(), min_model_version
                         )
                     )

--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -887,7 +887,9 @@ class Worker(object):
                             loss.numpy(), self._model_version
                         )
                     )
-                    self._log_loss_count += 1
+                    self._log_loss_count = (
+                        int(self._model_version / self._log_loss_steps) + 1
+                    )
                 if accepted:
                     break
             elif task_type == elasticdl_pb2.PREDICTION:


### PR DESCRIPTION
The log count is too much if the worker logs the loss for each batch.  We can refer to [tf.estimator.RunConfig](https://www.tensorflow.org/api_docs/python/tf/estimator/RunConfig) to control the frequency.