### PR TITLE
refine elasticdl:ci dockerfile for integration test

### DIFF
--- a/elasticdl/docker/Dockerfile
+++ b/elasticdl/docker/Dockerfile
@@ -7,8 +7,6 @@ ARG BASE_IMAGE=tensorflow/tensorflow:2.1.0-py3
 # docker build --target dev -t dev_image -f this_dockerfile elasticdl_repo_dir
 # To build ci:
 # docker build --target ci -t ci_image -f this_dockerfile elasticdl_repo_dir
-# To build release:
-# docker -t image_name -f this_dockerfile elasticdl_repo_dir
 
 # Stage 1: dev
 FROM ${BASE_IMAGE} as dev
@@ -66,9 +64,6 @@ RUN cd /elasticdl && \
     cp dist/elasticdl-develop-py3-none-any.whl /
 
 
-# Stage 2: ci
-FROM dev as ci
-
 # This assumes that the data generation package is independent with the
 # rest part of ElasticDL.  The generated data will be in /data.
 COPY elasticdl/python/data/recordio_gen/image_label.py /var/image_label.py
@@ -89,23 +84,23 @@ RUN python /var/heart_recordio_gen.py --data_dir /root/.keras/datasets \
 
 RUN rm -rf /root/.keras/datasets
 
-WORKDIR /
-ENV PYTHONPATH=/elasticdl
-COPY setup.py /elasticdl/setup.py
-RUN cd /elasticdl && python setup.py -q install
-COPY model_zoo /model_zoo
 
+# Stage 2: ci
 
-# Stage 3: release
-FROM ${BASE_IMAGE} as release
+FROM ${BASE_IMAGE} as ci
 ARG EXTRA_PYPI_INDEX=https://pypi.org/simple
 
-# Replace the Splash screen from TensorFlow image.
 COPY elasticdl/docker/bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
 
+# Copy data
+COPY --from=dev /data /data
+
+# Copy model zoo
+COPY model_zoo /model_zoo
+
 # Copy GO PS
-ARG GO_PS=/root/go/bin/main
+ARG GO_PS=/root/go/bin/start_ps
 RUN mkdir -p /usr/local/go/bin
 COPY --from=dev ${GO_PS} /usr/local/go/bin
 ENV PATH /usr/local/go/bin:$PATH

--- a/elasticdl/docker/Dockerfile
+++ b/elasticdl/docker/Dockerfile
@@ -42,6 +42,24 @@ RUN /install-go.bash ${GO_MIRROR_URL} && rm /install-go.bash
 COPY elasticdl/docker/scripts/install-protobuf.bash /
 RUN /install-protobuf.bash && rm /install-protobuf.bash
 
+# This assumes that the data generation package is independent with the
+# rest part of ElasticDL.  The generated data will be in /data.
+COPY elasticdl/python/data/recordio_gen/image_label.py /var/image_label.py
+RUN python /var/image_label.py --dataset mnist --fraction 0.15 \
+        --records_per_shard 4096 /data
+
+# Copy frappe dataset
+COPY elasticdl/python/data/recordio_gen/frappe_recordio_gen.py \
+     /var/frappe_recordio_gen.py
+RUN python /var/frappe_recordio_gen.py --data /root/.keras/datasets \
+    --output_dir /data/frappe \
+    --fraction 0.05
+# Copy heart dataset
+COPY elasticdl/python/data/recordio_gen/heart_recordio_gen.py \
+     /var/heart_recordio_gen.py
+RUN python /var/heart_recordio_gen.py --data_dir /root/.keras/datasets \
+    --output_dir /data/heart
+
 # Install elasticdl.org/elasticdl Go package
 ENV ELASTICDLPATH /root/elasticdl
 COPY . /elasticdl
@@ -62,27 +80,6 @@ RUN cd /elasticdl && \
 RUN cd /elasticdl && \
     python setup.py -q bdist_wheel && \
     cp dist/elasticdl-develop-py3-none-any.whl /
-
-
-# This assumes that the data generation package is independent with the
-# rest part of ElasticDL.  The generated data will be in /data.
-COPY elasticdl/python/data/recordio_gen/image_label.py /var/image_label.py
-RUN python /var/image_label.py --dataset mnist --fraction 0.15 \
-        --records_per_shard 4096 /data
-
-# Copy frappe dataset
-COPY elasticdl/python/data/recordio_gen/frappe_recordio_gen.py \
-     /var/frappe_recordio_gen.py
-RUN python /var/frappe_recordio_gen.py --data /root/.keras/datasets \
-    --output_dir /data/frappe \
-    --fraction 0.05
-# Copy heart dataset
-COPY elasticdl/python/data/recordio_gen/heart_recordio_gen.py \
-     /var/heart_recordio_gen.py
-RUN python /var/heart_recordio_gen.py --data_dir /root/.keras/datasets \
-    --output_dir /data/heart
-
-RUN rm -rf /root/.keras/datasets
 
 
 # Stage 2: ci
@@ -114,3 +111,7 @@ COPY --from=dev /elasticdl-develop-py3-none-any.whl /
 RUN python -m pip -q install /elasticdl-develop-py3-none-any.whl \
         --extra-index-url=${EXTRA_PYPI_INDEX} \
     && rm /elasticdl-develop-py3-none-any.whl
+
+# Generate mnist checkpoint for evaluation and prediction
+COPY --from=dev /elasticdl/scripts/gen_mnist_checkpoint.py /gen_mnist_checkpoint.py
+RUN python /gen_mnist_checkpoint.py --checkpoint_dir=/model_zoo/test_data/mnist_ckpt

--- a/elasticdl/docker/Dockerfile
+++ b/elasticdl/docker/Dockerfile
@@ -98,6 +98,8 @@ COPY --from=dev /data /data
 
 # Copy model zoo
 COPY model_zoo /model_zoo
+RUN python -m pip -q install -r /model_zoo/requirements.txt \
+        --extra-index-url=${EXTRA_PYPI_INDEX}
 
 # Copy GO PS
 ARG GO_PS=/root/go/bin/start_ps

--- a/elasticdl/docker/Dockerfile.dev_allreduce
+++ b/elasticdl/docker/Dockerfile.dev_allreduce
@@ -1,4 +1,4 @@
-FROM elasticdl:ci
+FROM elasticdl:dev
 
 WORKDIR /root/
 RUN git clone --depth=1 https://github.com/caicloud/ftlib.git

--- a/elasticdl/docker/build_all.sh
+++ b/elasticdl/docker/build_all.sh
@@ -18,13 +18,14 @@ TF_VERSION=2.1.0
 
 if [[ ! -d .git ]]; then
     echo "We must run this script at the root of the source tree."
+    exit 1
 fi
 
 if [[ $# -eq 1 && $1 == "-gpu" ]]; then
     base_image="tensorflow/tensorflow:${TF_VERSION}-gpu-py3"
     echo "To support CUDA; all images are from " $base_image
-    dev_image="elasticdl:gpudev"
-    ci_image="elasticdl:gpuci"
+    dev_image="elasticdl:dev-gpu"
+    ci_image="elasticdl:ci-gpu"
 
 else
     base_image="tensorflow/tensorflow:${TF_VERSION}-py3"

--- a/elasticdl/docker/build_all.sh
+++ b/elasticdl/docker/build_all.sh
@@ -1,27 +1,36 @@
 #!/bin/bash
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 
 TF_VERSION=2.1.0
 
 if [[ ! -d .git ]]; then
     echo "We must run this script at the root of the source tree."
-    exit -1
 fi
 
 if [[ $# -eq 1 && $1 == "-gpu" ]]; then
     base_image="tensorflow/tensorflow:${TF_VERSION}-gpu-py3"
     echo "To support CUDA; all images are from " $base_image
-    image="elasticdl:gpu"
     dev_image="elasticdl:gpudev"
     ci_image="elasticdl:gpuci"
 
 else
     base_image="tensorflow/tensorflow:${TF_VERSION}-py3"
-    image="elasticdl"
     dev_image="elasticdl:dev"
     ci_image="elasticdl:ci"
 fi
-
-docker build --target release -t $image -f elasticdl/docker/Dockerfile --build-arg BASE_IMAGE=$base_image .
 
 docker build --target dev -t $dev_image -f elasticdl/docker/Dockerfile --build-arg BASE_IMAGE=$base_image .
 

--- a/elasticdl/python/common/save_utils.py
+++ b/elasticdl/python/common/save_utils.py
@@ -1,3 +1,16 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import contextlib
 import os
 import shutil
@@ -59,6 +72,16 @@ def _get_params_shard_from_pb(model_pb, shard_index, shard_num):
                 embedding_table_values[name][0].append(embedding_id)
                 embedding_table_values[name][1].append(vector)
     return non_embedding_vars, embedding_table_values
+
+
+def save_checkpoint_without_embedding(model, checkpoint_dir, version=100):
+    checkpoint_saver = CheckpointSaver(checkpoint_dir, 0, 0, False)
+    params = Parameters()
+    for var in model.trainable_variables:
+        params.non_embedding_params[var.name] = var
+    params.version = version
+    model_pb = params.to_model_pb()
+    checkpoint_saver.save(version, model_pb, False)
 
 
 class Checkpoint(object):

--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -434,8 +434,7 @@ class Master(object):
                 ps_args.insert(0, ps_client_command)
             else:
                 ps_client_command = (
-                    BashCommandTemplate.SET_PIPEFAIL
-                    + " python -m elasticdl.python.ps.main"
+                    BashCommandTemplate.SET_PIPEFAIL + " elasticdl train"
                 )
                 ps_args = [
                     "--grads_to_wait",

--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -434,7 +434,8 @@ class Master(object):
                 ps_args.insert(0, ps_client_command)
             else:
                 ps_client_command = (
-                    BashCommandTemplate.SET_PIPEFAIL + " elasticdl train"
+                    BashCommandTemplate.SET_PIPEFAIL
+                    + " python -m elasticdl.python.ps.main"
                 )
                 ps_args = [
                     "--grads_to_wait",

--- a/elasticdl/python/tests/callbacks_test.py
+++ b/elasticdl/python/tests/callbacks_test.py
@@ -1,3 +1,16 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import tempfile
 import unittest
@@ -9,13 +22,15 @@ import tensorflow as tf
 from elasticdl.proto import elasticdl_pb2
 from elasticdl.python.common.constants import DistributionStrategy, JobType
 from elasticdl.python.common.model_handler import ModelHandler
+from elasticdl.python.common.save_utils import (
+    save_checkpoint_without_embedding,
+)
 from elasticdl.python.elasticdl.callbacks import (
     LearningRateScheduler,
     MaxStepsStopping,
     SavedModelExporter,
 )
 from elasticdl.python.master.task_dispatcher import _Task
-from elasticdl.python.tests.test_utils import save_checkpoint_without_embedding
 from elasticdl.python.worker.task_data_service import TaskDataService
 
 

--- a/elasticdl/python/tests/test_utils.py
+++ b/elasticdl/python/tests/test_utils.py
@@ -1,3 +1,16 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import csv
 import os
 import tempfile
@@ -23,14 +36,13 @@ from elasticdl.python.common.model_utils import (
     get_module_file_path,
     load_module,
 )
-from elasticdl.python.common.save_utils import CheckpointSaver
 from elasticdl.python.data.recordio_gen.frappe_recordio_gen import (
     load_raw_data,
 )
 from elasticdl.python.master.evaluation_service import EvaluationService
 from elasticdl.python.master.servicer import MasterServicer
 from elasticdl.python.master.task_dispatcher import _TaskDispatcher
-from elasticdl.python.ps.parameter_server import Parameters, ParameterServer
+from elasticdl.python.ps.parameter_server import ParameterServer
 from elasticdl.python.tests.in_process_master import InProcessMaster
 from elasticdl.python.worker.worker import Worker
 
@@ -630,13 +642,3 @@ def get_frappe_dataset(batch_size):
     test_db = tf.data.Dataset.from_tensor_slices((x_test, y_test))
     test_db = test_db.batch(batch_size)
     return db, test_db
-
-
-def save_checkpoint_without_embedding(model, checkpoint_dir, version=100):
-    checkpoint_saver = CheckpointSaver(checkpoint_dir, 0, 0, False)
-    params = Parameters()
-    for var in model.trainable_variables:
-        params.non_embedding_params[var.name] = var
-    params.version = version
-    model_pb = params.to_model_pb()
-    checkpoint_saver.save(version, model_pb, False)

--- a/scripts/client_test.sh
+++ b/scripts/client_test.sh
@@ -18,9 +18,7 @@ JOB_TYPE=$1
 PS_NUM=$2
 WORKER_NUM=$3
 
-# Generate checkpoint for mnist to test evaluation and prediction
-MNIST_CKPT_DIR=model_zoo/test_data/mnist_ckpt/
-python scripts/gen_mnist_checkpoint.py --checkpoint_dir=${MNIST_CKPT_DIR}
+MNIST_CKPT_DIR=/model_zoo/test_data/mnist_ckpt/
 
 
 if [[ "$JOB_TYPE" == "train" ]]; then
@@ -56,7 +54,7 @@ elif [[ "$JOB_TYPE" == "evaluate" ]]; then
       --image_name=elasticdl:ci \
       --model_zoo=model_zoo \
       --model_def=mnist_functional_api.mnist_functional_api.custom_model \
-      --checkpoint_dir_for_init=/${MNIST_CKPT_DIR}/version-100  \
+      --checkpoint_dir_for_init=${MNIST_CKPT_DIR}/version-100  \
       --validation_data=/data/mnist/test \
       --num_epochs=1 \
       --master_resource_request="cpu=0.3,memory=1024Mi" \
@@ -79,7 +77,7 @@ elif [[ "$JOB_TYPE" == "predict" ]]; then
       --image_name=elasticdl:ci \
       --model_zoo=model_zoo \
       --model_def=mnist_functional_api.mnist_functional_api.custom_model \
-      --checkpoint_dir_for_init=/${MNIST_CKPT_DIR}/version-100 \
+      --checkpoint_dir_for_init=${MNIST_CKPT_DIR}/version-100 \
       --prediction_data=/data/mnist/test \
       --master_resource_request="cpu=0.2,memory=1024Mi" \
       --master_resource_limit="cpu=1,memory=2048Mi" \

--- a/scripts/client_test.sh
+++ b/scripts/client_test.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 
 JOB_TYPE=$1
 PS_NUM=$2
@@ -6,12 +20,12 @@ WORKER_NUM=$3
 
 # Generate checkpoint for mnist to test evaluation and prediction
 MNIST_CKPT_DIR=model_zoo/test_data/mnist_ckpt/
-python -m scripts.gen_mnist_checkpoint --checkpoint_dir=${MNIST_CKPT_DIR}
+python scripts/gen_mnist_checkpoint.py --checkpoint_dir=${MNIST_CKPT_DIR}
 
 
 if [[ "$JOB_TYPE" == "train" ]]; then
     elasticdl train \
-      --image_base=elasticdl:ci \
+      --image_name=elasticdl:ci \
       --model_zoo=model_zoo \
       --model_def=deepfm_functional_api.deepfm_functional_api.custom_model \
       --training_data=/data/frappe/train \
@@ -25,8 +39,8 @@ if [[ "$JOB_TYPE" == "train" ]]; then
       --ps_resource_limit="cpu=1,memory=2048Mi" \
       --minibatch_size=64 \
       --num_minibatches_per_task=2 \
-      --num_workers=$WORKER_NUM \
-      --num_ps_pods=$PS_NUM \
+      --num_workers="$WORKER_NUM" \
+      --num_ps_pods="$PS_NUM" \
       --checkpoint_steps=500 \
       --evaluation_steps=500 \
       --tensorboard_log_dir=/tmp/tensorboard-log \
@@ -39,7 +53,7 @@ if [[ "$JOB_TYPE" == "train" ]]; then
       --volume="host_path=${PWD},mount_path=/saved_model"
 elif [[ "$JOB_TYPE" == "evaluate" ]]; then
     elasticdl evaluate \
-      --image_base=elasticdl:ci \
+      --image_name=elasticdl:ci \
       --model_zoo=model_zoo \
       --model_def=mnist_functional_api.mnist_functional_api.custom_model \
       --checkpoint_dir_for_init=/${MNIST_CKPT_DIR}/version-100  \
@@ -53,8 +67,8 @@ elif [[ "$JOB_TYPE" == "evaluate" ]]; then
       --ps_resource_limit="cpu=1,memory=2048Mi" \
       --minibatch_size=64 \
       --num_minibatches_per_task=2 \
-      --num_workers=$WORKER_NUM \
-      --num_ps_pods=$PS_NUM \
+      --num_workers="$WORKER_NUM" \
+      --num_ps_pods="$PS_NUM" \
       --evaluation_steps=15 \
       --tensorboard_log_dir=/tmp/tensorboard-log \
       --job_name=test-evaluate \
@@ -62,7 +76,7 @@ elif [[ "$JOB_TYPE" == "evaluate" ]]; then
       --image_pull_policy=Never
 elif [[ "$JOB_TYPE" == "predict" ]]; then
     elasticdl predict \
-      --image_base=elasticdl:ci \
+      --image_name=elasticdl:ci \
       --model_zoo=model_zoo \
       --model_def=mnist_functional_api.mnist_functional_api.custom_model \
       --checkpoint_dir_for_init=/${MNIST_CKPT_DIR}/version-100 \
@@ -75,8 +89,8 @@ elif [[ "$JOB_TYPE" == "predict" ]]; then
       --ps_resource_limit="cpu=1,memory=2048Mi" \
       --minibatch_size=64 \
       --num_minibatches_per_task=2 \
-      --num_workers=$WORKER_NUM \
-      --num_ps_pods=$PS_NUM \
+      --num_workers="$WORKER_NUM" \
+      --num_ps_pods="$PS_NUM" \
       --job_name=test-predict \
       --log_level=INFO \
       --image_pull_policy=Never
@@ -95,10 +109,10 @@ elif [[ "$JOB_TYPE" == "local" ]]; then
       --distribution_strategy=Local 
 elif [[ "$JOB_TYPE" == "odps" ]]; then
     elasticdl train \
-      --image_base=elasticdl:ci \
+      --image_name=elasticdl:ci \
       --model_zoo=model_zoo \
       --model_def=odps_iris_dnn_model.odps_iris_dnn_model.custom_model \
-      --training_data=$MAXCOMPUTE_TABLE \
+      --training_data="$MAXCOMPUTE_TABLE" \
       --data_reader_params='columns=["sepal_length", "sepal_width", "petal_length", "petal_width", "class"]; label_col="class"' \
       --envs="MAXCOMPUTE_PROJECT=$MAXCOMPUTE_PROJECT,MAXCOMPUTE_AK=$MAXCOMPUTE_AK,MAXCOMPUTE_SK=$MAXCOMPUTE_SK,MAXCOMPUTE_ENDPOINT=" \
       --num_epochs=2 \
@@ -110,8 +124,8 @@ elif [[ "$JOB_TYPE" == "odps" ]]; then
       --ps_resource_limit="cpu=1,memory=2048Mi" \
       --minibatch_size=64 \
       --num_minibatches_per_task=2 \
-      --num_workers=$WORKER_NUM \
-      --num_ps_pods=$PS_NUM \
+      --num_workers="$WORKER_NUM" \
+      --num_ps_pods="$PS_NUM" \
       --checkpoint_steps=10 \
       --grads_to_wait=2 \
       --job_name=test-odps \

--- a/scripts/gen_mnist_checkpoint.py
+++ b/scripts/gen_mnist_checkpoint.py
@@ -1,8 +1,23 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 
 import tensorflow as tf
 
-from elasticdl.python.tests.test_utils import save_checkpoint_without_embedding
+from elasticdl.python.common.save_utils import (
+    save_checkpoint_without_embedding,
+)
 
 
 def mnist_custom_model():


### PR DESCRIPTION
We need to make running integration test in Travis is the same as running in local.

We need a Dockerfile like this:

```
FROM tensorflow
RUN pip install elasticdl 
COPY model_zoo /model_zoo
```

This PR will do the first step, we make a Dockerfile for ci like following:

```
FROM tensorflow

COPY --from=dev /elasticdl-develop-py3-none-any.whl /
RUN python -m pip -q install /elasticdl-develop-py3-none-any.whl \
        --extra-index-url=${EXTRA_PYPI_INDEX} \
    && rm /elasticdl-develop-py3-none-any.whl

// to be simplified in the next step
COPY --from=dev ${GO_PS} /usr/local/go/bin

COPY model_zoo /model_zoo

// to be simplified in the next step
COPY --from=dev /data /data
```

So, in the integration test, we could directly pass "elasticdl:ci" to `image_name`  to launch a training job.