### PR TITLE
Merge two Travis CI stages into one job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,21 +24,17 @@ cache:
 
 jobs:
   include:
-    - stage: precommit
-      name: "Pre-commit Check"
+    - stage: test
+      name: "Pre-commit and Tests"
       script:
         - set -e
-        - docker build --target dev -t elasticdl:dev -f
-          elasticdl/docker/Dockerfile .
+        # Build Docker images.
+        - bash elasticdl/docker/build_all.sh
+        # Run pre-commit checks.
         - docker run --rm -it -v $PWD:/work -w /work
           elasticdl:dev /work/scripts/pre-commit.sh
-    - stage: tests
-      name: "Tests"
-      script:
-        - set -e
         # Set up Kubernetes environment
         - bash scripts/setup_k8s_env.sh
-        - bash elasticdl/docker/build_all.sh
         # Create shared folder to store coverage report
         - mkdir shared
         # Run unit tests not related to ODPS
@@ -54,7 +50,7 @@ jobs:
         # Run unit tests related to ODPS (skipped for pull requests from forks)
         - |
           if [ "$ODPS_ACCESS_ID" == "" ] || [ "$ODPS_ACCESS_KEY" == "" ]; then
-            echo "Skipping ODPS related unit tests since either ODPS_ACCESS_ID " \
+            echo "Skip ODPS related unit tests since either ODPS_ACCESS_ID " \
             "or ODPS_ACCESS_KEY is not set"
           else
             docker run --rm -it \


### PR DESCRIPTION
As we have `set -e` in the job, if the pre-commit checks fail, the CI fails -- no longer need to have two Travis CI stages.