### PR TITLE
Install shellcheck in Dev image.

### DIFF
--- a/elasticdl/docker/Dockerfile
+++ b/elasticdl/docker/Dockerfile
@@ -6,7 +6,7 @@ ARG EXTRA_PYPI_INDEX=https://pypi.org/simple
 
 RUN apt-get -qq update && \
     apt-get -qq install -y unzip curl git software-properties-common g++ wget \
-                       libeigen3-dev > /dev/null && \
+                       shellcheck libeigen3-dev > /dev/null && \
     python -m pip install --quiet --upgrade pip
 
 COPY elasticdl/requirements.txt /requirements.txt


### PR DESCRIPTION
Currently shellcheck binary is missing in elasticdl:dev. It will cause pre-commit run with shellcheck hook fails.