### PR TITLE
Use tee to reads logs from stdout and stderr

### DIFF
--- a/elasticdl/python/common/constants.py
+++ b/elasticdl/python/common/constants.py
@@ -74,4 +74,4 @@ class ReaderType(object):
 
 
 class BashCommandTemplate(object):
-    REDIRECTION = ">> {} 2>&1"
+    REDIRECTION = " 2>&1 | tee {}"

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -6,6 +6,7 @@ from elasticdl.python.common.args import (
     parse_envs,
     wrap_python_args_with_string,
 )
+from elasticdl.python.common.constants import BashCommandTemplate
 from elasticdl.python.common.constants import DistributionStrategy
 from elasticdl.python.common.log_utils import default_logger as logger
 from elasticdl.python.elasticdl.image_builder import (
@@ -184,7 +185,9 @@ def _submit_job(image_name, client_args, container_args):
     master_client_command = "python -m elasticdl.python.master.main"
     container_args.insert(0, master_client_command)
     if client_args.log_file_path:
-        container_args.append(">> {} 2>&1".format(client_args.log_file_path))
+        container_args.append(
+            BashCommandTemplate.REDIRECTION.format(client_args.log_file_path)
+        )
 
     python_command = " ".join(container_args)
     container_args = ["-c", python_command]

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -6,8 +6,10 @@ from elasticdl.python.common.args import (
     parse_envs,
     wrap_python_args_with_string,
 )
-from elasticdl.python.common.constants import BashCommandTemplate
-from elasticdl.python.common.constants import DistributionStrategy
+from elasticdl.python.common.constants import (
+    BashCommandTemplate,
+    DistributionStrategy,
+)
 from elasticdl.python.common.log_utils import default_logger as logger
 from elasticdl.python.elasticdl.image_builder import (
     build_and_push_docker_image,

--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -15,7 +15,6 @@ from elasticdl.python.common.args import (
 )
 from elasticdl.python.common.constants import (
     GRPC,
-    BashCommandTemplate,
     DistributionStrategy,
     InstanceManagerStatus,
     JobType,
@@ -457,14 +456,6 @@ class Master(object):
                 ps_args = wrap_python_args_with_string(ps_args)
                 ps_args.insert(0, ps_client_command)
 
-            if args.log_file_path:
-                worker_args.append(
-                    BashCommandTemplate.REDIRECTION.format(args.log_file_path)
-                )
-                ps_args.append(
-                    BashCommandTemplate.REDIRECTION.format(args.log_file_path)
-                )
-
             worker_args = ["-c", " ".join(worker_args)]
             ps_args = ["-c", " ".join(ps_args)]
 
@@ -501,6 +492,7 @@ class Master(object):
                 expose_ports=self.distribution_strategy
                 == DistributionStrategy.ALLREDUCE,
                 disable_relaunch=disable_relaunch,
+                log_file_path=args.log_file_path,
             )
 
         return instance_manager


### PR DESCRIPTION
We cannot use `kubectl logs pod_name` to view logs if we use `>>`  to redirect logs into a file. But `tee` can do it.
"The tee command reads from the standard input and writes to both standard output and one or more files at the same time. tee is mostly used in combination with other commands through piping.
" 