### PR TITLE
Reformat docs/design/archived/*.md

### DIFF
--- a/docs/designs/archived/model_evaluation.md
+++ b/docs/designs/archived/model_evaluation.md
@@ -1,57 +1,74 @@
-## Model Evaluation Design
+# Model Evaluation Design
 
 This document describes the design of model evaluation task for ElasticDL.
 
-### Minimal Viable Product
+## Minimal Viable Product
 
-#### Definitions
+### Definitions
 
-* `Model evaluation`: Computing metrics to judge the performance of the trained model.
-* `Evaluation worker`: The worker responsible for performing model evaluation task.
-* `Multiprocessing`: Executing tasks in multiple threads in parallel on the same pod.
+- `Model evaluation`: Computing metrics to judge the performance of the trained
+model.
+- `Evaluation worker`: The worker responsible for performing model evaluation
+task.
+- `Multiprocessing`: Executing tasks in multiple threads in parallel on the
+same pod.
 
-#### Requirements
+### Requirements
 
-* There's only one evaluation worker without multiprocessing.
-* Master pod is responsible for creating the evaluation worker.
-* Evaluation worker is created by master pod together with the workers for training.
-* Evaluation starts after a specified warm-up period and on a given time interval. For example, we need to expose
-    the following parameters to users:
-    * `start_delay_secs`: Start evaluating after waiting for this many seconds.
-    * `throttle_secs`: Do not re-evaluate unless the last evaluation was started at least this many seconds ago.
-* The evaluation worker fetches the latest model from master pod.
-* Model can be evaluated by a specified number of steps or batches of evaluation samples. If `None`,
+- There's only one evaluation worker without multiprocessing.
+- Master pod is responsible for creating the evaluation worker.
+- Evaluation worker is created by master pod together with the workers for
+training.
+- Evaluation starts after a specified warm-up period and on a given time
+interval. For example, we need to expose the following parameters to users:
+  - `start_delay_secs`: Start evaluating after waiting for this many seconds.
+  - `throttle_secs`: Do not re-evaluate unless the last evaluation was
+started at least this many seconds ago.
+- The evaluation worker fetches the latest model from master pod.
+- Model can be evaluated by a specified number of steps or batches of
+evaluation samples. If `None`,
     evaluation will continue until reaching the end of input.
-* Model evaluation metrics can be defined by users together with the model definition.
-* The computed model evaluation metrics can be report back to master through RPC call.
+- Model evaluation metrics can be defined by users together with the model
+definition.
+- The computed model evaluation metrics can be report back to master through
+RPC call.
 
-#### Implementation Plan
+### Implementation Plan
 
-* Implement `MasterServicer.ReportEvaluationMetrics()` and additional proto definitions such as
+- Implement `MasterServicer.ReportEvaluationMetrics()` and additional proto
+definitions such as
     `ReportEvaluationMetricsReply` and `ReportEvaluationMetricsRequest`.
-* Extend `Worker` to support the following:
-    * `distributed_evaluate()` that contains the main logic for model evaluation.
-    * `report_task_result()` that reports evaluation task result (e.g. task id and error message) back to master through RPC call.
-    * `report_evaluation_metrics()` that reports the computed evaluation metrics (e.g. accuracy, precision, recall, etc.) back to master through RPC call.
-* Add main CLI entry-point to `Worker.distributed_evaluate()` that will be used in `WorkerManager`.
-* Extend `WorkerManager` to support the following:
-    * Instantiate a separate evaluation task queue from evaluation data directory.
-    * Start an evaluation worker from evaluation task queue.
-    * Update `master.main()` to support model evaluation task if user requested.
+- Extend `Worker` to support the following:
+  - `distributed_evaluate()` that contains the main logic for model
+evaluation.
+  - `report_task_result()` that reports evaluation task result (e.g. task id
+and error message) back to master through RPC call.
+  - `report_evaluation_metrics()` that reports the computed evaluation
+metrics (e.g. accuracy, precision, recall, etc.) back to master through RPC
+call.
+- Add main CLI entry-point to `Worker.distributed_evaluate()` that will be used
+in `WorkerManager`.
+- Extend `WorkerManager` to support the following:
+  - Instantiate a separate evaluation task queue from evaluation data
+directory.
+  - Start an evaluation worker from evaluation task queue.
+  - Update `master.main()` to support model evaluation task if user requested.
 
-### Future Development
+## Future Development
 
 A list of potential features we may want for model evaluation in the future:
 
-* `num_parallel_processes`: The number of children processes to run evaluation on each individual evaluation worker.
-* `sample_weights`: Optional Numpy array of weights for the test samples, used for weighting the loss function.
+- `num_parallel_processes`: The number of children processes to run evaluation
+on each individual evaluation worker.
+- `sample_weights`: Optional Numpy array of weights for the test samples, used
+for weighting the loss function.
 
-### References
+## References
 
 Some of the ideas are borrowed from existing solutions listed below:
 
-* [`tf.keras.models.Model.evaluate()`](https://www.tensorflow.org/api_docs/python/tf/keras/models/Model#evaluate)
-* [`tf.keras.metrics`](https://www.tensorflow.org/api_docs/python/tf/keras/metrics)
-* [`tf.estimator.EvalSpec`](https://www.tensorflow.org/api_docs/python/tf/estimator/EvalSpec)
-* [`tf.estimator.Estimator.evaluate()`](https://www.tensorflow.org/api_docs/python/tf/estimator/Estimator#evaluate)
-* [`tf.estimator.train_and_evaluate()`](https://www.tensorflow.org/api_docs/python/tf/estimator/train_and_evaluate)
+- [`tf.keras.models.Model.evaluate()`](https://www.tensorflow.org/api_docs/python/tf/keras/models/Model#evaluate)
+- [`tf.keras.metrics`](https://www.tensorflow.org/api_docs/python/tf/keras/metrics)
+- [`tf.estimator.EvalSpec`](https://www.tensorflow.org/api_docs/python/tf/estimator/EvalSpec)
+- [`tf.estimator.Estimator.evaluate()`](https://www.tensorflow.org/api_docs/python/tf/estimator/Estimator#evaluate)
+- [`tf.estimator.train_and_evaluate()`](https://www.tensorflow.org/api_docs/python/tf/estimator/train_and_evaluate)

--- a/docs/designs/archived/overview.md
+++ b/docs/designs/archived/overview.md
@@ -1,15 +1,27 @@
 # Overview
 
-ElasticDL is a framework implements the swamp optimization meta-algorithm. It is like Apache Hadoop is a framework that implements the MapReduce parallel programming paradigm.
+ElasticDL is a framework implements the swamp optimization meta-algorithm. It
+is like Apache Hadoop is a framework that implements the MapReduce parallel
+programming paradigm.
 
-To program the ElasticDL framework, programmers need to provide at least one `nn.Module`-derived class that describes the specification of a model. It is like programmers of Hadoop need to provide a class that implements the methods of Map and Reduce.
+To program the ElasticDL framework, programmers need to provide at least one
+`nn.Module`-derived class that describes the specification of a model. It is
+like programmers of Hadoop need to provide a class that implements the methods
+of Map and Reduce.
 
-To train a model, ElasticDL needs (1) hyperparameter values, and (2) the data.  Each ElasticDL job uses the same data to train one or more models, where each model needs a set of hyperparameter values. A model could have more than one sets of hyperparameter values.  In such a case, they are considered multiple models.
+To train a model, ElasticDL needs (1) hyperparameter values, and (2) the data.
+Each ElasticDL job uses the same data to train one or more models, where each
+model needs a set of hyperparameter values. A model could have more than one
+sets of hyperparameter values.  In such a case, they are considered multiple
+models.
 
 - A job is associated with a dataset.
-- A job is associated with one or more model specifications, each model specification is a Python classed derived from torch.nn.Module.
-- A model specification is associated with one or more sets of hyperparameter values.
-- The pair of a model specification and a set of its hyperparameter values is a model.
+- A job is associated with one or more model specifications, each model
+specification is a Python classed derived from torch.nn.Module.
+- A model specification is associated with one or more sets of hyperparameter
+values.
+- The pair of a model specification and a set of its hyperparameter values is a
+model.
 - A job includes a coordinator process and one or more bee processes.
 - A bee process trains one or more models.
 - The coordinator dispatches models to bees.

--- a/docs/designs/archived/parameter_server.md
+++ b/docs/designs/archived/parameter_server.md
@@ -4,60 +4,77 @@
 
 A typical parameter server (pserver) architecture contains three roles:
 
-- master, calling Kubernetes API to start workers and optionally parameter servers, and scheduling tasks to workers
-- pserver, maintaining the global model, and providing parameter pull/push/optimize/checkpoint service
-- worker, computing gradients of model parameters using local data and pushing gradients to pservers
-
+- master, calling Kubernetes API to start workers and optionally parameter
+servers, and scheduling tasks to workers
+- pserver, maintaining the global model, and providing parameter
+pull/push/optimize/checkpoint service
+- worker, computing gradients of model parameters using local data and pushing
+gradients to pservers
 
 Please refer to:
 
 ![parameter_server](images/parameter_server.png)
 
-
 ## Parameter Sharding
-
 
 We prefer to shard the global model for some reasons:
 
-- A model could be too large to fit in the memory of a process. For example, many recommending and ranking models take very high-dimensional (and sparse) inputs, thus require large embedding tables. In such cases, we'd have to have multiple parameter server instances to hold the global model.
+- A model could be too large to fit in the memory of a process. For example,
+many recommending and ranking models take very high-dimensional (and sparse)
+inputs, thus require large embedding tables. In such cases, we'd have to have
+multiple parameter server instances to hold the global model.
 
-- Even when a single process can hold the global model, we might still shard it onto multiple parameter server instances, who share the both communication and optimization workload.
+- Even when a single process can hold the global model, we might still shard it
+onto multiple parameter server instances, who share the both communication and
+optimization workload.
 
 There are several kinds of parameter to be handled separately:
 
-- Very big embedding table: Embedding table is a collection of <item id, embedding vector> pairs. There is also a mapping from item id to pserver id, so the corresonding embedding vector will be stored at the certain pserver
+- Very big embedding table: Embedding table is a collection of <item id,
+embedding vector> pairs. There is also a mapping from item id to pserver id, so
+the corresonding embedding vector will be stored at the certain pserver
 
-- Big dense tensor: If the dense tensor parameter exceeds certain size, it will be sliced into several subtensors. The parameter name combining subtensor id will become a unique key, and the value is the subtensor(Please note that the slice tensor operation is zero-copy)
+- Big dense tensor: If the dense tensor parameter exceeds certain size, it will
+be sliced into several subtensors. The parameter name combining subtensor id
+will become a unique key, and the value is the subtensor(Please note that the
+slice tensor operation is zero-copy)
 
-- Small dense tensor: The small dense tensor parameter will be stored at certain pserver wholely
+- Small dense tensor: The small dense tensor parameter will be stored at
+certain pserver wholely
 
+The local model on workers and the global model on the parameter server(s) have
+the same size. In case that large embedding tables make the model size too big
+to fit in a single process's memory space, an intuitive solution is to save the
+model copies on an external storage service like Redis or Memcached.
 
-The local model on workers and the global model on the parameter server(s) have the same size. In case that large embedding tables make the model size too big to fit in a single process's memory space, an intuitive solution is to save the model copies on an external storage service like Redis or Memcached.
+However, such a solution creates a complex workflow which introduces too many
+cross-node communications.
 
-However, such a solution creates a complex workflow which introduces too many cross-node communications.
-
-We propose an alternative solution that doesn't rely on Redis or Memcachd. Instead, the global model, including the large embedding tables, is sharded across parameter servers, and the local model contains only part of the embedding table -- the small fraction that is required to compute recent minibatch(es).
+We propose an alternative solution that doesn't rely on Redis or Memcachd.
+Instead, the global model, including the large embedding tables, is sharded
+across parameter servers, and the local model contains only part of the
+embedding table -- the small fraction that is required to compute recent
+minibatch(es).
 
 ## Parameter Initialization
 
-
-Parameter initialization of a very big embedding table is lazy. For example, in online learning, there could be unkown item id in the training data. So, until worker send the unkown item id to pserver, will pserver initialize corresponding embedding vector and send back to worker. This is a `get_or_create` semantic.
+Parameter initialization of a very big embedding table is lazy. For example, in
+online learning, there could be unkown item id in the training data. So, until
+worker send the unkown item id to pserver, will pserver initialize
+corresponding embedding vector and send back to worker. This is a
+`get_or_create` semantic.
 
 Other parameters could be initialized before training.
-
-
 
 ## Distribution Strategy
 
 We apply different strategies to different scenarios.
-
 
 | scenario| hardware | update stragety | communication  stragety |
 | :----  |:----  |:---|:---|
 | Recommendation  | CPU|  async SGD|  Parameter server |
 | CV | GPU | BSP SGD| AllReduce|
 | NLP | GPU | BSP SGD| AllReduce |
-
 
 BSP is short for Bulk synchronous parallel.
 
@@ -68,32 +85,32 @@ Following is the assumption under recommendation scenario:
 
 Please refer to [Elastic Scheduling](#Elastic Scheduling) part for more details.
 
-
-**Note**
-
-AllReduce failover and pserver failover will be discussed on other design docs.
+Note: AllReduce failover and pserver failover will be discussed on other design
+docs.
 
 ## Master
 
 - Master is responsible for creating/deleting/scheduling pserver and worker
-- Master defines a parameter sharding strategy, and generate unique key for each parameter(or sharded parameter)
-- Master defines a hash strategy from parameter key to pserver id 
+- Master defines a parameter sharding strategy, and generate unique key for
+each parameter(or sharded parameter)
+- Master defines a hash strategy from parameter key to pserver id
 
 Workflow:
 
-
 1. Master creates several pservers and workers according to users' configuration
-2. Master generates parameter sharding strategy based on the model definition provided by users
+2. Master generates parameter sharding strategy based on the model definition
+provided by users
 3. Master initializes parameter, and send to pservers
 4. Master triggers pservers and workers and starts training
-5. Master monitors the cluster, and increase or decrease workers according to priority
-
+5. Master monitors the cluster, and increase or decrease workers according to
+priority
 
 ## Pserver
 
-- Pserver provides kv store service, and workers could push/pull <key, value> to the pserver
-- Pserver provides optimize service, apply gradients to parameters and update back to kv store
-
+- Pserver provides kv store service, and workers could push/pull <key, value>
+to the pserver
+- Pserver provides optimize service, apply gradients to parameters and update
+back to kv store
 
 Workflow:
 
@@ -103,10 +120,8 @@ Workflow:
 4. Pserver updates <key, parameter> back to kv store
 5. Pserver saves model checkpoint to disk periodially
 
-
-**Note**
-
-We could implement the kv store by ourselves, or we could use some existing solution, such as redis.
+Note: We could implement the kv store by ourselves, or we could use some
+existing solution, such as redis.
 
 ## Worker
 
@@ -115,28 +130,32 @@ We could implement the kv store by ourselves, or we could use some existing solu
 
 Workflow:
 
-1. Before forward layer starting, worker sends key to pserver, and pull <key, parameter> back from pserver
+1. Before forward layer starting, worker sends key to pserver, and pull <key,
+parameter> back from pserver
 2. Worker starts forward layer computation
 3. After backward layer finishing, worker generates <key, gradient>
 4. Worker pushes <key, gradient> to pserver
 
+Worker could also run a evaluation task. It pulls <key, parameter> from
+pserver, and reports evaluation metrics results to master, but does not push
+data to pserver.
 
-Worker could also run a evaluation task. It pulls <key, parameter> from pserver, and reports evaluation metrics results to master, but does not push data to pserver.
-
-
-**Note**
-
-There could be some same item id in a minibatch data. So some gradient vector of embedding table will have the same item id. We need to sum these gradient before pushing to pserver.
-
+Note: There could be some same item id in a minibatch data. So some gradient
+vector of embedding table will have the same item id. We need to sum these
+gradient before pushing to pserver.
 
 ## Delayed model updating
 
-In order to reduce the communication overhead between workers and pservers, we propose a strategy called delayed model updating. A worker runs several rounds of forward/backward computation using its local model, and keep the gradients locally. After finishing, it pushes gradients to pservers.
+In order to reduce the communication overhead between workers and pservers, we
+propose a strategy called delayed model updating. A worker runs several rounds
+of forward/backward computation using its local model, and keep the gradients
+locally. After finishing, it pushes gradients to pservers.
 
-**Note**
-
-Since the local model is only a part of the global model, in some circumstance, workers still has to pull the embedding vector parameter from pservers if there exits unknow item ids in a minibatch data. In async mode, this will lead to relative newer embedding part parameters, but relative older other part parameters.
-
+Note: Since the local model is only a part of the global model, in some
+circumstance, workers still has to pull the embedding vector parameter from
+pservers if there exits unknow item ids in a minibatch data. In async mode, this
+will lead to relative newer embedding part parameters, but relative older other
+part parameters.
 
 ## Elastic scheduling
 
@@ -144,26 +163,35 @@ Since the local model is only a part of the global model, in some circumstance, 
 
 First, we analyse the hardware resources that pserver and worker consume.
 
-
 | role| CPU | memory | network bandwidth |  disk |
 | :----  |:----  |:---|:---|:---|
 | worker  | high| medium |  medium | low|
 | pserver | low | medium | high| medium |
 
-
-Worker does the forward/backward computation and consumes CPU most, while pserver provides kvstore service and consumes network bandwidth most. Since our target is to scheduling deep learning jobs elastically, we must have the ability to increase/decrease CPU resources of worker, and increase/decrease network bandwidth resources of pserver.
+Worker does the forward/backward computation and consumes CPU most, while
+pserver provides kvstore service and consumes network bandwidth most. Since our
+target is to scheduling deep learning jobs elastically, we must have the
+ability to increase/decrease CPU resources of worker, and increase/decrease
+network bandwidth resources of pserver.
 
 ### Solution
 
-As we are using asynchronous SGD, increasing/decreasing CPU resources of worker is trivial. We can just create more workers or kill some workers under different cluster status.
+As we are using asynchronous SGD, increasing/decreasing CPU resources of worker
+is trivial. We can just create more workers or kill some workers under
+different cluster status.
 
-For example, if job A requests 50 CPU cores, but current cluster only has 30 CPU cores. The cluster will lanuch the job immediately with 30 CPU cores. If the cluster has more CPU cores after a while, it will tell the master of job A to occupy the idle CPU cores and create more workers.
+For example, if job A requests 50 CPU cores, but current cluster only has 30
+CPU cores. The cluster will lanuch the job immediately with 30 CPU cores. If
+the cluster has more CPU cores after a while, it will tell the master of job A
+to occupy the idle CPU cores and create more workers.
 
-And for pserver, how can we adjust network bandwidth? One solution is to create or delete pserver pods. Since each node has a network interface card, more pserver pods in different nodes might mean more network bandwidth.
+And for pserver, how can we adjust network bandwidth? One solution is to create
+or delete pserver pods. Since each node has a network interface card, more
+pserver pods in different nodes might mean more network bandwidth.
 
-**Note**
-
-ElasticDL has no ability to control network bandwidth, or get current network traffic status. So a naive stragety could be making pservers occupy more nodes.
+Note: ElasticDL has no ability to control network bandwidth, or get current
+network traffic status. So a naive stragety could be making pservers occupy more
+nodes.
 
 If we change pserver pod number, following things also need to be done:
 
@@ -173,21 +201,34 @@ If we change pserver pod number, following things also need to be done:
 4. reseting grpc channels between pservers and workers
 5. reseting parameters pull/gradients push logic in workers
 
-The second solution to avoid parameter re-sharding is using consistent hashing. However, consistent hashing usually raises the time complexity of each push/pull operation, which causes a remarkable loss on performance.
+The second solution to avoid parameter re-sharding is using consistent hashing.
+However, consistent hashing usually raises the time complexity of each
+push/pull operation, which causes a remarkable loss on performance.
 
-The third solution is to adjust network bandwidth of current pserver pod. We can create many pserver pods first, but set network bandwidth limit to certain medium value. If we want to increase/decrease network bandwith, we increase/decrease the network bandwidth limit.
+The third solution is to adjust network bandwidth of current pserver pod. We
+can create many pserver pods first, but set network bandwidth limit to certain
+medium value. If we want to increase/decrease network bandwith, we
+increase/decrease the network bandwidth limit.
 
-The third solution consumes the same memory, a little more CPU comparing to the former solutions, but avoids complex parameter re-sharding/consistent hashing under varying pserver pods. However, it's hard to manage network bandwidth resources in a data center. There could be a complex network topology. 
+The third solution consumes the same memory, a little more CPU comparing to the
+former solutions, but avoids complex parameter re-sharding/consistent hashing
+under varying pserver pods. However, it's hard to manage network bandwidth
+resources in a data center. There could be a complex network topology.
 
-The forth solution is to create many pserver pods and keep the pserver pod number unchanged. Each parameter sharding will be mapped to a pserver pod. But the location of pserver pods could be changed.
+The forth solution is to create many pserver pods and keep the pserver pod
+number unchanged. Each parameter sharding will be mapped to a pserver pod. But
+the location of pserver pods could be changed.
 
-In general, one team's job has high prority on his own resources. For example, team A has a job A which require 3 pserver nodes, but team A only has two nodes for pserver. So it will "borrow" one from other team, and schedules pserver pods to 3 nodes, 2 of them is his own, 1 is from another team.
+In general, one team's job has high prority on his own resources. For example,
+team A has a job A which require 3 pserver nodes, but team A only has two nodes
+for pserver. So it will "borrow" one from other team, and schedules pserver
+pods to 3 nodes, 2 of them is his own, 1 is from another team.
 
-It the other team launch his own job, it will tell job A to release the "borrowed" node. So the pserver pods of job A will be moved to his own 2 nodes.
+It the other team launch his own job, it will tell job A to release the
+"borrowed" node. So the pserver pods of job A will be moved to his own 2 nodes.
 
-**Note**
-
-The premise of "moving" pserver pod to another place is that the new node has sufficient resources, such as memory to load parameter shards.
+Note: The premise of "moving" pserver pod to another place is that the new node
+has sufficient resources, such as memory to load parameter shards.
 
 ## Failover
 
@@ -196,36 +237,62 @@ There are two scenarios of failover to be taken into consideration:
 - machines get breakdown
 - some pods are killed because of priority scheduling
 
-Since worker is stateless, we do not have to support failover for worker. 
+Since worker is stateless, we do not have to support failover for worker.
 
-However, pserver is stateful, which stores parameter shards. We must be careful when handling pserver.
+However, pserver is stateful, which stores parameter shards. We must be careful
+when handling pserver.
 
-To solve machines breakdown problem, we make replication for each pserver pod. The parameter sharding will be stored at one pserver pod, and also the neighbour pserver pods. The replication number is exposed to users to set, from 0 to 2.
+To solve machines breakdown problem, we make replication for each pserver pod.
+The parameter sharding will be stored at one pserver pod, and also the
+neighbour pserver pods. The replication number is exposed to users to set, from
+0 to 2.
 
-So, if one pserver pod is breakdown, we could keep providing kvstore service without suspension. At the same time, the master will find another place to start a new pserver pod to recover to the original state.
+So, if one pserver pod is breakdown, we could keep providing kvstore service
+without suspension. At the same time, the master will find another place to
+start a new pserver pod to recover to the original state.
 
-In addition, if there is no big embedding table in the model, which means a worker holds whole parameters, the pserver could also recover from a worker.
+In addition, if there is no big embedding table in the model, which means a
+worker holds whole parameters, the pserver could also recover from a worker.
 
-Besides, we will save checkpoint periodially to a distributed file system. If we meets occasional many machines breakdown, the only thing to do is to setup a new job, and load corresponding parameter shards from the checkpoint.
+Besides, we will save checkpoint periodially to a distributed file system. If
+we meets occasional many machines breakdown, the only thing to do is to setup a
+new job, and load corresponding parameter shards from the checkpoint.
 
-Since pserver pods has relative higher priority than worker pods, worker pods of one lower priority job will be killed first to satisfy another job. If we kill all worker pods of one job, then the pserver pods of this job will also be idle. There is no load on CPU and network bandwidth, the pserver pods only occupy some memory. So, we do not need to kill pserver pods further.
+Since pserver pods has relative higher priority than worker pods, worker pods
+of one lower priority job will be killed first to satisfy another job. If we
+kill all worker pods of one job, then the pserver pods of this job will also be
+idle. There is no load on CPU and network bandwidth, the pserver pods only
+occupy some memory. So, we do not need to kill pserver pods further.
 
-We should avoid changing pserver pod numbers in general, since it will bring lots of other work. If this assumption is valid, the second scenario would be skipped.
+We should avoid changing pserver pod numbers in general, since it will bring
+lots of other work. If this assumption is valid, the second scenario would be
+skipped.
 
 ## Deployment
 
-After training some epoches, we will choose one checkpoint which has the best evalution metric as the final model. And this model will be deployed to online.
+After training some epoches, we will choose one checkpoint which has the best
+evalution metric as the final model. And this model will be deployed to online.
 
-We provide two depolyment solutions which handles different model size separately.
+We provide two depolyment solutions which handles different model size
+separately.
 
 ### Solution one
 
-If the checkpoint file is not very large, and could be loaded to a single node, the deployment of parameter server architecture will be the same as single node. 
+If the checkpoint file is not very large, and could be loaded to a single node,
+the deployment of parameter server architecture will be the same as single node.
 
-We need to make both transformations to network definition and model parameter. In parameter server architecture, we may define some customized layers, but we have to use standard layers in deloyment. And some model parameter has to be merged, in order to coordinate with standard layers.
+We need to make both transformations to network definition and model parameter.
+In parameter server architecture, we may define some customized layers, but we
+have to use standard layers in deloyment. And some model parameter has to be
+merged, in order to coordinate with standard layers.
 
 ### Solution two
 
-If the checkpoint file is too large to load into a single node, we have to spilt it into several pieces. The largest parameter could be a embedding table. We can split the embedding table by rows, and each piece hold a part of the embedding tale. 
+If the checkpoint file is too large to load into a single node, we have to
+spilt it into several pieces. The largest parameter could be a embedding table.
+We can split the embedding table by rows, and each piece hold a part of the
+embedding tale.
 
-We apply the first solution to each model piece. And then, the upcoming item id will be handled and dispatched to correct model piece. This is a divide-conque solution.
+We apply the first solution to each model piece. And then, the upcoming item id
+will be handled and dispatched to correct model piece. This is a divide-conque
+solution.

--- a/docs/designs/archived/worker_optimization.md
+++ b/docs/designs/archived/worker_optimization.md
@@ -1,8 +1,11 @@
-# ElasticDL Worker Training Performance Optimization 
-This document describes the design for performance optimization for ElasticDL worker training process.
+# ElasticDL Worker Training Performance Optimization
+
+This document describes the design for performance optimization for ElasticDL
+worker training process.
 
 ## Current worker training pipeline (@July 24, 2019)
-```
+
+```text
 while True:
     task = get_task()
     if no task, break
@@ -19,24 +22,25 @@ while True:
             report_evaluation_metrics(metrics)
         elif task is prediction:
             predict = compute_predict(features)
-            report_prediction_outputs(predict) 
+            report_prediction_outputs(predict)
     report_task_result()
 ```
 
 There are 4 types of ElasticDL jobs:
 
 1. Training-only
-2. Training-with-evaluation
-2. Evaluation-only
-3. Prediction-only
+1. Training-with-evaluation
+1. Evaluation-only
+1. Prediction-only
 
 ## Test setting
+
 Here, we will concentrate on the performance of the training-only case.
 
+All tests are done with CIFAR10 training data. The timing-related arguments
+used in the test are:
 
-All tests are done with CIFAR10 training data. The timing-related arguments used in the test are:
-
-```
+```bash
   --num_epochs=1
   --master_resource_request="cpu=2,memory=2048Mi,ephemeral-storage=5000Mi"
   --worker_resource_request="cpu=4,memory=2048Mi,ephemeral-storage=5000Mi,gpu=1"
@@ -48,34 +52,46 @@ All tests are done with CIFAR10 training data. The timing-related arguments used
 ```
 
 ## Current perf for training-only job
+
 The total training time and some break-down timing (in seconds) are below:
 
 Total Time | get_batch | input_fn | compute_loss | get_model | report_gradient
 ---|---|---|---|---|---
 51.0 | 6.7 | 17.9 | 14.8 | 5.0 | 5.0
 
-(6.7 + 17.9) / 51.0 = 48% time is spent on training data read and preprocessing (`get_batch` + `input_fn`).
+(6.7 + 17.9) / 51.0 = 48% time is spent on training data read and preprocessing
+(`get_batch` + `input_fn`).
 
 14.8 / 51.0 = 29% time is on model compute (`compute_loss`).
 
-(5.0 + 5.0) / 51.0 = 20% time is on PS related ops (`get_model` + `report_gradient`)
+(5.0 + 5.0) / 51.0 = 20% time is on PS related ops (`get_model` +
+`report_gradient`)
 
 ## Optimization Strategy
 
 ### Data Read and Preprocessing
-Data Read and preprocessing (`get_batch` and `input_fn`) are serialized with the model compute and PS-related ops within one thread. They can be processed asynchronously  and in parallel, so that their processing time is overlapping with the other parts of the training pipeline.
 
-We can use TensorFlow Dataset for its asynchronization and C++ level multithreading.
+Data Read and preprocessing (`get_batch` and `input_fn`) are serialized with
+the model compute and PS-related ops within one thread. They can be processed
+asynchronously  and in parallel, so that their processing time is overlapping
+with the other parts of the training pipeline.
 
-One way is to generate a dataset for each task after `get_task`. But the dataset will get stuck whenever `get_task` is needed, and there is overhead in creating a new dataset.
+We can use TensorFlow Dataset for its asynchronization and C++ level
+multithreading.
 
-A better way is to use a shared dataset, which will call `get_task` to get new training data when it runs out the data.
-The user needs to provide `dataset_fn` instead of `input_fn`. `dataset_fn` would take a RecordIO dataset as input, decode and preprocessing the data as needed.
+One way is to generate a dataset for each task after `get_task`. But the
+dataset will get stuck whenever `get_task` is needed, and there is overhead in
+creating a new dataset.
 
+A better way is to use a shared dataset, which will call `get_task` to get new
+training data when it runs out the data.
+The user needs to provide `dataset_fn` instead of `input_fn`. `dataset_fn`
+would take a RecordIO dataset as input, decode and preprocessing the data as
+needed.
 
 For example, instead of:
 
-```
+```python
 def input_fn(records):
     feature_description = {
         "image": tf.io.FixedLenFeature([32, 32, 3], tf.float32),
@@ -106,7 +122,7 @@ def input_fn(records):
 
 Define `dataset_fn` instead:
 
-```
+```python
 def dataset_fn(dataset):
     def _parse_data(record):
         feature_description = {
@@ -132,7 +148,7 @@ def dataset_fn(dataset):
 
 For training-only, we can use a shared dataset as below:
 
-```       
+```python
 def data_generator(self):
     task = get_task()
     if no task, break
@@ -140,16 +156,20 @@ def data_generator(self):
         yield r
 
 # Create recordio dataset
+
 recordio_dataset = tf.data.Dataset.from_generator(
     data_generator, (tf.string), (tf.TensorShape([]))
-    
+
 # apply dataset_fn
+
 dataset = dataset_fn(recordio_dataset)
 
 # batching
+
 dataset = dataset.batch(minibatch)
 
 # training loop
+
 for d in dataset:
     features = d[0]
     labels = d[1]
@@ -160,37 +180,40 @@ for d in dataset:
         report_task_result()
 ```
 
-To support the full functionalities of the worker (training-only, training-with-evaluation, evaluation-only, predict-only), we need to keep track of the pending tasks to get:
+To support the full functionalities of the worker (training-only,
+training-with-evaluation, evaluation-only, predict-only), we need to keep track
+of the pending tasks to get:
 
 1. the current task type(training, evaluation, or predict).
 2. when a task finishes, so we can `report_task_result`.
 
-
 ### Roadmap for this implementaion
-1. Add prerequisite: 
-    * The master knows the type of the job from user provided arguments. Add an extra argument for the job type in worker initialization. 
-    * Add `dataset_fn` in model_zoo examples.
+
+1. Add prerequisite:
+   - The master knows the type of the job from user provided arguments. Add an
+extra argument for the job type in worker initialization.
+   - Add `dataset_fn` in model_zoo examples.
 2. Support training-only with a shared dataset.
-    * If the job type is not training-only, keep use the legacy code.
+   - If the job type is not training-only, keep use the legacy code.
 3. Add evaluation-only, predict-only support.
 4. Support training-with-evaluation.
-5. remove the legacy code, including `input_fn`. 
-
+5. remove the legacy code, including `input_fn`.
 
 ### Model Compute
-The TensorFlow eager mode comes at the expense of performance compared with the graph mode. [`tf.function`](https://www.tensorflow.org/beta/tutorials/eager/tf_function) can be used to accelerate the model compute parts(`compute_loss`, `compute_metrics`, `compute_predict`).
 
-#### Implementation
-Define `compute_loss`, `compute_metrics`, `compute_predict` as `tf.function`-decorated functions.
+The TensorFlow eager mode comes at the expense of performance compared with the
+graph mode.
+[`tf.function`](https://www.tensorflow.org/beta/tutorials/eager/tf_function)
+can be used to accelerate the model compute parts(`compute_loss`,
+`compute_metrics`, `compute_predict`).
+
+Define `compute_loss`, `compute_metrics`, `compute_predict` as
+`tf.function`-decorated functions.
 
 ### Expected perf after the optimization
+
 The timing below is from a prototype testing.
 
 Total Time | `compute_loss` | `get_model` | `report_gradient`
 ---|---|---|---
 23.8 | 4.2 | 5.4 | 7.6
-
-
-
-
-


### PR DESCRIPTION
This PR makes `/docs/design/archived/*.md` compliant to markdownlint rules.

After some manual fixes,  I deposited some heuristic auto-reformat rules into https://github.com/wangkuiyi/mdfmt.  This PR is generated from calling `mdfmt` with some manual changes that cannot be covered.

This PR also slightly changed the configuration `.markdownlinter.yaml`.