### PR TITLE
Reformat CODE_OF_CONDUCT and a few other documents

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,21 +14,21 @@ appearance, race, religion, or sexual identity and orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
+- The use of sexualized language or imagery and unwelcome sexual attention or
  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
  professional setting
 
 ## Our Responsibilities
@@ -67,10 +67,11 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+<https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>.
 
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+<https://www.contributor-covenant.org/faq>.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,14 @@
 # Release 0.1.0
 
 ## Major Features and Improvements
+
 - This is the first release of ElasticDL. It supports TensorFlow 2.0.
-- Includes a master-worker architecture, where the master controls task generation and entire job progress. Workers communicate with the master to get the tasks to execute and report execution results.
-- Supports different job types: training-only, training-with-evaluation, evaluation-only and prediction-only.
+- Includes a master-worker architecture, where the master controls task
+  generation and entire job progress. Workers communicate with the master to get
+  the tasks to execute and report execution results.
+- Supports different job types: training-only, training-with-evaluation,
+  evaluation-only and prediction-only.
 - Provides high-level APIs and CLI for training, evaluation and prediction.
-- Supports running in environments, including MiniKube, GCP, and on-prem clusters.
+- Supports running in environments, including MiniKube, GCP, and on-prem
+  clusters.
 - Adds experimental integration with SQLFlow for ODPS data source.

--- a/docs/tutorials/preprocessing_tutorial.md
+++ b/docs/tutorials/preprocessing_tutorial.md
@@ -9,9 +9,9 @@ TensorFlow. ElasticDL preprocessing provides a number of Keras layers to
 preprocess data directly in Keras models.
 For example, using ElasticDL preprocessing layers you could:
 
-* Normalize an input value by using the mean and standard deviation.
-* Convert floats to integers by assigning them to buckets and rounding.
-* Convert strings to integers by lookuping a vocabulary or hashing.
+- Normalize an input value by using the mean and standard deviation.
+- Convert floats to integers by assigning them to buckets and rounding.
+- Convert strings to integers by lookuping a vocabulary or hashing.
 
 ### Normalize input values
 

--- a/elasticdl/python/elasticdl/README.md
+++ b/elasticdl/python/elasticdl/README.md
@@ -5,11 +5,11 @@
 A model definition directory is needed to be created, the files in the directory
 are as follows:
 
-* (mandatory) A Python source file which defines the keras model and use the
+- (mandatory) A Python source file which defines the keras model and use the
   directory base name as the filename.
-* (mandatory) The file `__init__.py` is necessary.
-* (optional) Source files of other Python modules.
-* (optional) A requirements.txt file that lists dependencies required by the
+- (mandatory) The file `__init__.py` is necessary.
+- (optional) Source files of other Python modules.
+- (optional) A requirements.txt file that lists dependencies required by the
   above source files.
 
 There are several Keras examples provided in `model_zoo` directory.

--- a/elasticdl_preprocessing/README.md
+++ b/elasticdl_preprocessing/README.md
@@ -1,11 +1,20 @@
 # ElasticDL Preprocessing
 
-This is a feature preprocessing library provided by ElasticDL.  
+This is a feature preprocessing library provided by ElasticDL.
 It provides APIs in the following forms:
 
 - Keras layer
 - Feature column API
 
-This is an extension of the native [Keras Preprocessing Layers](https://www.tensorflow.org/versions/r2.2/api_docs/python/tf/keras/preprocessing) and [Feature Column API](https://www.tensorflow.org/versions/r2.2/api_docs/python/tf/feature_column) from TensorFlow. We can develop our model using the native high-level API from TensorFlow and our library. We can train this model using native TensorFlow or ElasticDL.  
+This is an extension of the native [Keras Preprocessing
+Layers](https://www.tensorflow.org/versions/r2.2/api_docs/python/tf/keras/preprocessing)
+and [Feature Column
+API](https://www.tensorflow.org/versions/r2.2/api_docs/python/tf/feature_column)
+from TensorFlow. We can develop our model using the native high-level API from
+TensorFlow and our library. We can train this model using native TensorFlow or
+ElasticDL.
 
-*Note: Some native [Keras Preprocess layers](https://github.com/tensorflow/community/pull/188) will be released in TF2.2. For the TF version <= 2.1, we will provide our implementation of the same functionality.*
+Note: Some native [Keras Preprocess
+layers](https://github.com/tensorflow/community/pull/188) will be released in
+TF2.2. For the TF version <= 2.1, we will provide our implementation of the same
+functionality.


### PR DESCRIPTION
This PR makes `CODE_OF_CONDUCT.md`, `RELEASE.md`, and a few others compliant to markdownlint rules.

After some manual fixes,  I deposited some heuristic auto-reformat rules into https://github.com/wangkuiyi/mdfmt.  This PR is generated from calling `mdfmt` with some manual changes that cannot be covered.

This PR also slightly changed the configuration `.markdownlinter.yaml`.