### PR TITLE
Only the last worker waits using AllReduce.

### DIFF
--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -386,6 +386,13 @@ class InstanceManager(object):
             # tolerance.
             self._start_ps(ps_id)
 
+    def get_alive_workers(self):
+        alive_workers = []
+        for pod_name, phase in self._worker_pods_phase.values():
+            if phase == PodStatus.RUNNING:
+                alive_workers.append(pod_name)
+        return alive_workers
+
     @property
     def ps_addrs(self):
         return self._ps_addrs

--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -160,11 +160,11 @@ class Master(object):
         self.task_d.add_deferred_callback_create_train_end_task()
         self.evaluation_service = self._create_evaluation_service(args)
 
-        # Initialize master service
-        self.master_servicer, self.server = self._create_master_service(args)
-
         # Initialize instance manager
         self.instance_manager = self._create_instance_manager(args)
+
+        # Initialize master service
+        self.master_servicer, self.server = self._create_master_service(args)
 
         self._should_stop = False
         self._exit_code = 0
@@ -376,6 +376,7 @@ class Master(object):
             args.minibatch_size,
             self.task_d,
             evaluation_service=self.evaluation_service,
+            master=self,
         )
         elasticdl_pb2_grpc.add_MasterServicer_to_server(
             master_servicer, server

--- a/elasticdl/python/master/servicer.py
+++ b/elasticdl/python/master/servicer.py
@@ -84,6 +84,8 @@ class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
                 self._master.distribution_strategy
                 == DistributionStrategy.ALLREDUCE
             ):
+                # If there is no more task, master only send wait task to
+                # the last worker and other workers exit.
                 if len(self._master.instance_manager.get_alive_workers()) == 1:
                     res.type = res.type = elasticdl_pb2.WAIT
             else:

--- a/elasticdl/python/master/servicer.py
+++ b/elasticdl/python/master/servicer.py
@@ -87,7 +87,7 @@ class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
                 # If there is no more task, master only send wait task to
                 # the last worker and other workers exit.
                 if len(self._master.instance_manager.get_alive_workers()) == 1:
-                    res.type = res.type = elasticdl_pb2.WAIT
+                    res.type = elasticdl_pb2.WAIT
             else:
                 res.type = elasticdl_pb2.WAIT
         with self._lock:

--- a/elasticdl/python/master/servicer.py
+++ b/elasticdl/python/master/servicer.py
@@ -19,13 +19,14 @@ from google.protobuf import empty_pb2
 
 from elasticdl.proto import elasticdl_pb2, elasticdl_pb2_grpc
 from elasticdl.python.common.log_utils import default_logger as logger
+from elasticdl_client.common.constants import DistributionStrategy
 
 
 class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
     """Master service implementation"""
 
     def __init__(
-        self, minibatch_size, task_d, evaluation_service,
+        self, minibatch_size, task_d, evaluation_service, master,
     ):
         # TODO: group params together into a single object.
         self._task_d = task_d
@@ -34,6 +35,7 @@ class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
         self._version = 0
 
         self._evaluation_service = evaluation_service
+        self._master = master
         self._task_complete_times = {
             elasticdl_pb2.EVALUATION: [],
             elasticdl_pb2.TRAINING: [],
@@ -78,7 +80,14 @@ class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
             # we are trying to pop and invoke the callback.
             # Then the master tells the worker to wait
             # in case of new tasks later.
-            res.type = elasticdl_pb2.WAIT
+            if (
+                self._master.distribution_strategy
+                == DistributionStrategy.ALLREDUCE
+            ):
+                if len(self._master.instance_manager.get_alive_workers()) == 1:
+                    res.type = res.type = elasticdl_pb2.WAIT
+            else:
+                res.type = elasticdl_pb2.WAIT
         with self._lock:
             self._worker_liveness_time[request.worker_id] = time.time()
         return res

--- a/elasticdl/python/tests/evaluation_service_test.py
+++ b/elasticdl/python/tests/evaluation_service_test.py
@@ -105,7 +105,9 @@ class EvaluationServiceTest(unittest.TestCase):
             None, task_d, 10, 20, 0, False, _eval_metrics_fn,
         )
 
-        _ = MasterServicer(2, task_d, evaluation_service=evaluation_service,)
+        _ = MasterServicer(
+            2, task_d, evaluation_service=evaluation_service, master=None
+        )
 
         # No checkpoint available
         self.assertFalse(evaluation_service.try_to_create_new_job())
@@ -130,7 +132,9 @@ class EvaluationServiceTest(unittest.TestCase):
         )
         task_d.set_evaluation_service(evaluation_service)
 
-        _ = MasterServicer(2, task_d, evaluation_service=evaluation_service,)
+        _ = MasterServicer(
+            2, task_d, evaluation_service=evaluation_service, master=None,
+        )
 
         self.assertEqual(8, len(task_d._eval_todo))
         for i in range(8):

--- a/elasticdl/python/tests/servicer_test.py
+++ b/elasticdl/python/tests/servicer_test.py
@@ -51,22 +51,23 @@ class SimpleModel(tf.keras.Model):
 
 class ServicerTest(unittest.TestCase):
     def testGetEmptyTask(self):
-        master = MasterServicer(
+        master_servicer = MasterServicer(
             3,
             _TaskDispatcher({}, {}, {}, records_per_task=3, num_epochs=2),
             evaluation_service=None,
+            master=None,
         )
 
         req = elasticdl_pb2.GetTaskRequest()
 
         # No task yet, make sure the returned versions are as expected.
         req.worker_id = 1
-        task = master.get_task(req, None)
+        task = master_servicer.get_task(req, None)
         self.assertEqual("", task.shard_name)
         self.assertEqual(0, task.model_version)
 
-        master._version = 1
-        task = master.get_task(req, None)
+        master_servicer._version = 1
+        task = master_servicer.get_task(req, None)
         self.assertEqual("", task.shard_name)
         self.assertEqual(1, task.model_version)
 
@@ -78,7 +79,9 @@ class ServicerTest(unittest.TestCase):
             records_per_task=3,
             num_epochs=2,
         )
-        master = MasterServicer(3, task_d, evaluation_service=None,)
+        master = MasterServicer(
+            3, task_d, evaluation_service=None, master=None
+        )
 
         # task to number of runs.
         tasks = defaultdict(int)

--- a/elasticdl/python/tests/test_utils.py
+++ b/elasticdl/python/tests/test_utils.py
@@ -411,7 +411,7 @@ def distributed_train_and_evaluate(
     task_d.set_evaluation_service(evaluation_service)
 
     master = MasterServicer(
-        batch_size, task_d, evaluation_service=evaluation_service,
+        batch_size, task_d, evaluation_service=evaluation_service, master=None,
     )
     callbacks = [
         callback_class(master, worker) for callback_class in callback_classes


### PR DESCRIPTION
Fix #1895.

Master only sends wait tasks to the last worker and other workers exit if there is no more task. The training will hang if some workers wait without task using AllReduce.