### PR TITLE
Add the section to authorize the job execution.

### DIFF
--- a/docs/tutorials/elasticdl_local.md
+++ b/docs/tutorials/elasticdl_local.md
@@ -70,7 +70,7 @@ configuration YAML file.
 ```bash
 git clone https://github.com/sql-machine-learning/elasticdl.git
 cd elasticdl
-kubectl apply -f ../elasticdl/manifests/elasticdl-rbac.yaml
+kubectl apply -f elasticdl/manifests/elasticdl-rbac.yaml
 ```
 
 ## Install ElasticDL Client Tool

--- a/docs/tutorials/elasticdl_local.md
+++ b/docs/tutorials/elasticdl_local.md
@@ -63,6 +63,16 @@ The above command-line option `--mount-string` exposes the directory `./data` on
 the host to Minikube, so we can bind mount it into containers running on the
 local Kubernetes cluster.
 
+The following command is necessary to enable [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+of Kubernetes. At first, we need retrieves the source code to get the RBAC
+configuration YAML file.
+
+```bash
+git clone https://github.com/sql-machine-learning/elasticdl.git
+cd elasticdl
+kubectl apply -f ../elasticdl/manifests/elasticdl-rbac.yaml
+```
+
 ## Install ElasticDL Client Tool
 
 ```bash
@@ -75,32 +85,16 @@ Kubernetes runs Docker containers, so we need to release the training program,
 composed of user-defined models and ElasticDL, into a Docker image.
 
 In this tutorial, we use a predefined model in the ElasticDL repository. The
-following command retrieves the source code of the user-defined model into
-`./elasticdl/model_zoo`.
-
-```bash
-git clone https://github.com/sql-machine-learning/elasticdl.git
-```
+repository has been already cloned in the step above. And the model definitions
+are in the `model_zoo` folder.
 
 The following commands build the Docker image `elasticdl:mnist`. Please feel
 free to name it in any other name you like.
 
 ```bash
-cd elasticdl/model_zoo
+cd model_zoo
 elasticdl zoo init
 elasticdl zoo build --image=elasticdl:mnist .
-```
-
-## Authorize the Job Execution
-
-If you are going to run ElasticDL job in Minikube for the first time. Please
-execute the following command to authorize the execution. As ElasticDL is a
-Kubernetes-native deep learning framework, we execute it to authorize the
-master pod to create and monitor the worker/ps pods. The command need to be
-executed only once.
-
-```bash
-kubectl apply -f ../elasticdl/manifests/elasticdl-rbac.yaml
 ```
 
 ## Submit the Training Job

--- a/docs/tutorials/elasticdl_local.md
+++ b/docs/tutorials/elasticdl_local.md
@@ -56,7 +56,6 @@ The following command to start a Kubernetes cluster locally using Minikube.
 minikube start --vm-driver=hyperkit \
   --cpus 2 --memory 6144 --disk-size=50gb \
   --mount=true --mount-string="./data:/data"
-kubectl apply -f elasticdl/manifests/elasticdl-rbac.yaml
 eval $(minikube docker-env)
 ```
 
@@ -87,9 +86,19 @@ The following commands build the Docker image `elasticdl:mnist`. Please feel
 free to name it in any other name you like.
 
 ```bash
-cd model_zoo
+cd elasticdl/model_zoo
 elasticdl zoo init
 elasticdl zoo build --image=elasticdl:mnist .
+```
+
+## Authorize the Job Execution
+
+If you are going to run ElasticDL job in Minikube for the first time. Please
+execute the following command to authorize the execution. The command need
+to be executed only once.
+
+```bash
+kubectl apply -f ../elasticdl/manifests/elasticdl-rbac.yaml
 ```
 
 ## Submit the Training Job

--- a/docs/tutorials/elasticdl_local.md
+++ b/docs/tutorials/elasticdl_local.md
@@ -94,8 +94,10 @@ elasticdl zoo build --image=elasticdl:mnist .
 ## Authorize the Job Execution
 
 If you are going to run ElasticDL job in Minikube for the first time. Please
-execute the following command to authorize the execution. The command need
-to be executed only once.
+execute the following command to authorize the execution. As ElasticDL is a
+Kubernetes-native deep learning framework. We need authorize the master pod
+to create and monitor the worker/ps pods. The command need to be executed
+only once.
 
 ```bash
 kubectl apply -f ../elasticdl/manifests/elasticdl-rbac.yaml

--- a/docs/tutorials/elasticdl_local.md
+++ b/docs/tutorials/elasticdl_local.md
@@ -95,9 +95,9 @@ elasticdl zoo build --image=elasticdl:mnist .
 
 If you are going to run ElasticDL job in Minikube for the first time. Please
 execute the following command to authorize the execution. As ElasticDL is a
-Kubernetes-native deep learning framework. We need authorize the master pod
-to create and monitor the worker/ps pods. The command need to be executed
-only once.
+Kubernetes-native deep learning framework, we execute it to authorize the
+master pod to create and monitor the worker/ps pods. The command need to be
+executed only once.
 
 ```bash
 kubectl apply -f ../elasticdl/manifests/elasticdl-rbac.yaml


### PR DESCRIPTION
`kubectl apply -f ../elasticdl/manifests/elasticdl-rbac.yaml` need to be executed after git clone elasticdl repo.

In the next step, we can add a command in elasticdl_client to do the work of `kubectl apply -f ../elasticdl/manifests/elasticdl-rbac.yaml` in order to initialize the execution environment in Minikube. The task is tracked in the issue #2154 