### PR TITLE
fix ci

### DIFF
--- a/elasticdl/docker/scripts/install-go.bash
+++ b/elasticdl/docker/scripts/install-go.bash
@@ -14,7 +14,6 @@ go get golang.org/x/lint/golint
 go get golang.org/x/tools/cmd/goyacc	
 go get golang.org/x/tools/cmd/cover	
 go get github.com/mattn/goveralls	
-go get github.com/rakyll/gotest	
 
 
 cp $GOPATH/bin/* /usr/local/bin/


### PR DESCRIPTION
Current CI failed with gotest library

```
go: finding golang.org/x/sys v0.0.0-20191026070338-33540a1f6037
# github.com/rakyll/gotest
root/go/pkg/mod/github.com/rakyll/gotest@v0.0.2/main.go:105:3: undefined: c
root/go/pkg/mod/github.com/rakyll/gotest@v0.0.2/main.go:113:3: undefined: c
root/go/pkg/mod/github.com/rakyll/gotest@v0.0.2/main.go:117:3: undefined: c
root/go/pkg/mod/github.com/rakyll/gotest@v0.0.2/main.go:123:3: undefined: c
root/go/pkg/mod/github.com/rakyll/gotest@v0.0.2/main.go:155:8: cannot use c (type color.Attribute) as type *color.Color in assignment
note: module requires Go 1.14
The command '/bin/sh -c /install-go.bash ${GO_MIRROR_URL} && rm /install-go.bash' returned a non-zero code: 2
The command "docker build --target dev -t elasticdl:dev -f elasticdl/docker/Dockerfile ." exited with 2.
0.55s$ docker run --rm -it -v $PWD:/work -w /work elasticdl:dev bash -c "pre-commit run --files $(find elasticdl/python elasticdl_preprocessing model_zoo setup.py scripts/ -name '*.py' -print0 | tr '\0' ' ') $(find elasticdl/pkg -name '*.go' -print0 | tr '\0' ' ')"
Unable to find image 'elasticdl:dev' locally
docker: Error response from daemon: pull access denied for elasticdl, repository does not exist or may require 'docker login'.
See 'docker run --help'.
The command "docker run --rm -it -v $PWD:/work -w /work elasticdl:dev bash -c "pre-commit run --files $(find elasticdl/python elasticdl_preprocessing model_zoo setup.py scripts/ -name '*.py' -print0 | tr '\0' ' ') $(find elasticdl/pkg -name '*.go' -print0 | tr '\0' ' ')"" exited with 125.
```