### PR TITLE
Set learning rate 0.01 for the mnist model.

### DIFF
--- a/model_zoo/mnist/mnist_functional_api.py
+++ b/model_zoo/mnist/mnist_functional_api.py
@@ -63,7 +63,7 @@ def loss(labels, predictions):
     )
 
 
-def optimizer(lr=0.1):
+def optimizer(lr=0.01):
     return tf.optimizers.SGD(lr)
 
 


### PR DESCRIPTION
lr=0.1 may be big for AllReduce and the training cannot converge.