### PR TITLE
Fix allreduce args and workdir

### DIFF
--- a/elasticdl/docker/Dockerfile
+++ b/elasticdl/docker/Dockerfile
@@ -5,9 +5,9 @@ FROM ${BASE_IMAGE} as dev
 ARG EXTRA_PYPI_INDEX=https://pypi.org/simple
 
 RUN apt-get -qq update && \
-    apt-get -qq install -y unzip curl git software-properties-common g++ wget \
-                       shellcheck libeigen3-dev clang-format > /dev/null && \
-    python -m pip install --quiet --upgrade pip
+        apt-get -qq install -y unzip curl git software-properties-common g++ wget \
+        shellcheck libeigen3-dev clang-format > /dev/null && \
+        python -m pip install --quiet --upgrade pip
 
 COPY elasticdl_client/requirements.txt /requirements.txt
 RUN python -m pip install --quiet -r /requirements.txt \
@@ -22,7 +22,7 @@ RUN python -m pip install --quiet -r /requirements.txt \
 COPY elasticdl_preprocessing/requirements-dev.txt /requirements-dev.txt
 RUN python -m pip install --quiet -r /requirements-dev.txt \
         --extra-index-url=$EXTRA_PYPI_INDEX \
-    && rm /requirements-dev.txt
+        && rm /requirements-dev.txt
 
 COPY elasticdl/requirements.txt /requirements.txt
 RUN python -m pip install --quiet -r /requirements.txt \
@@ -32,12 +32,12 @@ RUN python -m pip install --quiet -r /requirements.txt \
 COPY elasticdl/requirements-dev.txt /requirements-dev.txt
 RUN python -m pip install --quiet -r /requirements-dev.txt \
         --extra-index-url=$EXTRA_PYPI_INDEX \
-    && rm /requirements-dev.txt
+        && rm /requirements-dev.txt
 
 ENV TF_PATH /tmp/tensorflow
 RUN cd /tmp \
-    && git clone --depth=1 --branch v2.2.0-rc0 \
-           https://github.com/tensorflow/tensorflow
+        && git clone --depth=1 --branch v2.2.0-rc0 \
+        https://github.com/tensorflow/tensorflow
 
 # Install Go and related tools
 ARG GO_MIRROR_URL=https://dl.google.com/go
@@ -58,16 +58,14 @@ COPY elasticdl/python/data/recordio_gen/heart_recordio_gen.py /scripts/heart_rec
 
 FROM dev as allreduce
 
-WORKDIR /root/
-
 # Note that pip is having issue downloading PyTorch on manylinux so we use curl
 # to download it instead
 RUN curl -sLo torch-1.4.0-cp36-cp36m-manylinux1_x86_64.whl \
-  https://files.pythonhosted.org/packages/24/19/4804aea17cd136f1705a5e98a00618cb8f6ccc375ad8bfa437408e09d058/torch-1.4.0-cp36-cp36m-manylinux1_x86_64.whl
+        https://files.pythonhosted.org/packages/24/19/4804aea17cd136f1705a5e98a00618cb8f6ccc375ad8bfa437408e09d058/torch-1.4.0-cp36-cp36m-manylinux1_x86_64.whl
 RUN python -m pip install --quiet torch-1.4.0-cp36-cp36m-manylinux1_x86_64.whl \
         && rm torch-1.4.0-cp36-cp36m-manylinux1_x86_64.whl
 
-RUN git clone --depth=1 https://github.com/caicloud/ftlib.git
+RUN cd /root && git clone --depth=1 https://github.com/caicloud/ftlib.git
 RUN cd /root/ftlib && python -m pip install --quiet -r requirements.txt
 RUN cd /root/ftlib/ftlib/consensus/gossip && bash ./gen_shared_lib.sh
 RUN cp -r /root/ftlib/ftlib /usr/local/lib/python3.6/dist-packages/ftlib

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -147,11 +147,14 @@ class InstanceManager(object):
         logger.info("Starting worker: %d" % worker_id)
         bash_command = self._worker_args[1]
         bash_command += " --worker_id {}".format(worker_id)
-        bash_command += " --ps_addrs {}".format(self._ps_addrs)
+        if self._ps_addrs:
+            bash_command += " --ps_addrs {}".format(self._ps_addrs)
         if self._log_file_path:
             bash_command += BashCommandTemplate.REDIRECTION.format(
                 self._log_file_path
             )
+        for extra_arg in self._worker_args[2:]:
+            bash_command += " {}".format(extra_arg)
         worker_args = [self._worker_args[0], bash_command]
         with self._lock:
             pod = self._k8s_client.create_worker(


### PR DESCRIPTION
1. If using allreduce, master should not set worker args `--ps_addrs`.
1. Make sure to pass extra args (which includes `collective_communicator_service_name` for allreduce) to worker.
1. Do not change WORKDIR to `/root` for allreduce to be consistent with `ps`.

fix #2170 
fix #2169 