### PR TITLE
Get the elasticdl_ps path dynamically while building the docker image for elasticdl job.

### DIFF
--- a/elasticdl_client/api.py
+++ b/elasticdl_client/api.py
@@ -53,7 +53,9 @@ RUN pip install elasticdl_preprocessing\
  --extra-index-url={{ EXTRA_PYPI_INDEX }}
 
 RUN pip install elasticdl --extra-index-url={{ EXTRA_PYPI_INDEX }}
-ENV PATH /usr/local/lib/python3.6/site-packages/elasticdl/go/bin:$PATH
+RUN /bin/bash -c\
+ 'PYTHON_PKG_PATH=$(pip3 show elasticdl | grep "Location:" | cut -d " " -f2);\
+ echo "PATH=${PYTHON_PKG_PATH}/elasticdl/go/bin:$PATH" >> /root/.bashrc'
 
 COPY . /model_zoo
 RUN pip install -r /model_zoo/requirements.txt\


### PR DESCRIPTION
Fix #2123 

For the base image `python:3.6`, the path of `elasticdl_ps` is `/usr/local/lib/python3.6/site-packages/elasticdl/go/bin`.
For the base image `tensorflow/tensorflow:2.1.0-py3`, the path of `elasticdl_ps` is `/usr/local/lib/python3.6/dist-packages/elasticdl/go/bin`.
Since the path can be different in various base images, we cannot hard code the path of `elasticdl_ps` in the Dockerfile.

In this solution, we get the installed path dynamically after `pip install elasticdl`, and then append the value to the PATH environment variable.