### PR TITLE
Set packages in the setup.py of elasticdl_preprocessing

### DIFF
--- a/elasticdl_preprocessing/setup.py
+++ b/elasticdl_preprocessing/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 with open("elasticdl_preprocessing/requirements.txt") as f:
     required_deps = f.read().splitlines()
@@ -21,6 +21,6 @@ setup(
     install_requires=required_deps,
     extras_require=extras,
     python_requires=">=3.5",
-    packages=["elasticdl_preprocessing"],
+    packages=find_packages(include=["*elasticdl_preprocessing*"], ),
     package_data={"": ["requirements.txt"]},
 )

--- a/elasticdl_preprocessing/setup.py
+++ b/elasticdl_preprocessing/setup.py
@@ -1,3 +1,16 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from setuptools import find_packages, setup
 
 with open("elasticdl_preprocessing/requirements.txt") as f:
@@ -9,7 +22,7 @@ with open("elasticdl_preprocessing/requirements-dev.txt") as f:
 
 setup(
     name="elasticdl_preprocessing",
-    version="0.1.0",
+    version="develop",
     description="A Kubernetes-native Deep Learning Framework",
     long_description="This is an extension of the native Keras Preprocessing"
     " Layers and Feature Column API from TensorFlow. We can develop our model"
@@ -21,6 +34,6 @@ setup(
     install_requires=required_deps,
     extras_require=extras,
     python_requires=">=3.5",
-    packages=find_packages(include=["*elasticdl_preprocessing*"], ),
+    packages=find_packages(include=["*elasticdl_preprocessing*"],),
     package_data={"": ["requirements.txt"]},
 )


### PR DESCRIPTION
We should use `find_packages` in the `setup.py` to include all Python files in the `elasticdl_preprocessing` directory.