### PR TITLE
WIP Reduce stages in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: minimal
 
-dist: bionic
+dist: focal
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ jobs:
     - stage: tests
       script:
         - set -e
-        - apt-get update -y
-        - apt install --only-upgrade docker-ce -y
+        - sudo apt-get update -y
+        - sudo apt-get install --only-upgrade docker-ce -y
         - export DOCKER_BUILDKIT=1
         - bash elasticdl/docker/build_all.sh
         # Run pre-commit checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: minimal
 
-dist: focal
+dist: bionic
 
 addons:
   apt:
     packages:
-      - docker-ce
       - python3-pip
       - python3-setuptools
       - clang-format
@@ -27,8 +26,7 @@ jobs:
     - stage: tests
       script:
         - set -e
-        - sudo apt-get update -y
-        - sudo apt-get install --only-upgrade docker-ce -y
+        - bash scripts/travis/install-docker.sh
         - export DOCKER_BUILDKIT=1
         - bash elasticdl/docker/build_all.sh
         # Run pre-commit checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: minimal
 
-dist: xenial
+dist: bionic
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ addons:
       - clang-format
 
 install:
+  # Install the most recent version of Docker to use DOCKER_BUILDKIT.
+  - bash scripts/travis/install-docker.sh
   - docker version
 
 stages:
@@ -26,8 +28,6 @@ jobs:
     - stage: tests
       script:
         - set -e
-        # Install the most recent version of Docker to use DOCKER_BUILDKIT.
-        - bash scripts/travis/install-docker.sh
         - export DOCKER_BUILDKIT=1
         - bash elasticdl/docker/build_all.sh
         # Run pre-commit checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,23 +24,18 @@ cache:
 
 jobs:
   include:
-    - stage: precommit
-      name: "Pre-commit Check"
+    - stage: tests
       script:
         - set -e
+        - apt-get update -y
+        - apt install --only-upgrade docker-ce -y
         - export DOCKER_BUILDKIT=1
-        - docker build --target dev -t elasticdl:dev -f
-          elasticdl/docker/Dockerfile .
+        - bash elasticdl/docker/build_all.sh
+        # Run pre-commit checks
         - docker run --rm -it -v $PWD:/work -w /work
           elasticdl:dev /work/scripts/pre-commit.sh
-    - stage: tests
-      name: "Tests"
-      script:
-        - set -e
-        - export DOCKER_BUILDKIT=1
         # Set up Kubernetes environment
         - bash scripts/setup_k8s_env.sh
-        - bash elasticdl/docker/build_all.sh
         # Create shared folder to store coverage report
         - mkdir shared
         # Run unit tests not related to ODPS
@@ -56,7 +51,7 @@ jobs:
         # Run unit tests related to ODPS (skipped for pull requests from forks)
         - |
           if [ "$ODPS_ACCESS_ID" == "" ] || [ "$ODPS_ACCESS_KEY" == "" ]; then
-            echo "Skipping ODPS related unit tests since either ODPS_ACCESS_ID " \
+            echo "Skip ODPS related unit tests since either ODPS_ACCESS_ID " \
             "or ODPS_ACCESS_KEY is not set"
           else
             docker run --rm -it \

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ jobs:
     - stage: tests
       script:
         - set -e
+        # Install the most recent version of Docker to use DOCKER_BUILDKIT.
         - bash scripts/travis/install-docker.sh
         - export DOCKER_BUILDKIT=1
         - bash elasticdl/docker/build_all.sh

--- a/elasticdl/docker/Dockerfile
+++ b/elasticdl/docker/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_IMAGE=tensorflow/tensorflow:2.1.0-py3
-# Use tensorflow/tensorflow:2.1.0-gpu-py3 if you want GPU-support.
+ARG BASE_IMAGE=tensorflow/tensorflow:2.1.1
+# Use tensorflow/tensorflow:2.1.1-gpu if you want GPU-support.
 
 # Multi-stage is used for dev/ci/release images
 # Better to build in DOCKER_BUILDKIT by setting env: DOCKER_BUILDKIT=1

--- a/elasticdl/docker/build_all.sh
+++ b/elasticdl/docker/build_all.sh
@@ -12,29 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-TF_VERSION=2.1.0
-
-if [[ ! -d .git ]]; then
-    echo "We must run this script at the root of the source tree."
-    exit 1
-fi
-
-if [[ $# -eq 1 && $1 == "-gpu" ]]; then
-    base_image="tensorflow/tensorflow:${TF_VERSION}-gpu-py3"
-    echo "To support CUDA; all images are from " $base_image
-    dev_image="elasticdl:dev-gpu"
-    ci_image="elasticdl:ci-gpu"
-
-else
-    base_image="tensorflow/tensorflow:${TF_VERSION}-py3"
-    dev_image="elasticdl:dev"
-    ci_image="elasticdl:ci"
-fi
-
-docker build --target dev -t $dev_image -f elasticdl/docker/Dockerfile --build-arg BASE_IMAGE=$base_image .
-
-docker build --target ci -t $ci_image -f elasticdl/docker/Dockerfile --build-arg BASE_IMAGE=$base_image .
-
+docker build --target dev -t elasticdl:dev -f elasticdl/docker/Dockerfile .
+docker build --target ci -t elasticdl:ci -f elasticdl/docker/Dockerfile .
 docker build -t elasticdl:dev_allreduce -f elasticdl/docker/Dockerfile.dev_allreduce .

--- a/scripts/travis/install-docker.sh
+++ b/scripts/travis/install-docker.sh
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
-# This file comes from https://docs.docker.com/engine/install/ubuntu/.
-sudo apt-get remove docker docker-engine docker.io containerd runc
-
 # Update the apt package index and install packages to allow apt to use a
 # repository over HTTPS.
 sudo apt-get -qq update
@@ -41,6 +36,7 @@ sudo apt-get -qq update
 sudo apt-get -qq install -y docker-ce docker-ce-cli containerd.io > /dev/null
 
 # Enable docker without sudo.
+sudo groupadd docker
 sudo usermod -aG docker "$USER"
 
 # Activate the changes to groups.

--- a/scripts/travis/install-docker.sh
+++ b/scripts/travis/install-docker.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright 2020 The ElasticDL Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+# This file comes from https://docs.docker.com/engine/install/ubuntu/.
+sudo apt-get remove docker docker-engine docker.io containerd runc
+
+# Update the apt package index and install packages to allow apt to use a
+# repository over HTTPS.
+sudo apt-get -qq update
+sudo apt-get -qq install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common > /dev/null
+
+# Add Docker’s official GPG key.
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+# Set up the stable repository.
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+
+# Install the Docker engine
+sudo apt-get -qq update
+sudo apt-get -qq install -y docker-ce docker-ce-cli containerd.io > /dev/null
+
+# Enable docker without sudo.
+sudo groupadd docker
+sudo usermod -aG docker "$USER"
+
+# Activate the changes to groups.
+newgrp docker

--- a/scripts/travis/install-docker.sh
+++ b/scripts/travis/install-docker.sh
@@ -36,8 +36,4 @@ sudo apt-get -qq update
 sudo apt-get -qq install -y docker-ce docker-ce-cli containerd.io # > /dev/null
 
 # Enable docker without sudo.
-# sudo groupadd docker
 sudo usermod -aG docker "$USER"
-
-# Activate the changes to groups.
-# newgrp docker

--- a/scripts/travis/install-docker.sh
+++ b/scripts/travis/install-docker.sh
@@ -41,7 +41,6 @@ sudo apt-get -qq update
 sudo apt-get -qq install -y docker-ce docker-ce-cli containerd.io > /dev/null
 
 # Enable docker without sudo.
-sudo groupadd docker
 sudo usermod -aG docker "$USER"
 
 # Activate the changes to groups.

--- a/scripts/travis/install-docker.sh
+++ b/scripts/travis/install-docker.sh
@@ -20,7 +20,7 @@ sudo apt-get -qq install -y \
     ca-certificates \
     curl \
     gnupg-agent \
-    software-properties-common > /dev/null
+    software-properties-common # > /dev/null
 
 # Add Docker’s official GPG key.
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
@@ -33,9 +33,10 @@ sudo add-apt-repository \
 
 # Install the Docker engine
 sudo apt-get -qq update
-sudo apt-get -qq install -y docker-ce docker-ce-cli containerd.io > /dev/null
+sudo apt-get -qq install -y docker-ce docker-ce-cli containerd.io # > /dev/null
 
 # Enable docker without sudo.
+sudo groupadd docker
 sudo usermod -aG docker "$USER"
 
 # Activate the changes to groups.

--- a/scripts/travis/install-docker.sh
+++ b/scripts/travis/install-docker.sh
@@ -36,8 +36,8 @@ sudo apt-get -qq update
 sudo apt-get -qq install -y docker-ce docker-ce-cli containerd.io # > /dev/null
 
 # Enable docker without sudo.
-sudo groupadd docker
+# sudo groupadd docker
 sudo usermod -aG docker "$USER"
 
 # Activate the changes to groups.
-newgrp docker
+# newgrp docker

--- a/scripts/travis/install-docker.sh
+++ b/scripts/travis/install-docker.sh
@@ -36,7 +36,6 @@ sudo apt-get -qq update
 sudo apt-get -qq install -y docker-ce docker-ce-cli containerd.io > /dev/null
 
 # Enable docker without sudo.
-sudo groupadd docker
 sudo usermod -aG docker "$USER"
 
 # Activate the changes to groups.


### PR DESCRIPTION
Since each of the two stages has only one job, and each job builds the Docker image, I am trying to merge them into one job.

Also, following https://ops.tips/blog/update-travis-ci-docker/, I am trying to upgrade Docker in Travis VMs so we can enable `DOCKER_BUILDKIT`.