### PR TITLE
Move elasticdl_preprocessing folder out of the elasticdl main package in the wheel deployment.

### DIFF
--- a/elasticdl/docker/Dockerfile.ci
+++ b/elasticdl/docker/Dockerfile.ci
@@ -33,6 +33,12 @@ COPY model_zoo /model_zoo
 RUN python -m pip install --quiet -r /model_zoo/requirements.txt \
         --extra-index-url=${EXTRA_PYPI_INDEX}
 
+# Install elasticdl_preprocessing package
+COPY build/elasticdl_preprocessing-develop-py3-none-any.whl /
+RUN python -m pip install --quiet /elasticdl_preprocessing-develop-py3-none-any.whl \
+        --extra-index-url=${EXTRA_PYPI_INDEX} \
+    && rm /elasticdl_preprocessing-develop-py3-none-any.whl
+
 # Install elasticdl package
 COPY build/elasticdl-develop-py3-none-any.whl /
 RUN python -m pip install --quiet /elasticdl-develop-py3-none-any.whl \

--- a/elasticdl/requirements.txt
+++ b/elasticdl/requirements.txt
@@ -6,3 +6,4 @@ Cython
 odps
 tensorflow==2.1.0
 deepctr
+elasticdl_preprocessing

--- a/elasticdl/requirements.txt
+++ b/elasticdl/requirements.txt
@@ -6,4 +6,3 @@ Cython
 odps
 tensorflow==2.1.0
 deepctr
-elasticdl_preprocessing

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -46,4 +46,7 @@ mv coverage.xml ./build
 # Create elasticdl package
 mkdir -p ./elasticdl/go/bin
 cp /tmp/elasticdl_ps ./elasticdl/go/bin/
+rm -rf ./build/lib
 python setup.py --quiet bdist_wheel --dist-dir ./build
+rm -rf ./build/lib
+python setup_preprocessing.py --quiet bdist_wheel --dist-dir ./build

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ from setuptools import find_packages, setup
 
 with open("elasticdl/requirements.txt") as f:
     required_deps = f.read().splitlines()
+required_deps.append("elasticdl_preprocessing")
 
 extras = {}
 with open("elasticdl/requirements-dev.txt") as f:
@@ -33,7 +34,9 @@ setup(
     install_requires=required_deps,
     extras_require=extras,
     python_requires=">=3.5",
-    packages=find_packages(exclude=["*test*"]),
+    packages=find_packages(
+        exclude=["*test*", "elasticdl_preprocessing*", "model_zoo*"]
+    ),
     package_data={
         "": [
             "proto/*.proto",

--- a/setup_preprocessing.py
+++ b/setup_preprocessing.py
@@ -34,6 +34,8 @@ setup(
     install_requires=required_deps,
     extras_require=extras,
     python_requires=">=3.5",
-    packages=find_packages(include=["*elasticdl_preprocessing*"],),
+    packages=find_packages(
+        include=["elasticdl_preprocessing*"], exclude=["*test*"]
+    ),
     package_data={"": ["requirements.txt"]},
 )


### PR DESCRIPTION
Currently we are building two pip packages from elasticdl repo: `elasticdl` and `elasticdl_preprocessing`. While we pip install elasticdl, it also extracts an `elasticdl_preprocessing` folder. It will overwrite the files from `elasticdl_preprocessing` package.

In order to fix this, we don't include `elasticdl_preprocessing` folder in elasticdl package.