### PR TITLE
fix grpc.tools version

### DIFF
--- a/elasticdl/requirements.txt
+++ b/elasticdl/requirements.txt
@@ -1,4 +1,4 @@
-grpcio-tools
+grpcio-tools==1.29.0
 kubernetes==10.1.0
 docker
 pyrecordio>=0.0.6


### PR DESCRIPTION
grpc.tools release 1.30.0 today, which breaks the CI. This PR fixes the version to 1.29.0