### PR TITLE
pre-commit run -a isort

### DIFF
--- a/elasticdl/__init__.py
+++ b/elasticdl/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl/proto/__init__.py
+++ b/elasticdl/proto/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl/python/__init__.py
+++ b/elasticdl/python/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl/python/collective_ops/__init__.py
+++ b/elasticdl/python/collective_ops/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl/python/common/__init__.py
+++ b/elasticdl/python/common/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl/python/data/__init__.py
+++ b/elasticdl/python/data/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl/python/data/reader/__init__.py
+++ b/elasticdl/python/data/reader/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl/python/data/recordio_gen/__init__.py
+++ b/elasticdl/python/data/recordio_gen/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl/python/elasticdl/feature_column/__init__.py
+++ b/elasticdl/python/elasticdl/feature_column/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl/python/elasticdl/layers/__init__.py
+++ b/elasticdl/python/elasticdl/layers/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl/python/master/__init__.py
+++ b/elasticdl/python/master/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl/python/ps/__init__.py
+++ b/elasticdl/python/ps/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl/python/tests/__init__.py
+++ b/elasticdl/python/tests/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl/python/worker/__init__.py
+++ b/elasticdl/python/worker/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl_preprocessing/__init__.py
+++ b/elasticdl_preprocessing/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl_preprocessing/feature_column/__init__.py
+++ b/elasticdl_preprocessing/feature_column/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl_preprocessing/tests/__init__.py
+++ b/elasticdl_preprocessing/tests/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/elasticdl_preprocessing/utils/__init__.py
+++ b/elasticdl_preprocessing/utils/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/model_zoo/__init__.py
+++ b/model_zoo/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/model_zoo/census_model_sqlflow/__init__.py
+++ b/model_zoo/census_model_sqlflow/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/model_zoo/census_model_sqlflow/dnn/__init__.py
+++ b/model_zoo/census_model_sqlflow/dnn/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/model_zoo/census_model_sqlflow/wide_and_deep/__init__.py
+++ b/model_zoo/census_model_sqlflow/wide_and_deep/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/model_zoo/cifar10_functional_api/__init__.py
+++ b/model_zoo/cifar10_functional_api/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/model_zoo/cifar10_subclass/__init__.py
+++ b/model_zoo/cifar10_subclass/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/model_zoo/dac_ctr/__init__.py
+++ b/model_zoo/dac_ctr/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/model_zoo/imagenet_resnet50/__init__.py
+++ b/model_zoo/imagenet_resnet50/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/model_zoo/mnist_functional_api/__init__.py
+++ b/model_zoo/mnist_functional_api/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/model_zoo/mnist_subclass/__init__.py
+++ b/model_zoo/mnist_subclass/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/model_zoo/odps_iris_dnn_model/__init__.py
+++ b/model_zoo/odps_iris_dnn_model/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/model_zoo/resnet50_subclass/__init__.py
+++ b/model_zoo/resnet50_subclass/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-


### PR DESCRIPTION
I ran `pre-commit run -a isort` to fix problems related with the `isort` hook.

This is part of the work to fix all pre-commit errors of the codebase.