### PR TITLE
Delete the task_d argument in MasterServicer

### DIFF
--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -374,7 +374,6 @@ class Master(object):
         )
         master_servicer = MasterServicer(
             args.minibatch_size,
-            self.task_d,
             evaluation_service=self.evaluation_service,
             master=self,
         )

--- a/elasticdl/python/master/servicer.py
+++ b/elasticdl/python/master/servicer.py
@@ -26,10 +26,12 @@ class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
     """Master service implementation"""
 
     def __init__(
-        self, minibatch_size, task_d, evaluation_service, master,
+        self, minibatch_size, evaluation_service, master,
     ):
         # TODO: group params together into a single object.
-        self._task_d = task_d
+        self._task_d = master.task_d
+        self._instance_manager = master.instance_manager
+        self._distribution_strategy = master.distribution_strategy
         self._lock = threading.Lock()
         self._minibatch_size = minibatch_size
         self._version = 0
@@ -81,12 +83,11 @@ class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
             # Then the master tells the worker to wait
             # in case of new tasks later.
             if (
-                self._master.distribution_strategy
-                == DistributionStrategy.ALLREDUCE
+                self._distribution_strategy == DistributionStrategy.ALLREDUCE
             ):
                 # If there is no more task, master only send wait task to
                 # the last worker and other workers exit.
-                if len(self._master.instance_manager.get_alive_workers()) == 1:
+                if len(self._instance_manager.get_alive_workers()) == 1:
                     res.type = elasticdl_pb2.WAIT
             else:
                 res.type = elasticdl_pb2.WAIT

--- a/elasticdl/python/master/servicer.py
+++ b/elasticdl/python/master/servicer.py
@@ -82,9 +82,7 @@ class MasterServicer(elasticdl_pb2_grpc.MasterServicer):
             # we are trying to pop and invoke the callback.
             # Then the master tells the worker to wait
             # in case of new tasks later.
-            if (
-                self._distribution_strategy == DistributionStrategy.ALLREDUCE
-            ):
+            if self._distribution_strategy == DistributionStrategy.ALLREDUCE:
                 # If there is no more task, master only send wait task to
                 # the last worker and other workers exit.
                 if len(self._instance_manager.get_alive_workers()) == 1:

--- a/elasticdl/python/tests/evaluation_service_test.py
+++ b/elasticdl/python/tests/evaluation_service_test.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import Mock
 
 import numpy as np
 import tensorflow as tf
@@ -105,8 +106,11 @@ class EvaluationServiceTest(unittest.TestCase):
             None, task_d, 10, 20, 0, False, _eval_metrics_fn,
         )
 
+        master = Mock(
+            task_d=task_d, instance_manager=None, distribution_strategy=None,
+        )
         _ = MasterServicer(
-            2, task_d, evaluation_service=evaluation_service, master=None
+            2, evaluation_service=evaluation_service, master=master
         )
 
         # No checkpoint available
@@ -132,8 +136,12 @@ class EvaluationServiceTest(unittest.TestCase):
         )
         task_d.set_evaluation_service(evaluation_service)
 
+        master = Mock(
+            task_d=task_d, instance_manager=None, distribution_strategy=None,
+        )
+
         _ = MasterServicer(
-            2, task_d, evaluation_service=evaluation_service, master=None,
+            2, evaluation_service=evaluation_service, master=master,
         )
 
         self.assertEqual(8, len(task_d._eval_todo))

--- a/elasticdl/python/tests/servicer_test.py
+++ b/elasticdl/python/tests/servicer_test.py
@@ -14,9 +14,10 @@
 import random
 import unittest
 from collections import defaultdict
+from unittest.mock import Mock
 
 import tensorflow as tf
-from unittest.mock import Mock
+
 from elasticdl.proto import elasticdl_pb2
 from elasticdl.python.master.servicer import MasterServicer
 from elasticdl.python.master.task_dispatcher import _TaskDispatcher
@@ -52,9 +53,7 @@ class SimpleModel(tf.keras.Model):
 class ServicerTest(unittest.TestCase):
     def setUp(self):
         self.master = Mock(
-            task_d=None,
-            instance_manager=None,
-            distribution_strategy=None,
+            task_d=None, instance_manager=None, distribution_strategy=None,
         )
 
     def test_get_empty_task(self):
@@ -62,9 +61,7 @@ class ServicerTest(unittest.TestCase):
             {}, {}, {}, records_per_task=3, num_epochs=2
         )
         master_servicer = MasterServicer(
-            3,
-            evaluation_service=None,
-            master=self.master,
+            3, evaluation_service=None, master=self.master,
         )
 
         req = elasticdl_pb2.GetTaskRequest()
@@ -88,9 +85,7 @@ class ServicerTest(unittest.TestCase):
             records_per_task=3,
             num_epochs=2,
         )
-        master = MasterServicer(
-            3, evaluation_service=None, master=self.master
-        )
+        master = MasterServicer(3, evaluation_service=None, master=self.master)
 
         # task to number of runs.
         tasks = defaultdict(int)

--- a/elasticdl/python/tests/test_utils.py
+++ b/elasticdl/python/tests/test_utils.py
@@ -17,6 +17,7 @@ import tempfile
 from collections.__init__ import namedtuple
 from contextlib import closing
 from pathlib import Path
+from unittest.mock import Mock
 
 import grpc
 import numpy as np
@@ -409,12 +410,13 @@ def distributed_train_and_evaluate(
         )
     task_d.set_evaluation_service(evaluation_service)
 
+    master = Mock(
+        task_d=task_d, instance_manager=None, distribution_strategy=None,
+    )
+
     def master_creator():
         return MasterServicer(
-            batch_size,
-            task_d,
-            evaluation_service=evaluation_service,
-            master=None,
+            batch_size, evaluation_service=evaluation_service, master=master,
         )
 
     svc, port = _server(master_creator)


### PR DESCRIPTION
The `task_id` is an attribute of the `master`. We don't need to set the `task_d` if we have set the `master` in `MasterServicer`.