### PR TITLE
Reformat docs/blogs/*.md

### DIFF
--- a/docs/blogs/antfin_ata_modeling.md
+++ b/docs/blogs/antfin_ata_modeling.md
@@ -18,7 +18,8 @@
 实现特征预处理，本文介绍结构化数据特征预处理方案。
 - 开发了 Parameter Server 的分布式训练框架，支持在 Kubernetes 上对 worker
 进行弹性调度。在资源不足的情况下，能快速开始训练任务，缩短模型迭代等待时间。
-详细见 [ElasticDL：同时提升研发效率和机群利用率](./elasticdl-antfin-introduction.md)
+详细见
+[ElasticDL：同时提升研发效率和机群利用率](./elasticdl-antfin-introduction.md)
 
 ## 深度学习中结构化数据的特征预处理
 
@@ -26,11 +27,11 @@
 式，常见的特征变换方式有：
 
 - 对数值型特征进行[标准化](https://en.wikipedia.org/wiki/Feature_scaling#Standardization_(Z-score_Normalization))
-变换。
-- 对数值型特征进行[分桶](https://en.wikipedia.org/wiki/Data_binning)变换，
-输出特征值所在分桶的整数序号。
-- 对字符型特征进行[哈希](https://en.wikipedia.org/wiki/Hash_function)
-分桶变换，即对字符串进行哈希后对桶数取模，映射成整数输出。
+  变换。
+- 对数值型特征进行[分桶](https://en.wikipedia.org/wiki/Data_binning)变换，输出特
+  征值所在分桶的整数序号。
+- 对字符型特征进行[哈希](https://en.wikipedia.org/wiki/Hash_function)分桶变换，
+  即对字符串进行哈希后对桶数取模，映射成整数输出。
 - 对字符型特征进行查词表变换，输出词在词表中的整数序号。
 
 然而在特征变换之前，需要对数据集进行统计分析，得到特征的全局统计量。利用全
@@ -86,7 +87,8 @@ ElasticDL 支持分布式训练 Keras 模型，为了方便用户将特征预处
 | IndexLookup | 将字符串通过查词表转成整数，输出词所在词表的索引 | 特征值集合(词表) |
 
 特征变换 layer 的使用教程请查看
-[Preprocess Inputs using ElasticDL Preprocessing Layers](https://github.com/sql-machine-learning/elasticdl/blob/develop/docs/tutorials/preprocessing_tutorial.md)
+[Preprocess Inputs using ElasticDL Preprocessing
+Layers](https://github.com/sql-machine-learning/elasticdl/blob/develop/docs/tutorials/preprocessing_tutorial.md)
 
 ### Keras 模型训练定义
 
@@ -104,7 +106,6 @@ def custom_model():
     outputs = tf.keras.layers.Dense(3, name="output")(x)
     return tf.keras.Model(inputs=inputs, outputs=outputs, name="simple-model")
 
-
 def loss(labels, predictions):
     return tf.reduce_mean(
         tf.nn.sparse_softmax_cross_entropy_with_logits(
@@ -112,10 +113,8 @@ def loss(labels, predictions):
         )
     )
 
-
 def optimizer(lr=0.1):
     return tf.optimizers.SGD(lr)
-
 
 def eval_metrics_fn():
     return {
@@ -124,7 +123,6 @@ def eval_metrics_fn():
             tf.cast(tf.reshape(labels, [-1]), tf.int32),
         )
     }
-
 
 def dataset_fn(dataset, mode, metadata):
     def _parse_data(record):
@@ -136,22 +134,28 @@ def dataset_fn(dataset, mode, metadata):
     return dataset
 ```
 
-模型定义完成后，在ElasticDL提供的基础镜像中，放入模型文件生成新的镜像，即可在 PAI 平台上提交分布式训练。
+模型定义完成后，在ElasticDL提供的基础镜像中，放入模型文件生成新的镜像，即可在
+PAI 平台上提交分布式训练。
 
 ## PAI 平台上集成特征预处理的 DeepCTR 算法
 
-为了让用户能快速将 ElasticDL 应用到真实业务场景，ElasticDL 在 [PAI](https://pai.alipay.com)
+为了让用户能快速将 ElasticDL 应用到真实业务场景，ElasticDL 在
+[PAI](https://pai.alipay.com)
 平台上提供了 ElasticDL-DeepCTR 组件，如下图所示:
 
 ![PAI ElasticDL DeepCTR](../images/pai_gui/pai_elasticdl_deepctr.jpg)
 
 该算法组件有如下特点：
 
-- 根据用户配置的特征来自动生成特征预处理逻辑，并与深度学习 CTR 算法相结合，组成完整的模型。
-- 提供了常用的 CTR 预估算法，包括 Wide & Deep, DeepFM, Deep Cross Network 和 xDeepFM。
-- 分布式策略采用 ParameterServer，可以根据数据量来配置 worker 的数量来加速模型训练。
+- 根据用户配置的特征来自动生成特征预处理逻辑，并与深度学习 CTR
+算法相结合，组成完整的模型。
+- 提供了常用的 CTR 预估算法，包括 Wide & Deep, DeepFM, Deep Cross Network 和
+xDeepFM。
+- 分布式策略采用 ParameterServer，可以根据数据量来配置 worker
+的数量来加速模型训练。
 
-为了验证模型性能，我们选用了 [Kaggle Display Advertising Challenge](https://www.kaggle.com/c/criteo-display-ad-challenge)
+为了验证模型性能，我们选用了 [Kaggle Display Advertising
+Challenge](https://www.kaggle.com/c/criteo-display-ad-challenge)
 的数据集,来测试模型性能。将组件的标准化特征列和分箱特征列都配置成 I0-I13，
 哈希特征列配置成 C0-C13，最终使用 xDeepFM 模型的 logloss 为
 0.45634 (Kaggle best logloss: 0.44463)。通过很简单的配置，

--- a/docs/blogs/elasticdl-antfin-introduction.md
+++ b/docs/blogs/elasticdl-antfin-introduction.md
@@ -1,57 +1,81 @@
 # ElasticDL: Kubernetes-native 弹性分布式深度学习系统
 
-[ElasticDL](https://github.com/sql-machine-learning/elasticdl) 是基于 Kubernetes 和 TensorFlow 2.x eager execution
+[ElasticDL](https://github.com/sql-machine-learning/elasticdl) 是基于
+Kubernetes 和 TensorFlow 2.x eager execution
 的支持容错和弹性调度的分布式深度学习系统。ElasticDL 具有如下特点：
 
 - 弹性调度。在训练过程中可以动态伸缩 worker 数量，并保持训练过程不被中断停止。
 - 高性能的 parameter server。ElasticDL 用 Go 实现了 Parameter Server，
-具有良好的吞吐能力和可扩展性，同时优化了 embedding table 的梯度更新策略，减少通信开销，加速模型迭代。
+具有良好的吞吐能力和可扩展性，同时优化了 embedding table
+的梯度更新策略，减少通信开销，加速模型迭代。
 - TensorFlow 2.x Keras API 定义模型。keras API 具有很高的易用性和灵活性，
 学习成本低，同时开源社区基于 Keras 开发了很多经典模型和 layer，便于复用。
 
 ## 弹性调度
 
-在很多人共用计算集群的情况下，支持弹性调度意味着极大提升团队效率和集群的总体利用率。前者支持快速迭代以保持技术领先；后者决定企业成本和云计算业务的盈利能力。
+在很多人共用计算集群的情况下，支持弹性调度意味着极大提升团队效率和集群的总体利用
+率。前者支持快速迭代以保持技术领先；后者决定企业成本和云计算业务的盈利能力。
 
-一个展示弹性调度效果的例子如下。假设一个集群里有 N 个 GPU，一个作业包 括一个进程，占用了 N/2 个 GPU。
-第二个作业需要 N/2+1 个 GPU；但是此时机 群里空闲 GPU 只有 N/2 个。如果没有弹性调度能力，那么第二个作业被迫等待， 直到第一个作业结束释放资源。
-这个等待时间很可能和第二个作业的运行时间同 量级。此时，集群的利用率很低，是 50%。
-如果有弹性调度，那么第二个作业可 以马上启动，用 N/2 个 GPU 做计算。日后如果有更多空闲资源了，调度系统可 以增加其进程数量，充分利用资源。
+一个展示弹性调度效果的例子如下。假设一个集群里有 N 个 GPU，一个作业包
+括一个进程，占用了 N/2 个 GPU。
+第二个作业需要 N/2+1 个 GPU；但是此时机 群里空闲 GPU 只有 N/2
+个。如果没有弹性调度能力，那么第二个作业被迫等待， 直到第一个作业结束释放资源。
+这个等待时间很可能和第二个作业的运行时间同 量级。此时，集群的利用率很低，是
+50%。
+如果有弹性调度，那么第二个作业可 以马上启动，用 N/2 个 GPU
+做计算。日后如果有更多空闲资源了，调度系统可 以增加其进程数量，充分利用资源。
 
-另一个例子是，假设有一个作业已经在执行了，此时一个新的更高优先级的作业需要资源，所以调度系统杀掉了（preempt）了第一个作业的几个进程来腾出资 源启动第二个作业。
-如果没有弹性调度和容错，那么第一个作业会失败，所有进程都结束。直到有足够资源重启它，并且沿着最近的 checkpoint 继续。
-如果有弹性调度，则第一个作业的剩下的进程可以继续执行，只是因为可用的进程 (GPU）少了，所以速度慢一些而已。
+另一个例子是，假设有一个作业已经在执行了，此时一个新的更高优先级的作业需要资源，
+所以调度系统杀掉了（preempt）了第一个作业的几个进程来腾出资 源启动第二个作业。
+如果没有弹性调度和容错，那么第一个作业会失败，所有进程都结束。直到有足够资源重启
+它，并且沿着最近的 checkpoint 继续。
+如果有弹性调度，则第一个作业的剩下的进程可以继续执行，只是因为可用的进程
+(GPU）少了，所以速度慢一些而已。
 
 以上两个例子都展示了弹性调度对集群利用率的提升，以及对团队工作效率的保障。
 
 ### 弹性调度和刚性调度
 
-- 刚性调度[（gang scheduling）](https://en.wikipedia.org/wiki/Gang_scheduling): **一个作业里的 n 个进程，要么都运行，要么都死掉。**
+- 刚性调度[（gang scheduling）](https://en.wikipedia.org/wiki/Gang_scheduling):
+**一个作业里的 n 个进程，要么都运行，要么都死掉。**
 
-  - Google 开源的 Kubeflow 是一个 Kubernetes 扩展 operators，支持在 Kubernetes 上分布式地运行 TensorFlow 作业。
-  因为 TensorFlow runtime 目前支持一定程度的容错，所以作业执行过程中，如果有一些 workers 挂了，剩下的可以继续。不过不支持因为日后资源富余，恢复 workers 数量。
-  - Facebook 开源的 PyTorch Elastic 也是类似的扩展，支持分布式 PyTorch 作业。号称 Elastic，其实是 job 失败后从 checkpoint 重启。
-  - XGBoost、MXNet 社区也习惯于复用 Kubeflow。用 MPI 写的程序也可以利用 Kubeflow 拉起。
-  
+  - Google 开源的 Kubeflow 是一个 Kubernetes 扩展 operators，支持在 Kubernetes
+上分布式地运行 TensorFlow 作业。
+  因为 TensorFlow runtime
+目前支持一定程度的容错，所以作业执行过程中，如果有一些 workers
+挂了，剩下的可以继续。不过不支持因为日后资源富余，恢复 workers 数量。
+  - Facebook 开源的 PyTorch Elastic 也是类似的扩展，支持分布式 PyTorch
+作业。号称 Elastic，其实是 job 失败后从 checkpoint 重启。
+  - XGBoost、MXNet 社区也习惯于复用 Kubeflow。用 MPI 写的程序也可以利用
+Kubeflow 拉起。
+
   以上 Kubernetes operators 都可以在蚂蚁金服的 ASI（旧称 Sigma）上部署。
 
-  Gang scheduling 的特点是：运行时如果有一个进程挂了（比如被更高优先级的作业抢占了资源），则整个作业挂掉。等资源足够再启动所有的 n 个进程了，则可以重启（或者从最近的 checkpoint 恢复）。
-  
+  Gang scheduling 的特点是：运行时如果有一个进程挂了（比如被更高优先级的作业抢占
+  了资源），则整个作业挂掉。等资源足够再启动所有的 n 个进程了，则可以重启（或者
+  从最近的 checkpoint恢复）。
+
 - 弹性调度（elastic scheduling）：**训练作业运行过程中，进程数量的变化不影响作业。**
 
-  - 运行过程中，一个或者几个进程被高优先级的作业抢占，剩下的进程不受影响地继续进行。如果将来资源丰沛了，系统可以加几个进程，此时作业仍然不受影响地继续运行。
-  - ElasticDL 可以启动和调度分布式 TensorFlow、PyTorch 作业。也很容易支持分布式 XGBoost 作业。
+  - 运行过程中，一个或者几个进程被高优先级的作业抢占，剩下的进程不受影响地继续进
+    行。如果将来资源丰沛了，系统可以加几个进程，此时作业仍然不受影响地继续运行。
+  - ElasticDL 可以启动和调度分布式 TensorFlow、PyTorch 作业。也很容易支持分布式
+    XGBoost 作业。
 
 ### ElasticDL 弹性调度分布式架构
 
-ElasticDL 采用 master-worker 的分布式架构，下图为采用 Parameter Server 分布式策略的 ElasticDL 架构。
+ElasticDL 采用 master-worker 的分布式架构，下图为采用 Parameter Server
+分布式策略的 ElasticDL 架构。
 
 ![ElasticDL PS Architecture](../images/elasticdl_ps_architecture.svg)
 
 图中的 mater 主要包含两个角色：
 
-1. 负责启动 worker pod 和 PS pod，并管理所启动 pod 的生命周期，当有 pod 因为被抢占等原因失败时，会重启 pod。
-2. 将数据构造成 task，每个 task 包含一个数据分片，并将 task 分派给 worker 来计算梯度。如果 worker 负责的 task 失败，则 master 会将此 task 分配给其他 worker。
+1. 负责启动 worker pod 和 PS pod，并管理所启动 pod 的生命周期，当有 pod
+因为被抢占等原因失败时，会重启 pod。
+2. 将数据构造成 task，每个 task 包含一个数据分片，并将 task 分派给 worker
+来计算梯度。如果 worker 负责的 task 失败，则 master 会将此 task 分配给其他
+worker。
 
 ElasticDL 的 master 给 worker 分派计算任务 task 的示意图：
 
@@ -59,59 +83,94 @@ ElasticDL 的 master 给 worker 分派计算任务 task 的示意图：
 
 ### ElasticDL 弹性调度 benchmark
 
-为了说明 ElasticDL 弹性调度的优点，我们做了两组实验来说明 ElasticDL 可以带来用户体验和集群利用率的双丰收。
+为了说明 ElasticDL 弹性调度的优点，我们做了两组实验来说明 ElasticDL
+可以带来用户体验和集群利用率的双丰收。
 
 #### 实验一：多个 AI 训练作业
 
 考虑两个 AI 训练作业需要的资源总和略超过集群的情况：
 
-- 如果没有 elastic scheduling，则两个作业顺序执行。第二个作业的发起人需要等很久 —— 用户体验不好。并且任何时刻只有一个作业在运行 —— 集群资源用不满。
-- 如果有 elastic scheduling，则两个作业并发执行，虽然后启动的作业拿不到期待的全部资源，但是也马上就开始执行了 —— 用户体验好。因为两个作业并发 —— 集群被用满。
+- 如果没有 elastic scheduling，则两个作业顺序执行。第二个作业的发起人需要等很久
+—— 用户体验不好。并且任何时刻只有一个作业在运行 —— 集群资源用不满。
+- 如果有 elastic
+scheduling，则两个作业并发执行，虽然后启动的作业拿不到期待的全部资源，但是也马上
+就开始执行了 —— 用户体验好。因为两个作业并发 —— 集群被用满。
 
-我们做了一个实验来验证上述好处，这个实验可以在 ASI 集群和开源 Kubernetes 集群上复现。
+我们做了一个实验来验证上述好处，这个实验可以在 ASI 集群和开源 Kubernetes
+集群上复现。
 
 ![Utilized CPU with two training jobs](../images/utilized_cpu_with_jobs.jpg)
 
-上图对应的实验里，我们用 gang scheduling 的方式提交了两个训练作业，每个作业都需要 175 个 CPU。
-而集群总 CPU 数是 320，不足以同时运行两个作业，所以依次运行它们。可以看到第一 个作业在 650 秒时结束。
+上图对应的实验里，我们用 gang scheduling
+的方式提交了两个训练作业，每个作业都需要 175 个 CPU。
+而集群总 CPU 数是 320，不足以同时运行两个作业，所以依次运行它们。可以看到第一
+个作业在 650 秒时结束。
 随后集群花了一点时间调度，然后开始运行第二个作业，直到 1300 秒 时结束。
-下图对应的实验里，我们用 ElasticDL 来执行同样的两个训练作业。第一个作业提交之后的 300 秒，
-我们提交了第二个作业。第二个作业⻢上就开始运行，用满了集群剩下的资源，而不需要等到 第一个作业结束。
-在 650 秒时，第一个作业结束。随后，在 1100 秒时，第二个作业也结束了。因 为弹性调度，
+下图对应的实验里，我们用 ElasticDL
+来执行同样的两个训练作业。第一个作业提交之后的 300 秒，
+我们提交了第二个作业。第二个作业⻢上就开始运行，用满了集群剩下的资源，而不需要等
+到 第一个作业结束。
+在 650 秒时，第一个作业结束。随后，在 1100 秒时，第二个作业也结束了。因
+为弹性调度，
 使得两个作业尽量同时运行，所以总结束时间比也上图要早。
 
 总结:
 
-- 用户等待作业启动时间几乎是 0。这对于 AI 很重要，因为用户最关注的是第一个迭代尽快 开始 —— 如果第一个迭代 fail 了，很可能是用户程序的 bug。
-- 集群利用率高。第二个实验(elastic scheduling)执行期间，有一段时间集群利用率是 100%;其他时间也不低于第一个实验(gang scheduling)。
-- 作业完成更快。第二个试验里，两个作业用了约 1100 秒;第一个实验里需要约 1300 秒。
+- 用户等待作业启动时间几乎是 0。这对于 AI
+很重要，因为用户最关注的是第一个迭代尽快 开始 —— 如果第一个迭代 fail
+了，很可能是用户程序的 bug。
+- 集群利用率高。第二个实验(elastic scheduling)执行期间，有一段时间集群利用率是
+100%;其他时间也不低于第一个实验(gang scheduling)。
+- 作业完成更快。第二个试验里，两个作业用了约 1100 秒;第一个实验里需要约 1300
+秒。
 
 ### 实验二：AI 作业和在线服务混布
 
-运行各种在线服务的生产集群，通常需要留出余量资源，以应付突然增⻓的用户请求量。我们希望 利用这些 “余量” 来做 AI 训练，
-从而提升集群利用率。下面实验验证:通过用较低优先级运行 ElasticDL 训练作业，在用户请求增加的时候，Kubernetes 自动扩容在线服务(NGINX);
-此时 ElasticDL 作业自动释放资源，配合在线服务的扩容。当流量高峰过去之后，Kubernetes 自动缩容 NGINX 服务，此时，ElasticDL 自动利用释放的资源。
+运行各种在线服务的生产集群，通常需要留出余量资源，以应付突然增⻓的用户请求量。我
+们希望 利用这些 “余量” 来做 AI 训练，
+从而提升集群利用率。下面实验验证:通过用较低优先级运行 ElasticDL
+训练作业，在用户请求增加的时候，Kubernetes 自动扩容在线服务(NGINX);
+此时 ElasticDL
+作业自动释放资源，配合在线服务的扩容。当流量高峰过去之后，Kubernetes 自动缩容
+NGINX 服务，此时，ElasticDL 自动利用释放的资源。
 
 ![Utilized CPU with a nginx job](../images/utilized_cpu_with_nginx.jpg)
 
-图中紫色曲线是 NGINX 服务使用的 CPU 数量，随用户请求数量变化。绿色曲线是 ElasticDL 训练作业使用的 CPU 数量，随 NGINX 的资源需求自动变化。蓝色曲线是机群的总体资源利用 率 —— 保持在 90% 以上。
+图中紫色曲线是 NGINX 服务使用的 CPU 数量，随用户请求数量变化。绿色曲线是
+ElasticDL 训练作业使用的 CPU 数量，随 NGINX
+的资源需求自动变化。蓝色曲线是机群的总体资源利用 率 —— 保持在 90% 以上。
 
 ### 实验三：训练时调整 worker 数量不影响收敛性
 
-有用户担心训练过程中 worker 的数量发生变化，会导致不收敛。实际情况下从未发生这类问题。
-使用 [Kaggle Display Advertising Challenge](https://www.kaggle.com/c/criteo-display-ad-challenge) 的数据集,
-用 ElasticDL 和用 gang scheduling 分别训练 wide-and-deep DNN model，收敛曲线如下:
+有用户担心训练过程中 worker
+的数量发生变化，会导致不收敛。实际情况下从未发生这类问题。
+使用 [Kaggle Display Advertising
+Challenge](https://www.kaggle.com/c/criteo-display-ad-challenge) 的数据集,
+用 ElasticDL 和用 gang scheduling 分别训练 wide-and-deep DNN
+model，收敛曲线如下:
 
 ![AUC with different workers](../images/auc_with_different_workers.jpg)
 
- 此实验使用了异步 SGD 更新。多项研究(如[[Ho2013](http://www.cs.cmu.edu/~seunghak/SSPTable_NIPS2013.pdf)], [[Zhang2016](https://arxiv.org/pdf/1511.05950.pdf)])表明，在异步 SGD 下 worker 数量越多，参数滞后(Staleness)越严重，并且严重的 staleness 会影响到模型收敛。在 ElasticDL 弹性调度下，worker 数量可能因为被抢占而下降，staleness 会减轻，理论上不会对模型训练产生负面影响。实验结果也符合此理论。
- 
+ 此实验使用了异步 SGD
+更新。多项研究(如[[Ho2013](http://www.cs.cmu.edu/~seunghak/SSPTable_NIPS2013.pdf
+)], [[Zhang2016](https://arxiv.org/pdf/1511.05950.pdf)])表明，在异步 SGD 下
+worker 数量越多，参数滞后(Staleness)越严重，并且严重的 staleness
+会影响到模型收敛。在 ElasticDL 弹性调度下，worker
+数量可能因为被抢占而下降，staleness
+会减轻，理论上不会对模型训练产生负面影响。实验结果也符合此理论。
+
 ## 高性能的 Parameter Server
 
-在搜索广告等场景，模型中可能包含较大的 embedding table，其内存会超过单机内存，我们通常使用 Parameter Server (PS) 分布式策略来训练此类模型，在 PS 策略下，PS 上存储着模型参数，Worker 从 PS 上请求参数，
-在本地使用训练数据计算梯度，最后把梯度再发送到 PS 上，PS 使用 worker 传来的梯度来迭代更新模型参数。
+在搜索广告等场景，模型中可能包含较大的 embedding
+table，其内存会超过单机内存，我们通常使用 Parameter Server (PS)
+分布式策略来训练此类模型，在 PS 策略下，PS 上存储着模型参数，Worker 从 PS
+上请求参数，
+在本地使用训练数据计算梯度，最后把梯度再发送到 PS 上，PS 使用 worker
+传来的梯度来迭代更新模型参数。
 
-ElasticDL 用 Go 实现了 Parameter Server，具有良好的吞吐能力和可扩展性。并且，我们针对 embedding table 做了一些额外的优化。
+ElasticDL 用 Go 实现了 Parameter
+Server，具有良好的吞吐能力和可扩展性。并且，我们针对 embedding table
+做了一些额外的优化。
 
 - embedding vector 惰性初始化，从而可以支持任意大小的embedding table
 - 把一个 embedding table 拆分到多个PS上存储与更新，均衡存储/通信/更新的负载
@@ -122,12 +181,15 @@ ElasticDL 用 Go 实现了 Parameter Server，具有良好的吞吐能力和可�
 
 ## TensorFlow 2.x Keras API 定义模型
 
-ElasticDL 支持原生 Keras API 来定义模型，用户在定义模型时并需要感知 ElasticDL，只需用 TensorFlow 提供的 Keras API 定义模型即可。
-除了模型定义，ElasticDL 还提供了基于 TensorFlow op 开发的 Keras 特征预处理 layer，方便用户进行特征预处理。
+ElasticDL 支持原生 Keras API 来定义模型，用户在定义模型时并需要感知
+ElasticDL，只需用 TensorFlow 提供的 Keras API 定义模型即可。
+除了模型定义，ElasticDL 还提供了基于 TensorFlow op 开发的 Keras 特征预处理
+layer，方便用户进行特征预处理。
 
 ### Keras API 定义模型
 
-ElasticDL 使用 TensorFlow eager execution 来计算模型梯度，支持用户使用 TensorFlow 2.x 的 Keras API 来定义模型，如下所示：
+ElasticDL 使用 TensorFlow eager execution 来计算模型梯度，支持用户使用
+TensorFlow 2.x 的 Keras API 来定义模型，如下所示：
 
 ```python
 def custom_model():
@@ -157,10 +219,8 @@ def loss(labels, predictions):
         )
     )
 
-
 def optimizer(lr=0.1):
     return tf.optimizers.SGD(lr)
-
 
 def eval_metrics_fn():
     return {
@@ -169,7 +229,6 @@ def eval_metrics_fn():
             tf.cast(tf.reshape(labels, [-1]), tf.int32),
         )
     }
-
 
 def dataset_fn(dataset, mode, metadata):
     def _parse_data(record):
@@ -202,8 +261,10 @@ elasticdl train \
 
 ### Keras 特征预处理 layer
 
-通常情况下，原始数据是不能直接被深度学习模型来训练的，需要将原始数据进行预处理，同时需要保证预处理逻辑的离线训练和在线部署的一致性。
-为了方便用户在开发模型时进行数据预处理，ElasticDL 基于 TensorFlow op 开发了特征预处理库 elasticdl_preprocessing，
+通常情况下，原始数据是不能直接被深度学习模型来训练的，需要将原始数据进行预处理，
+同时需要保证预处理逻辑的离线训练和在线部署的一致性。
+为了方便用户在开发模型时进行数据预处理，ElasticDL 基于 TensorFlow op
+开发了特征预处理库 elasticdl_preprocessing，
 使用 elasticdl_preprocessing，用户可以对原始数据做如下操作：
 
 - 对数值特征做标准化或者归一化
@@ -221,6 +282,7 @@ elasticdl_preprocessing 提供了下列特预处理 layer：
 | Hashing | 将字符串进行 hashing 后对 bins 数量求余运算|
 | IndexLookup | 将字符串通过查词表转成整数，输出词所在词表的索引|
 
-elasticdl_preprocessing 的特征预处理 layer 可以和 TensorFlow 的 Keras layer 一起构造一个完成的模型，
-并在训练结束后保存到 TensorFlow 的 SavedModel 中。特征预处理 layer 的使用可以参考
-[Preprocess Inputs using ElasticDL Preprocessing Layers](https://github.com/sql-machine-learning/elasticdl/blob/develop/docs/tutorials/preprocessing_tutorial.md)
+elasticdl_preprocessing 的特征预处理 layer 可以和 TensorFlow 的 Keras layer一起
+构造一个完成的模型，并在训练结束后保存到 TensorFlow 的 SavedModel 中。特征预处理
+layer 的使用可以参考 [Preprocess Inputs using ElasticDL Preprocessing
+Layers](https://github.com/sql-machine-learning/elasticdl/blob/develop/docs/tutorials/preprocessing_tutorial.md)

--- a/docs/blogs/elasticdl-gdd-2019.md
+++ b/docs/blogs/elasticdl-gdd-2019.md
@@ -10,21 +10,13 @@ ElasticDL 与 TensorFlow 2.0 以及 Kubernetes 的技术关联。
 
 基于 TensorFlow 的分布式训练系统大致可以分为以下四类：
 
-```
-|---------------|----------------|----------------|
-|               | TensorFlow 1.x | TensorFlow 2.x |
-|               |  graph mode    | eager mode     |
-|---------------|----------------|----------------|
-| in TensorFlow | TensorFlow's   | TensorFlow     |
-|   runtime     | PS-based       | distribution   |
-|               | distribution   | strategies     |
-|               |                | (early stage)  |
-|---------------|----------------|----------------|
-| on TensorFlow | Uber Horovod   | Ant Financial  |
-|  API          |                | ElasticDL      |
-|               |                | (early stage)  |
-|---------------|----------------|----------------|
-```
+|-----------------------|-------------------------------|---------------------------------|
+|                       | TensorFlow 1.x graph mode     | TensorFlow 2.x eager execution  |
+|-----------------------|-------------------------------|---------------------------------|
+| in TensorFlow runtime | TensorFlow's parameter server | TensorFlow distributed strategy |
+|-----------------------|-------------------------------|---------------------------------|
+| above TensorFlow API  | Uber Horovod                  | ElasticDL                       |
+|-----------------------|-------------------------------|---------------------------------|
 
 其中，ElasticDL 位于田字格的右下角。之所以选择这条技术思路，是为了利用
 Kubernetes 实现容错和弹性调度。
@@ -61,7 +53,8 @@ TensorFlow 原生的分布式训练能力不是*容错*的（fault-tolerant）�
 checkpoint 的能力；如果一个作业失败了，可以重启作业，从最近的
 checkpoint 开始继续执行。
 
-Kubeflow 可以在 Kubernetes 上启动基于 TensorFlow 原生的分布式计算能力的作业。但是
+Kubeflow 可以在 Kubernetes 上启动基于 TensorFlow
+原生的分布式计算能力的作业。但是
 因为后者并不能容错，所以 Kubeflow 并不能无中生有。不能容错，也意味着不
 能弹性调度。
 
@@ -140,7 +133,6 @@ Kubernetes 的通知，master 可以通过检查其他继承的心跳（heartbea
 知新启动的进程的信息，并且帮助它加入作业。这种“非 Kubernetes-native”的
 容错方式颇为被动，只能接受资源紧张时一些进程被抢占而挂掉的事实，而不能
 在其他作业释放资源后增加进程充分利用空闲资源。
-
 
 ## TensorFlow 2.0
 
@@ -270,10 +262,9 @@ ElasticDL 项目希望通过这样的分而治之的策略，提供高性能并�
 
 最近几年里，很多互联网服务开始把数据直接上传到通用数据库中，比如蚂蚁金
 服的很多数据是在 ODPS（也就是阿里云上的 MaxCompute 服务）以及新一代的
-[智能数据系
-统
-](https://www.infoq.cn/article/tdpG65SjWSsdBgHmCTc5?utm_source=related_read&utm_medium=article)
-。这促使我们考虑把数据清洗和预处理放在数据库中做，而特征工程、自动机器
+[智能数据系统](https://www.infoq.cn/article/tdpG65SjWSsdBgHmCTc5?utm_source=related_read&utm_medium=article)。
+
+这促使我们考虑把数据清洗和预处理放在数据库中做，而特征工程、自动机器
 学习、和训练过程在 ElasticDL 这样的 AI 引擎里做。SQLFlow 把扩展语法的
 SQL 程序翻译成一个 Python 程序，把两部分链接起来。
 

--- a/docs/blogs/elasticdl-usability.md
+++ b/docs/blogs/elasticdl-usability.md
@@ -2,38 +2,51 @@
 
 ## 分布式深度学习程序难写
 
-一个深度学习的训练任务往往需要较多的训练数据，和较长的训练时间。一个通常的做法是把单机程序给分布式化，利用集群的资源，启动多个 worker，来共同完成一个训练任务。
+一个深度学习的训练任务往往需要较多的训练数据，和较长的训练时间。一个通常的做法是
+把单机程序给分布式化，利用集群的资源，启动多个 worker，来共同完成一个训练任务。
 
-分布式深度学习程序的编写是相对困难的，编程者既要了解深度学习，也要了解分布式系统开发。
-在一个分布式深度学习系统中，需要启动和监控若干个 workers 进程，对数据和计算任务进行拆分，并且分发给 workers。
+分布式深度学习程序的编写是相对困难的，编程者既要了解深度学习，也要了解分布式系统
+开发。
+在一个分布式深度学习系统中，需要启动和监控若干个 workers
+进程，对数据和计算任务进行拆分，并且分发给 workers。
 此外，还需要考虑 workers 之间的通信（communication）和 同步（synchronization）。
-随着计算规模的增加，workers 进程数目也会增加。当计算规模很大时，包含数十个进程的作业在执行过程中一个进程都不挂的概率几乎是0。
+随着计算规模的增加，workers
+进程数目也会增加。当计算规模很大时，包含数十个进程的作业在执行过程中一个进程都不
+挂的概率几乎是0。
 如果一个进程挂掉，则整个作业重启，那么这个作业会陷入永不停歇的重启，无法结束。
 此时，需要结合深度学习训练算法的数学性质，设计容错机制。
 这要求编程者必须同时是深度学习和分布式系统的专家。
 
-我们为此设计和开发了 ElasticDL 分布式计算框架，让编程者只需了解深度学习，不需要了解分布式系统开发。
+我们为此设计和开发了 ElasticDL
+分布式计算框架，让编程者只需了解深度学习，不需要了解分布式系统开发。
 
-就像 MapReduce 框架中只需要用户完形填空两个函数：map 和 reduce，ElasticDL 只需要用户填写 forward、cost、feed 三个函数。
+就像 MapReduce 框架中只需要用户完形填空两个函数：map 和 reduce，ElasticDL
+只需要用户填写 forward、cost、feed 三个函数。
 其中 forward 定义深度学习的前向计算过程，
 ElasticDL 会调用 TensorFlow eager mode 中提供的 Gradient Tape 接口，
 来自动推导对应的后向计算过程（backward pass）；
 cost 指定模型训练时使用的 cost 函数；
 feed 用来定制化训练数据到 TensorFlow 的 tensor的转换过程。
 
-所有的这些函数的编程只需要了解 TensorFlow API，不需要对分布式训练有任何背景知识。
-这些函数也可以在单机上用小数据做调试验证，然后就可以放心地交给 ElasticDL 做分布式的容错的大规模训练了。
+所有的这些函数的编程只需要了解 TensorFlow
+API，不需要对分布式训练有任何背景知识。
+这些函数也可以在单机上用小数据做调试验证，然后就可以放心地交给 ElasticDL
+做分布式的容错的大规模训练了。
 
 ElasticDL 要求分布式计算平台是 Kubernetes。
 一方面 Kubernetes 是目前最先进的分布式操作系统，是公有云和私有云的事实工业标准；
-另一方面，ElasticDL 一改 Kubeflow 通过增加 Kubernetes operator 的方式定制 Kubernetes 的思路，
+另一方面，ElasticDL 一改 Kubeflow 通过增加 Kubernetes operator 的方式定制
+Kubernetes 的思路，
 为每个作业引入一个 master 进程（类似 Google MapReduce）。
 这个 master 进程作为作业的一部分，而不是 Kubernetes 的一部分，
 不仅了解集群情况，更了解深度学习作业本身，所以有充分的信息来做更优的调度。
-比如 master 进程可以请 Kubernetes 把两个 workers 启动在同一台物理机上，共用一个 GPU。
-这样，一个进程读数据的时候，请另外一个进程来做计算，从而让 GPU 的利用率总是很高。
+比如 master 进程可以请 Kubernetes 把两个 workers 启动在同一台物理机上，共用一个
+GPU。
+这样，一个进程读数据的时候，请另外一个进程来做计算，从而让 GPU
+的利用率总是很高。
 
-TensorFlow 是当今最受欢迎的深度学习框架。在蚂蚁金服内部，TensorFlow 在诸多业务场景中被广泛使用。
+TensorFlow 是当今最受欢迎的深度学习框架。在蚂蚁金服内部，TensorFlow
+在诸多业务场景中被广泛使用。
 我们发现 AllReduce 和 Parameter Server 是分布式训练程序中常用两种梯度聚合策略。
 在图像语音模型中，AllReduce 策略被广泛的使用。
 在搜索广告推荐模型中，我们更倾向于使用 Parameter Server 策略。
@@ -45,11 +58,16 @@ TensorFlow 是当今最受欢迎的深度学习框架。在蚂蚁金服内部，
 | ParameterServer | TensorFlow Estimator | Kubeflow TF-operator |
 | AllReduce | Keras + Horovod | Kubeflow MPI-operator |
 
-我们发现 TensorFlow Estimator 仅支持 graph execution，不支持 eager execution，调试代码和网络各层输出比较麻烦。并且，用户需要组合使用不同的工具，来编写不同分布式策略的训练程序。
+我们发现 TensorFlow Estimator 仅支持 graph execution，不支持 eager
+execution，调试代码和网络各层输出比较麻烦。并且，用户需要组合使用不同的工具，来
+编写不同分布式策略的训练程序。
 
-TensorFlow 2.x 默认支持 eager execution，并且推荐使用更加精简的 Keras API 来定义模型。
-TensorFlow Keras API 提高开发效率，降低使用门槛，与 eager execution 配合之后，使得程序更为直观，也更易调试。
-目前 TensorFlow 2.x 的 ParameterServer 和 AllReduce 分布式策略对 Keras API 的支持还不完善。
+TensorFlow 2.x 默认支持 eager execution，并且推荐使用更加精简的 Keras API
+来定义模型。
+TensorFlow Keras API 提高开发效率，降低使用门槛，与 eager execution
+配合之后，使得程序更为直观，也更易调试。
+目前 TensorFlow 2.x 的 ParameterServer 和 AllReduce 分布式策略对 Keras API
+的支持还不完善。
 
 而 ElasticDL 从易用性的角度出发，直接支持了 TensorFlow 2.x 的 Keras API。
 ElasticDL 同时提供统一的 ElasticDL client 命令行工具来提交作业。
@@ -59,11 +77,14 @@ ElasticDL 同时提供统一的 ElasticDL client 命令行工具来提交作业�
 | ParameterServer | TensorFlow Keras API | ElasticDL client |
 | AllReduce | TensorFlow Keras API | ElasticDL client |
 
-统一的模型定义接口和统一的任务提交工具，极大地减少了用户的心智负担，提高了工作效率。
+统一的模型定义接口和统一的任务提交工具，极大地减少了用户的心智负担，提高了工作效
+率。
 
 ## ElasticDL 是如何解决问题的
 
-在 ElasticDL 中，用户专注于使用 TensorFlow Keras API 描述单机程序，而不需要关心分布式程序的写法。ElasticDL 会自动把单机程序转为分布式训练程序。下面我们用一个mnist的训练例子来详细说明。
+在 ElasticDL 中，用户专注于使用 TensorFlow Keras API
+描述单机程序，而不需要关心分布式程序的写法。ElasticDL
+会自动把单机程序转为分布式训练程序。下面我们用一个mnist的训练例子来详细说明。
 
 ### 使用 Keras API 定义模型
 
@@ -133,45 +154,59 @@ def dataset_fn(dataset, mode, _):
     return dataset
 ```
 
-在 TensorFlow 2.x 中，上述定义的每个接口都可以单独测试，我们可以很方便的在本地调试模型定义。
+在 TensorFlow 2.x
+中，上述定义的每个接口都可以单独测试，我们可以很方便的在本地调试模型定义。
 
-同时，TensorFlow 2.x 默认支持 eager execution，ElasticDL worker 可以直接调用模型定义，进行前向计算。
-在反向计算中，worker 可以通过 TensorFlow 2.x 暴露的 Gradient Tape接口 来计算得到梯度。
+同时，TensorFlow 2.x 默认支持 eager execution，ElasticDL worker
+可以直接调用模型定义，进行前向计算。
+在反向计算中，worker 可以通过 TensorFlow 2.x 暴露的 Gradient Tape接口
+来计算得到梯度。
 
 ### ElasticDL master 提供 training loop
 
-我们通常使用 mini-batch SGD 的方法来训练深度学习模型。ElasticDL worker 会进行如下步骤来完成对一个 mini-batch 的训练：
+我们通常使用 mini-batch SGD 的方法来训练深度学习模型。ElasticDL worker
+会进行如下步骤来完成对一个 mini-batch 的训练：
 
 1. 读取一个 mini-batch 的训练数据
 2. 进行 forward 计算
 3. 进行 backward 计算，得到梯度
 4. 把梯度以某种方式进行聚合，并更新模型
 
-我们需要一个更大的 training loop 来包含这四个步骤，确保 worker 可以持续的读取下一个 mini-batch 的数据，继续训练，直到满足终止条件。
+我们需要一个更大的 training loop 来包含这四个步骤，确保 worker
+可以持续的读取下一个 mini-batch 的数据，继续训练，直到满足终止条件。
 
-ElasticDL master 中实现了这样的training loop，其关键点是通过动态数据分发，解决分布式训练中的数据读取问题。
+ElasticDL master 中实现了这样的training
+loop，其关键点是通过动态数据分发，解决分布式训练中的数据读取问题。
 
 首先 master 会根据数据索引将数据分片，然后为每个分片的索引创建一个 task。
-ElasticDL worker 会向 master 请求拿到 task。拿到 task 之后，worker 可以数据的索引找到对应的数据分片。
+ElasticDL worker 会向 master 请求拿到 task。拿到 task 之后，worker
+可以数据的索引找到对应的数据分片。
 
 ElasticDL master 中还为这些 task 维护了三个队列，todo/doing/done 队列。
 任务开始时，master 会将所有 task 放入 todo 队列。每分发一个 task 给 worker，
 都会把这个 task 从 todo 队列挪到 doing 队列。
-如果一个 worker 被抢占或者因为其他原因失败，master 可以通过监控 doing 队列 task 的 timeout，
+如果一个 worker 被抢占或者因为其他原因失败，master 可以通过监控 doing 队列 task
+的 timeout，
 把这个 task 挪回到 todo 队列中。
-如果 worker 顺利完成一个 task，master 则会收到通知，把这个 task 从 doing 队列挪到 done 队列。
+如果 worker 顺利完成一个 task，master 则会收到通知，把这个 task 从 doing
+队列挪到 done 队列。
 
-由于ElasticDL master 负责把数据索引分发给所有的 worker，所以我们只需要给 master 配置数据源即可。
+由于ElasticDL master 负责把数据索引分发给所有的 worker，所以我们只需要给 master
+配置数据源即可。
 目前 ElasticDL 支持 [RecordIO](https://github.com/wangkuiyi/recordio) 文件和
  [MaxCompute](https://www.alibabacloud.com/zh/product/maxcompute) 表两种数据源。
 用户只需配置训练数据集的 RecordIO 文件路径或者 MaxCompute 表名。
 
 同时使用动态数据分发机制之后，worker 数目也可以动态变化。
-新加入的 worker 可以直接向 master 请求分配数据分片，从而更方便地支持弹性调度 worker 的数量。
+新加入的 worker 可以直接向 master 请求分配数据分片，从而更方便地支持弹性调度
+worker 的数量。
 
 ### ElasticDL client 命令行工具提交作业
 
-在本地完成对模型的调试之后，我们可以借助 ElasticDL client 提供的命令行工具向 Kubernetes 集群提交分布式训练作业。我们只需要指定模型定义文件和一些额外的参数，包括资源配置等。
+在本地完成对模型的调试之后，我们可以借助 ElasticDL client 提供的命令行工具向
+Kubernetes
+集群提交分布式训练作业。我们只需要指定模型定义文件和一些额外的参数，包括资源配置
+等。
 
 ```bash
 elasticdl train \
@@ -191,17 +226,25 @@ elasticdl train \
  --output=model_output
  ```
 
- 在上述例子中，我们指定了 Parameter Server 的分布式策略，由一个parameter server 和 两个 worker 共同完成训练任务。
- ElasticDL 的 master pod 将会被首先创建，然后由 master 负责启动 worker pod，以及 parameter server pod，并且建立通信。
- ElasticDL master 可以监控每个 pod 的状态，当有 pod 挂掉时，master 会重新拉起新的 pod。
+ 在上述例子中，我们指定了 Parameter Server 的分布式策略，由一个parameter server
+和 两个 worker 共同完成训练任务。
+ ElasticDL 的 master pod 将会被首先创建，然后由 master 负责启动 worker
+pod，以及 parameter server pod，并且建立通信。
+ ElasticDL master 可以监控每个 pod 的状态，当有 pod 挂掉时，master
+会重新拉起新的 pod。
 
 ## Parameter Server 的改进
 
-在搜索广告等场景，模型中可能包含较大的 embedding table，其内存会超过单机内存。我们通常使用 Parameter Server (PS) 分布式策略来训练此类模型。
+在搜索广告等场景，模型中可能包含较大的 embedding
+table，其内存会超过单机内存。我们通常使用 Parameter Server (PS)
+分布式策略来训练此类模型。
 在 PS 策略下，PS 上存储着模型参数，worker 从 PS 上请求参数。
-worker 在本地使用训练数据计算梯度之后，把梯度再发送到 PS 上，PS 使用 worker 传来的梯度来迭代更新模型参数。
+worker 在本地使用训练数据计算梯度之后，把梯度再发送到 PS 上，PS 使用 worker
+传来的梯度来迭代更新模型参数。
 
-ElasticDL 用 Go 实现了 Parameter Server，具有良好的吞吐能力和可扩展性。并且，我们针对 embedding table 做了一些额外的优化。
+ElasticDL 用 Go 实现了 Parameter
+Server，具有良好的吞吐能力和可扩展性。并且，我们针对 embedding table
+做了一些额外的优化。
 
 - embedding vector 惰性初始化，用户无需提前指定 embedding table 的大小
 - 把一个 embedding table 拆分到多个 PS 上存储与更新，均衡存储与通信的负载
@@ -210,9 +253,11 @@ ElasticDL 用 Go 实现了 Parameter Server，具有良好的吞吐能力和可�
 
 通过上述设计与实现，ElasticDL 可以很高效的完成搜索推荐广告模型的训练。
 
-ElasticDL 自去年9月份开源以来，我们对 Parameter Server 持续迭代开发，不断提升性能。
+ElasticDL 自去年9月份开源以来，我们对 Parameter Server
+持续迭代开发，不断提升性能。
 我们以一个推荐中常用的 deepFM 模型来进行测试，测试中使用 frappe 数据集。
-在每次实验中，我们启动一个 parameter server 进程和四个 worker 进程，训练10个 epoch。
+在每次实验中，我们启动一个 parameter server 进程和四个 worker 进程，训练10个
+epoch。
 
 | Parameter Server 实现 | 训练时间（秒） |
 | --- | --- |
@@ -224,30 +269,28 @@ ElasticDL 自去年9月份开源以来，我们对 Parameter Server 持续迭代
 ## 使用 ElasticDL 进行 Kaggle 实战
 
 在本小节中，我们将使用 ElasticDL 进行一次 Kaggle 实战。
-本例中使用的是 Kaggle 上 Display Advertising Challenge 中的 criteo 数据集，这是一个关于广告点击率预估的比赛。
-我们将使用 xDeepFM 模型来进行建模，所有的实例代码都放在了 ElasticDL 的 [model zoo](https://github.com/sql-machine-learning/elasticdl/tree/develop/model_zoo/dac_ctr)中。
+本例中使用的是 Kaggle 上 Display Advertising Challenge 中的 criteo
+数据集，这是一个关于广告点击率预估的比赛。
+我们将使用 xDeepFM 模型来进行建模，所有的实例代码都放在了 ElasticDL 的 [model
+zoo](https://github.com/sql-machine-learning/elasticdl/tree/develop/model_zoo/dac_ctr)中。
 
 ### 数据预处理
 
-1. 我们首先从官方
-[链接](https://labs.criteo.com/2014/02/download-kaggle-display-advertising-challenge-dataset)
-下载 criteo 数据集。
+1. 下载 criteo [数据集](https://labs.criteo.com/2014/02/download-kaggle-display-advertising-challenge-dataset)。
 
-1. 然后我们需要把原始数据转换为 RecordIO 文件格式。
-我们提供了如下的转换脚本：
+1. 然后我们需要把原始数据转换为 RecordIO 文件格式。我们提供了如下的转换脚本：
 
-```bash
-python convert_to_recordio.py \
-    --records_per_shard 400000 \
-    --output_dir ./dac_records \
-    --data_path train.txt
-```
+   ```bash
+   python convert_to_recordio.py \
+      --records_per_shard 400000 \
+      --output_dir ./dac_records \
+      --data_path train.txt
+   ```
 
-原始数据会被按照 19:1 的比例，拆分为训练集和验证集，
-转换后的数据放在 dac_records 目录中。
+   原始数据会被按照 19:1 的比例，拆分为训练集和验证集，转换后的数据放在dac_records 目录中。
 
-1. 对原始数据进行特征统计。对于连续的特征，我们统计得出均值和方差；
-对于离散的特征，我们得出特征值个数。我们把统计后的数据放在一个文件中，供后续使用。
+1. 对原始数据进行特征统计。对于连续的特征，我们统计得出均值和方差；对于离散的特
+   征，我们得出特征值个数。我们把统计后的数据放在一个文件中，供后续使用。
 
 ### 模型定义
 
@@ -274,8 +317,10 @@ dnn_logit = tf.keras.layers.Dense(1, use_bias=False, activation=None)(
 
 ### 提交训练任务
 
-我们首先在 Google Cloud 上创建一个 GKE 集群，并且把转换好的 RecordIO 训练数据上传到集群上。
-详细的过程可以参考 ElasticDL 的 [gcloud教程](https://github.com/sql-machine-learning/elasticdl/blob/develop/docs/tutorials/elasticdl_cloud.md)。
+我们首先在 Google Cloud 上创建一个 GKE 集群，并且把转换好的 RecordIO
+训练数据上传到集群上。
+详细的过程可以参考 ElasticDL 的
+[gcloud教程](https://github.com/sql-machine-learning/elasticdl/blob/develop/docs/tutorials/elasticdl_cloud.md)。
 
 然后，我们在本地制作一个镜像，该镜像包含了 xDeepFM 模型定义，以及相关依赖包。
 
@@ -288,7 +333,8 @@ COPY model_zoo /model_zoo
 我们需要把该镜像推送到 GKE 集群能够访问到的仓库中，比如说 docker hub 的仓库中。
 
 最后，我们通过 ElasticDL client 工具向 GKE 集群提交训练作业。
-我们使用 ParameterServer 分布式策略进行训练，有 2 个 parameter serve pods 和 5个 worker pods共同参与训练。
+我们使用 ParameterServer 分布式策略进行训练，有 2 个 parameter serve pods 和
+5个 worker pods共同参与训练。
 
 ```bash
 elasticdl train \


### PR DESCRIPTION
This PR makes `/docs/blogs/*.md` compliant to markdownlint rules.

After some manual fixes,  I deposited some heuristic auto-reformat rules into https://github.com/wangkuiyi/mdfmt.  This PR is generated from calling `mdfmt` with some manual changes that cannot be covered.

This PR also slightly changed the configuration `.markdownlinter.yaml`.