### PR TITLE
remove unused callback args

### DIFF
--- a/elasticdl/python/tests/in_process_master.py
+++ b/elasticdl/python/tests/in_process_master.py
@@ -12,13 +12,11 @@
 # limitations under the License.
 
 """In process master for unittests"""
-from elasticdl.python.tests import test_call_back
 
 
 class InProcessMaster(object):
-    def __init__(self, master, callbacks=[]):
+    def __init__(self, master):
         self._m = master
-        self._callbacks = callbacks
 
     def get_task(self, req):
         return self._m.get_task(req, None)
@@ -32,11 +30,6 @@ class InProcessMaster(object):
     """
 
     def report_evaluation_metrics(self, req):
-        for callback in self._callbacks:
-            if test_call_back.ON_REPORT_EVALUATION_METRICS_BEGIN in (
-                callback.call_times
-            ):
-                callback()
         return self._m.report_evaluation_metrics(req, None)
 
     def report_task_result(self, req):

--- a/elasticdl/python/tests/test_utils.py
+++ b/elasticdl/python/tests/test_utils.py
@@ -286,7 +286,6 @@ def distributed_train_and_evaluate(
     loss="loss",
     training=True,
     dataset_name=DatasetName.IMAGE_DEFAULT,
-    callback_classes=[],
     use_async=False,
     get_model_steps=1,
     ps_channels=None,
@@ -310,8 +309,6 @@ def distributed_train_and_evaluate(
         training: True for job type `TRAIN_WITH_EVALUATION`, False for
             job type `EVALUATION`.
         dataset_name: A dataset name from `DatasetName`.
-        callback_classes: A List of callbacks that will be called at given
-            stages of the training procedure.
         use_async: A bool. True if using asynchronous updates.
         get_model_steps: Worker will perform `get_model` from the parameter
             server every this many steps.
@@ -413,11 +410,8 @@ def distributed_train_and_evaluate(
     master = MasterServicer(
         batch_size, task_d, evaluation_service=evaluation_service,
     )
-    callbacks = [
-        callback_class(master, worker) for callback_class in callback_classes
-    ]
 
-    in_process_master = InProcessMaster(master, callbacks)
+    in_process_master = InProcessMaster(master)
     worker._stub = in_process_master
     for pservicer in pservers:
         pservicer._master_stub = in_process_master


### PR DESCRIPTION
the prepositive task of #2193 . The `callbacks` argument is non referenced.
