### PR TITLE
Add shellcheck to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,46 +1,51 @@
+---
 repos:
--   repo: https://github.com/asottile/seed-isort-config
+  - repo: https://github.com/asottile/seed-isort-config
     rev: v1.9.1
     hooks:
-    - id: seed-isort-config
--   repo: https://github.com/pre-commit/mirrors-isort
+      - id: seed-isort-config
+  - repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.20
     hooks:
-    - id: isort
--   repo: https://github.com/psf/black
-    rev: stable
+      - id: isort
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
     hooks:
-    - id: black
-      args: [--line-length=79]
--   repo: https://github.com/pre-commit/pre-commit-hooks
+      - id: black
+        args: [--line-length=79]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:
-    -   id: flake8
--   repo: git://github.com/skorokithakis/pre-commit-mypy
+      - id: flake8
+  - repo: git://github.com/skorokithakis/pre-commit-mypy
     rev: v0.701
     hooks:
-    - id: mypy
-      args: [--ignore-missing-imports, --follow-imports=skip]
--   repo: local
+      - id: mypy
+        args: [--ignore-missing-imports, --follow-imports=skip]
+  - repo: local
     hooks:
-    - id: clang-format
-      name: clang-format
-      description: Format files with ClangFormat.
-      entry: bash ./scripts/codestyle/clang_format.hook -i
-      language: system
-      files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|proto)$
--   repo: local
+      - id: clang-format
+        name: clang-format
+        description: Format files with ClangFormat.
+        entry: bash ./scripts/codestyle/clang_format.hook -i
+        language: system
+        files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|proto)$
+  - repo: local
     hooks:
-    - id: cpplint-cpp-source
-      name: cpplint
-      description: Check C++ code style using cpplint.py.
-      entry: bash ./scripts/codestyle/cpplint_precommit.hook
-      language: system
-      files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx)$
-- repo: git://github.com/dnephin/pre-commit-golang
-  rev: v0.3.3
-  hooks:
-    - id: go-fmt
-    - id: go-lint
-    - id: validate-toml
-    - id: no-go-testing
+      - id: cpplint-cpp-source
+        name: cpplint
+        description: Check C++ code style using cpplint.py.
+        entry: bash ./scripts/codestyle/cpplint_precommit.hook
+        language: system
+        files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx)$
+  - repo: git://github.com/dnephin/pre-commit-golang
+    rev: v0.3.3
+    hooks:
+      - id: go-fmt
+      - id: go-lint
+      - id: validate-toml
+      - id: no-go-testing
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: v0.1.8
+    hooks:
+      - id: shellcheck


### PR DESCRIPTION
I also applied [yamllint](https://github.com/adrienverge/yamllint) manually to `.pre-commit-hook`.

I will add yamllint to the hook in a future PR.

Fix https://github.com/sql-machine-learning/elasticdl/issues/1970