### PR TITLE
Reformat docs/tutorials/get_started.md

### DIFF
--- a/docs/tutorials/get_started.md
+++ b/docs/tutorials/get_started.md
@@ -1,10 +1,12 @@
 # Getting Started with ElasticDL
 
-The tutorials in this document aims to help users get hands on quickly and have a preliminary understanding of ElasticDL.
+The tutorials in this document aims to help users get hands on quickly and have
+a preliminary understanding of ElasticDL.
 
 ## Run ElasticDL on Various Environments
 
-The following tutorials demonstrates how to run ElasticDL on different environments: 
+The following tutorials demonstrates how to run ElasticDL on different
+environments:
 
 1. Local Environment
 2. On-prem cluster
@@ -12,27 +14,31 @@ The following tutorials demonstrates how to run ElasticDL on different environme
 
 ### ElasticDL on Local Environment
 
-[Minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/) is a tool that makes it easy to run Kubernetes locally.
-It runs a single-node Kubernetes cluster inside a Virtual Machine (VM) on the laptop so developers can try out Kubernetes or develop with it day-to-day.
+[Minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/) is a
+tool that makes it easy to run Kubernetes locally.  It runs a single-node
+Kubernetes cluster inside a Virtual Machine (VM) on the laptop so developers can
+try out Kubernetes or develop with it day-to-day.
 
-[This tutorial](elasticdl_local.md) uses Minikube to run ElasticDL on a local laptop.
-
+[This tutorial](elasticdl_local.md) uses Minikube to run ElasticDL on a local
+laptop.
 
 ### ElasticDL on On-prem Cluster
 
-[This tutorial](elasticdl_on_prem_cluster.md) demonstrates how to run ElasticDL on an on-prem cluster.
-
+[This tutorial](elasticdl_on_prem_cluster.md) demonstrates how to run ElasticDL
+on an on-prem cluster.
 
 ### ElasticDL on Public Cloud
 
-[This tutorial](elasticdl_cloud.md) shows how to run ElasticDL on a public cloud, namely, Google Kubernetes Engine (GKE).
+[This tutorial](elasticdl_cloud.md) shows how to run ElasticDL on a public
+cloud, namely, Google Kubernetes Engine (GKE).
 
 ## Model Building
 
-We have also provided [this tutorial](model_building.md) to illustrate how to define necessary components that will be
-used for ElasticDL model training, evaluation, and prediction. 
+We have also provided [this tutorial](model_building.md) to illustrate how to
+define necessary components that will be used for ElasticDL model training,
+evaluation, and prediction.
 
 ## Data Preparation
 
-[This tutorial](data_preparation.md) demonstrates how to prepare datasets into the right format that can be
-used by ElasticDL. 
+[This tutorial](data_preparation.md) demonstrates how to prepare datasets into
+the right format that can be used by ElasticDL.


### PR DESCRIPTION
This PR makes the file compliant to the markdownlint pre-commit hook.

Most warnings about this file is about line-length over 80 characters. My solution is based on Emacs. I add the following line to my configuration file

```
(setq-default fill-column 80)
```

and for each line that is over 80 characters, I typed `M-q`.