### PR TITLE
Add "set -o pipefail" before the pipe to launch ElasticDL processes.

### DIFF
--- a/elasticdl/python/common/constants.py
+++ b/elasticdl/python/common/constants.py
@@ -75,3 +75,4 @@ class ReaderType(object):
 
 class BashCommandTemplate(object):
     REDIRECTION = " 2>&1 | tee {}"
+    SET_PIPEFAIL = "set -o pipefail;"

--- a/elasticdl/python/data/odps_io.py
+++ b/elasticdl/python/data/odps_io.py
@@ -15,12 +15,12 @@ from elasticdl.python.common.constants import MaxComputeConfig
 from elasticdl.python.common.log_utils import default_logger as logger
 
 
-def _nested_list_size(l):
+def _nested_list_size(nested_list):
     """
     Obtains the memory size for the nested list.
     """
-    total = sys.getsizeof(l)
-    for i in l:
+    total = sys.getsizeof(nested_list)
+    for i in nested_list:
         if isinstance(i, list):
             total += _nested_list_size(i)
         else:

--- a/elasticdl/python/elasticdl/api.py
+++ b/elasticdl/python/elasticdl/api.py
@@ -184,7 +184,10 @@ def _submit_job(image_name, client_args, container_args):
 
     container_args = wrap_python_args_with_string(container_args)
 
-    master_client_command = "python -m elasticdl.python.master.main"
+    master_client_command = (
+        BashCommandTemplate.SET_PIPEFAIL
+        + " python -m elasticdl.python.master.main"
+    )
     container_args.insert(0, master_client_command)
     if client_args.log_file_path:
         container_args.append(

--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -15,6 +15,7 @@ from elasticdl.python.common.args import (
 )
 from elasticdl.python.common.constants import (
     GRPC,
+    BashCommandTemplate,
     DistributionStrategy,
     InstanceManagerStatus,
     JobType,
@@ -375,7 +376,10 @@ class Master(object):
         if args.num_workers:
             assert args.worker_image, "Worker image cannot be empty"
 
-            worker_client_command = "python -m elasticdl.python.worker.main"
+            worker_client_command = (
+                BashCommandTemplate.SET_PIPEFAIL
+                + " python -m elasticdl.python.worker.main"
+            )
             worker_args = [
                 "--master_addr",
                 self.master_addr,
@@ -415,7 +419,10 @@ class Master(object):
                 ps_args = wrap_go_args_with_string(ps_args)
                 ps_args.insert(0, ps_client_command)
             else:
-                ps_client_command = "python -m elasticdl.python.ps.main"
+                ps_client_command = (
+                    BashCommandTemplate.SET_PIPEFAIL
+                    + " python -m elasticdl.python.ps.main"
+                )
                 ps_args = [
                     "--grads_to_wait",
                     str(args.grads_to_wait),


### PR DESCRIPTION
 If pipefail is enabled, the pipeline’s return status is the value of the last (rightmost) command to exit with a non-zero status, or zero if all commands exit successfully.

Then, the command it
```
 /bin/bash -c "set -o pipefail; python -m elasticdl.python.master.main xxx | tee elasticdl.log"
```