### PR TITLE
Remove the integration test for "local"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,6 @@ jobs:
               train
               evaluate
               predict
-              local
           )
           for JOB_TYPE in "${JOB_TYPES[@]}"; do
               bash scripts/travis/start_elasticdl_job.sh $JOB_TYPE

--- a/scripts/client_test.sh
+++ b/scripts/client_test.sh
@@ -92,19 +92,6 @@ elif [[ "$JOB_TYPE" == "predict" ]]; then
       --job_name=test-predict \
       --log_level=INFO \
       --image_pull_policy=Never
-elif [[ "$JOB_TYPE" == "local" ]]; then
-    elasticdl train \
-      --model_zoo=model_zoo \
-      --model_def=deepfm_functional_api.deepfm_functional_api.custom_model \
-      --training_data=/data/frappe/train \
-      --validation_data=/data/frappe/test \
-      --data_reader_params="reader_type=RecordIO" \
-      --num_epochs=1 \
-      --minibatch_size=64 \
-      --num_minibatches_per_task=2 \
-      --evaluation_steps=500 \
-      --job_name=test-local \
-      --distribution_strategy=Local 
 elif [[ "$JOB_TYPE" == "odps" ]]; then
     elasticdl train \
       --image_name=elasticdl:ci \

--- a/scripts/travis/start_elasticdl_job.sh
+++ b/scripts/travis/start_elasticdl_job.sh
@@ -34,10 +34,8 @@ else
         -w /work elasticdl:ci \
         bash -c "scripts/client_test.sh \
         ${JOB_TYPE} ${PS_NUM} ${WORKER_NUM}"
-    if [[ "$JOB_TYPE" != "local" ]]; then
-        python3 scripts/validate_job_status.py \
+    python3 scripts/validate_job_status.py \
         ${JOB_TYPE} ${PS_NUM} ${WORKER_NUM}
-    fi
     if [[ "$JOB_TYPE" == "odps" ]]; then
         docker run --rm -it \
             -e MAXCOMPUTE_TABLE=$MAXCOMPUTE_TABLE \


### PR DESCRIPTION
We developed "local" to test the training loop using the dataset_fn defined in the model file. But it is not user-friendly because users should execute it using ElasticDL package and an ElasticDL client command. There may be a better solution to do it. If users can use the `dataset_fn` to get a `tf.data.Dataset`, they can use `model.fit(dataset)` to test the training loop like a Kera-native program locally.

I will remove the source codes about local execution in the next PR. Then I will design the proposed solution to get a tf.dataDataset using dataset_fn defined in the model file.