### PR TITLE
Fix SameFileError exception.

### DIFF
--- a/elasticdl_client/api.py
+++ b/elasticdl_client/api.py
@@ -38,7 +38,10 @@ def init_zoo(args):
             raise RuntimeError(
                 "The cluster spec {} doesn't exist".format(cluster_spec_path)
             )
-        shutil.copy2(cluster_spec_path, os.getcwd())
+        try:
+            shutil.copy2(cluster_spec_path, os.getcwd())
+        except shutil.SameFileError:
+            pass
         cluster_spec_name = os.path.basename(cluster_spec_path)
 
     # Create the docker file

--- a/elasticdl_client/common/args.py
+++ b/elasticdl_client/common/args.py
@@ -16,7 +16,7 @@ from itertools import chain
 from elasticdl_client.common.constants import DistributionStrategy
 
 
-def add_zoo_init_arguments(parser):
+def add_zoo_init_params(parser):
     parser.add_argument(
         "--base_image",
         type=str,
@@ -38,7 +38,7 @@ def add_zoo_init_arguments(parser):
     )
 
 
-def add_zoo_build_arguments(parser):
+def add_zoo_build_params(parser):
     parser.add_argument(
         "path", type=str, help="The path where the build context locates."
     )
@@ -51,7 +51,7 @@ def add_zoo_build_arguments(parser):
     )
 
 
-def add_zoo_push_arguments(parser):
+def add_zoo_push_params(parser):
     parser.add_argument(
         "image",
         type=str,

--- a/elasticdl_client/main.py
+++ b/elasticdl_client/main.py
@@ -43,14 +43,14 @@ def build_argument_parser():
         "init", help="Initialize the model zoo."
     )
     zoo_init_parser.set_defaults(func=init_zoo)
-    args.add_zoo_init_arguments(zoo_init_parser)
+    args.add_zoo_init_params(zoo_init_parser)
 
     # elasticdl zoo build
     zoo_build_parser = zoo_subparsers.add_parser(
         "build", help="Build a docker image for the model zoo."
     )
     zoo_build_parser.set_defaults(func=build_zoo)
-    args.add_zoo_build_arguments(zoo_build_parser)
+    args.add_zoo_build_params(zoo_build_parser)
 
     # elasticdl zoo push
     zoo_push_parser = zoo_subparsers.add_parser(
@@ -59,7 +59,7 @@ def build_argument_parser():
         "ElasticDL job.",
     )
     zoo_push_parser.set_defaults(func=push_zoo)
-    args.add_zoo_push_arguments(zoo_push_parser)
+    args.add_zoo_push_params(zoo_push_parser)
 
     # elasticdl train
     train_parser = subparsers.add_parser(


### PR DESCRIPTION
- Fix the SameFileError exception while using shuilts.copy2
- rename `add_zoo_init_arguments` to `add_zoo_init_params`, make the naming convention to be aligned in api.py