### PR TITLE
Print help information instead of throwing exception if the argument parsing fails.

### DIFF
--- a/elasticdl_client/main.py
+++ b/elasticdl_client/main.py
@@ -94,7 +94,12 @@ def main():
         parser.print_help(sys.stderr)
         sys.exit(1)
 
-    args, _ = parser.parse_known_args()
+    try:
+        args, _ = parser.parse_known_args()
+    except TypeError:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
     args.func(args)
 
 


### PR DESCRIPTION
Fix #2178 