### PR TITLE
fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
     - $HOME/.keras/datasets
     # https://pre-commit.com/#travis-ci-example
     - $HOME/.cache
-    # Cache $hOME/go, which bound mount to /root/go of dev container.
+    # Cache $HOME/go, which bound mount to /root/go of dev container.
     - $HOME/go
 
 
@@ -47,12 +47,12 @@ jobs:
         # Run a minikube cluster
         - bash scripts/travis/start_minikube.sh
         # Run unit tests not related to ODPS
+        # TODO(qijun) cache Go
         - docker run --rm -it --net=host
           -v $HOME/.cache:/root/.cache
           -v $HOME/.keras/datasets:/root/.keras/datasets
           -v $HOME/.kube:/root/.kube
           -v $HOME/.minikube:/home/$USER/.minikube
-          -v $HOME/go:/root/go
           -v $PWD:/work -w /work
           elasticdl:dev bash -c "K8S_TESTS=True scripts/build_and_test.sh"
         # Report code coverage to https://codecov.io

--- a/scripts/travis/run_job.sh
+++ b/scripts/travis/run_job.sh
@@ -1,3 +1,16 @@
+# Copyright 2020 The ElasticDL Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 JOB_TYPE=$1
 
 if [[ "$JOB_TYPE" == "odps" ]] && \
@@ -10,7 +23,7 @@ else
     if [[ "$JOB_TYPE" == "odps" ]]; then
         export MAXCOMPUTE_TABLE="odps_integration_build_"`
             `"${TRAVIS_BUILD_NUMBER}_$(date +%s)"
-        bash /scripts/travis/create_odps_table.sh
+        bash scripts/travis/create_odps_table.sh
     fi
     PS_NUM=2
     WORKER_NUM=1


### PR DESCRIPTION
Fix #2038 

The `elasticdl.proto` imports `tensor.proto` of TensorFlow repo. As a result, when we build our PS Go package, it will pull the TensorFlow Go package. We do not want to import the large TensorFlow Go package.

So, we create a local simple Go package.

```bash
mkdir -p ${GOPATH}/pkg/mod
protoc -I${TF_PATH} ${TF_PATH}/tensorflow/core/framework/tensor.proto --go_out=${GOPATH}/pkg/mod
cd "$GOPATH"/pkg/mod/github.com/tensorflow
go mod init github.com/tensorflow
```

Then, our Go PS package depends on the local simple go module,  We replace the go.mod of elasticdl PS, to avoid pulling the large TensorFlow Go package.

```
go mod edit -replace github.com/tensorflow="${GOPATH}"/pkg/mod/github.com/tensorflow
```

Considering the complexity, we build the Go package inside Docker totally. Cache Go in Travis will be done in the next PR when we find an elegant solution.