### PR TITLE
BUGFIX: elasticdl_ps is not found if the base image is tensorflow/tensorflow.

### DIFF
--- a/elasticdl/docker/Dockerfile.ci
+++ b/elasticdl/docker/Dockerfile.ci
@@ -31,7 +31,11 @@ RUN python -m pip install --quiet /elasticdl-develop-py3-none-any.whl \
     && rm /elasticdl-develop-py3-none-any.whl
 
 # Add elasticdl_ps to system path
-ENV PATH /usr/local/lib/python3.6/dist-packages/elasticdl/go/bin:$PATH
+RUN /bin/bash -c \
+        'PYTHON_PKG_PATH=$(pip3 show elasticdl | grep "Location:" | cut -d " " -f2); \
+        echo "PATH=${PYTHON_PKG_PATH}/elasticdl/go/bin:$PATH" >> \
+            /root/.bashrc_elasticdl; \
+        echo ". /root/.bashrc_elasticdl" >> /root/.bashrc'
 
 # Generate mnist checkpoint for evaluation and prediction
 COPY scripts/travis/gen_mnist_checkpoint.py /gen_mnist_checkpoint.py

--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -437,7 +437,7 @@ class Master(object):
                 # of `elasticdl_ps` into the PATH environment variable.
                 ps_args = [
                     "source",
-                    "/root/.bashrc",
+                    "/root/.bashrc_elasticdl",
                     "&&",
                     ps_command,
                 ]

--- a/elasticdl_client/api.py
+++ b/elasticdl_client/api.py
@@ -55,7 +55,9 @@ RUN pip install elasticdl_preprocessing\
 RUN pip install elasticdl --extra-index-url={{ EXTRA_PYPI_INDEX }}
 RUN /bin/bash -c\
  'PYTHON_PKG_PATH=$(pip3 show elasticdl | grep "Location:" | cut -d " " -f2);\
- echo "PATH=${PYTHON_PKG_PATH}/elasticdl/go/bin:$PATH" >> /root/.bashrc'
+ echo "PATH=${PYTHON_PKG_PATH}/elasticdl/go/bin:$PATH" >>\
+ /root/.bashrc_elasticdl;\
+ echo ". /root/.bashrc_elasticdl" >> /root/.bashrc'
 
 COPY {{MODEL_ZOO_PATH}} /model_zoo
 RUN pip install -r /model_zoo/requirements.txt\

--- a/elasticdl_client/main.py
+++ b/elasticdl_client/main.py
@@ -94,7 +94,12 @@ def main():
         parser.print_help(sys.stderr)
         sys.exit(1)
 
-    args, _ = parser.parse_known_args()
+    try:
+        args, _ = parser.parse_known_args()
+    except TypeError:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
     args.func(args)
 
 


### PR DESCRIPTION
In the previous implementation, we append the installation path of `elasticdl_ps` binary into the PATH environment variable in the /root/.bash. The command for PS pod is `bash -c "source /root/.bashrc && elasticdl_ps ..."` to make sure `elasticdl_ps` can be found.

But the problem is that if using `tensorflow/tensorflow:2.1.0-py3` as the image, the `.bashrc` contains the following command at the head.

```SHELL
[ -z "$PS1" ] && return
```
If not running interactively, it doesn't do anything.

In order to fix this, we put the command of adding the `elasticdl_ps` path into envrionment variable into a new separate file `/root/.bashrc_elasticdl`, and then execute `source /root/.bashrc_elasticdl` in PS pod instead.