### PR TITLE
handle pod creation crash

### DIFF
--- a/elasticdl/python/common/k8s_client.py
+++ b/elasticdl/python/common/k8s_client.py
@@ -103,7 +103,7 @@ class Client(BaseClient):
     def _periodic_call(self):
         while True:
             self._periodic_call_func()
-            time.sleep(30)
+            time.sleep(15)
 
     def _get_service_address(self, service_name, port):
         return "%s.%s.svc:%d" % (service_name, self.namespace, port)

--- a/elasticdl/python/common/k8s_client.py
+++ b/elasticdl/python/common/k8s_client.py
@@ -45,6 +45,7 @@ class Client(BaseClient):
         namespace,
         job_name,
         event_callback=None,
+        periodic_call_func=None,
         cluster_spec="",
         force_use_kube_config_file=False
     ):
@@ -59,6 +60,7 @@ class Client(BaseClient):
                 Used as pod name prefix and value for "elasticdl" label.
             event_callback: If not None, an event watcher will be created and
                 events passed to the callback.
+            periodic_call_func: If not None, call this method periodically.
             force_use_kube_config_file: If true, force to load the cluster
                 config from ~/.kube/config. Otherwise, if it's in a process
                 running in a K8S environment, it loads the incluster config,
@@ -72,9 +74,14 @@ class Client(BaseClient):
             force_use_kube_config_file=force_use_kube_config_file,
         )
         self._event_cb = event_callback
+        self._periodic_call_func = periodic_call_func
         if self._event_cb:
             threading.Thread(
                 target=self._watch, name="event_watcher", daemon=True
+            ).start()
+        if self._periodic_call_func:
+            threading.Thread(
+                target=self._periodic_call, name="periodic_call", daemon=True
             ).start()
 
     def _watch(self):
@@ -92,6 +99,11 @@ class Client(BaseClient):
             # In case of any flaky issue causing exceptions, we wait for little
             # time and retry.
             time.sleep(5)
+
+    def _periodic_call(self):
+        while True:
+            self._periodic_call_func()
+            time.sleep(30)
 
     def _get_service_address(self, service_name, port):
         return "%s.%s.svc:%d" % (service_name, self.namespace, port)
@@ -167,7 +179,11 @@ class Client(BaseClient):
         # Add replica type and index
         pod.metadata.labels[ELASTICDL_REPLICA_TYPE_KEY] = type_key
         pod.metadata.labels[ELASTICDL_REPLICA_INDEX_KEY] = str(index_key)
-        return self.client.create_namespaced_pod(self.namespace, pod)
+        try:
+            return self.client.create_namespaced_pod(self.namespace, pod)
+        except client.rest.ApiException as e:
+            logger.warning("Failed to create %s pod: %s\n" % (pod_name, e))
+            return None
 
     def create_worker(self, **kargs):
         pod_name = self.get_worker_pod_name(kargs["worker_id"])

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -265,22 +265,26 @@ class InstanceManager(object):
     def stop_relaunch_and_remove_pods(self, pod_type):
         if pod_type == "worker":
             self._relaunch_deleted_live_worker = False
-            for worker_id in self._worker_pods_ip_phase:
-                self._k8s_client.delete_worker(worker_id)
+            ids = self._worker_pods_ip_phase
+            delete_func = self._k8s_client.delete_worker
         elif pod_type == "ps":
             self._relaunch_deleted_live_ps = False
-            for ps_id in self._ps_pods_phase:
-                self._k8s_client.delete_ps(ps_id)
+            ids = self._ps_pods_phase
+            delete_func = self._k8s_client.delete_ps
+        for id in ids:
+            delete_func(id)
 
     def get_pod_counter(self, pod_type):
+        worker_counter = Counter(
+            [v for _, _, v in self._worker_pods_ip_phase.values()]
+        )
+        ps_counter = Counter(
+            [v for _, _, v in self._worker_pods_ip_phase.values()]
+        )
         if pod_type == "worker":
-            return Counter(
-                [v for _, _, v in self._worker_pods_ip_phase.values()]
-            )
+            return worker_counter
         elif pod_type == "ps":
-            return Counter(
-                [v for _, _, v in self._worker_pods_ip_phase.values()]
-            )
+            return ps_counter
         else:
             return None
 

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -263,28 +263,26 @@ class InstanceManager(object):
         self._k8s_client.delete_ps(ps_id)
 
     def stop_relaunch_and_remove_pods(self, pod_type):
-        with self._lock:
-            if pod_type == "worker":
-                self._relaunch_deleted_live_worker = False
-                for worker_id in self._worker_pods_ip_phase:
-                    self._k8s_client.delete_worker(worker_id)
-            elif pod_type == "ps":
-                self._relaunch_deleted_live_ps = False
-                for ps_id in self._ps_pods_phase:
-                    self._k8s_client.delete_ps(ps_id)
+        if pod_type == "worker":
+            self._relaunch_deleted_live_worker = False
+            for worker_id in self._worker_pods_ip_phase:
+                self._k8s_client.delete_worker(worker_id)
+        elif pod_type == "ps":
+            self._relaunch_deleted_live_ps = False
+            for ps_id in self._ps_pods_phase:
+                self._k8s_client.delete_ps(ps_id)
 
     def get_pod_counter(self, pod_type):
-        with self._lock:
-            if pod_type == "worker":
-                return Counter(
-                    [v for _, _, v in self._worker_pods_ip_phase.values()]
-                )
-            elif pod_type == "ps":
-                return Counter(
-                    [v for _, _, v in self._worker_pods_ip_phase.values()]
-                )
-            else:
-                return None
+        if pod_type == "worker":
+            return Counter(
+                [v for _, _, v in self._worker_pods_ip_phase.values()]
+            )
+        elif pod_type == "ps":
+            return Counter(
+                [v for _, _, v in self._worker_pods_ip_phase.values()]
+            )
+        else:
+            return None
 
     def _event_cb(self, event):
         evt_obj = event.get("object")

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -274,15 +274,16 @@ class InstanceManager(object):
             for ps_id in self._ps_pods_phase:
                 self._k8s_client.delete_ps(ps_id)
 
-    def get_worker_counter(self):
+    def get_pod_counter(self, is_worker=True):
         with self._lock:
-            return Counter(
-                [v for _, _, v in self._worker_pods_ip_phase.values()]
-            )
-
-    def get_ps_counter(self):
-        with self._lock:
-            return Counter([v for _, v in self._ps_pods_phase.values()])
+            if is_worker:
+                return Counter(
+                    [v for _, _, v in self._worker_pods_ip_phase.values()]
+                )
+            else:
+                return Counter(
+                    [v for _, _, v in self._worker_pods_ip_phase.values()]
+                )
 
     def _event_cb(self, event):
         evt_obj = event.get("object")

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -281,9 +281,8 @@ class InstanceManager(object):
             worker_counter = Counter(
                 [v for _, _, v in self._worker_pods_ip_phase.values()]
             )
-            ps_counter = Counter(
-                [v for _, _, v in self._worker_pods_ip_phase.values()]
-            )
+            ps_counter = Counter([v for _, v in self._ps_pods_phase.values()])
+
         if pod_type == "worker":
             return worker_counter
         elif pod_type == "ps":

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -263,6 +263,7 @@ class InstanceManager(object):
         self._k8s_client.delete_ps(ps_id)
 
     def stop_relaunch_and_remove_pods(self, pod_type):
+        ids = []
         if pod_type == "worker":
             self._relaunch_deleted_live_worker = False
             ids = self._worker_pods_ip_phase
@@ -276,12 +277,13 @@ class InstanceManager(object):
                 delete_func(id)
 
     def get_pod_counter(self, pod_type):
-        worker_counter = Counter(
-            [v for _, _, v in self._worker_pods_ip_phase.values()]
-        )
-        ps_counter = Counter(
-            [v for _, _, v in self._worker_pods_ip_phase.values()]
-        )
+        with self._lock:
+            worker_counter = Counter(
+                [v for _, _, v in self._worker_pods_ip_phase.values()]
+            )
+            ps_counter = Counter(
+                [v for _, _, v in self._worker_pods_ip_phase.values()]
+            )
         if pod_type == "worker":
             return worker_counter
         elif pod_type == "ps":

--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -271,8 +271,9 @@ class InstanceManager(object):
             self._relaunch_deleted_live_ps = False
             ids = self._ps_pods_phase
             delete_func = self._k8s_client.delete_ps
-        for id in ids:
-            delete_func(id)
+        with self._lock:
+            for id in ids:
+                delete_func(id)
 
     def get_pod_counter(self, pod_type):
         worker_counter = Counter(

--- a/elasticdl/python/tests/k8s_instance_manager_test.py
+++ b/elasticdl/python/tests/k8s_instance_manager_test.py
@@ -233,7 +233,6 @@ class InstanceManagerTest(unittest.TestCase):
                 all_current_ps.add(k)
                 if phase in ["Running", "Pending"]:
                     all_live_ps.add(k)
-        self.assertTrue(all_current_ps)
         self.assertTrue(all_live_ps)
 
         ps_to_be_removed = all_live_ps.pop()

--- a/elasticdl/python/tests/k8s_instance_manager_test.py
+++ b/elasticdl/python/tests/k8s_instance_manager_test.py
@@ -44,7 +44,7 @@ class InstanceManagerTest(unittest.TestCase):
         max_check_num = 20
         for _ in range(max_check_num):
             time.sleep(3)
-            counters = instance_manager.get_pod_counter()
+            counters = instance_manager.get_pod_counter(pod_type="worker")
             if counters["Succeeded"] == 2:
                 break
 
@@ -53,14 +53,14 @@ class InstanceManagerTest(unittest.TestCase):
         instance_manager._process_worker()
         for _ in range(max_check_num):
             time.sleep(3)
-            counters = instance_manager.get_pod_counter()
+            counters = instance_manager.get_pod_counter(pod_type="worker")
             if counters["Succeeded"] == 3:
                 break
 
-        instance_manager.stop_relaunch_and_remove_workers()
+        instance_manager.stop_relaunch_and_remove_pods(pod_type="worker")
         for _ in range(max_check_num):
             time.sleep(3)
-            counters = instance_manager.get_pod_counter()
+            counters = instance_manager.get_pod_counter(pod_type="worker")
             if not counters:
                 break
         self.assertFalse(counters)
@@ -86,12 +86,12 @@ class InstanceManagerTest(unittest.TestCase):
         max_check_num = 20
         for _ in range(max_check_num):
             time.sleep(3)
-            counters = instance_manager.get_pod_counter()
+            counters = instance_manager.get_pod_counter(pod_type="worker")
             if counters["Running"]:
                 worker_addrs = instance_manager._get_alive_worker_addr()
                 self.assertEqual(len(worker_addrs), counters["Running"])
 
-        instance_manager.stop_relaunch_and_remove_workers()
+        instance_manager.stop_relaunch_and_remove_pods(pod_type="worker")
 
     @unittest.skipIf(
         os.environ.get("K8S_TESTS", "True") == "False",
@@ -119,14 +119,14 @@ class InstanceManagerTest(unittest.TestCase):
         max_check_num = 20
         for _ in range(max_check_num):
             time.sleep(3)
-            counters = instance_manager.get_pod_counter()
+            counters = instance_manager.get_pod_counter(pod_type="worker")
             if counters["Failed"] == 3:
                 break
 
-        instance_manager.stop_relaunch_and_remove_workers()
+        instance_manager.stop_relaunch_and_remove_pods(pod_type="worker")
         for _ in range(max_check_num):
             time.sleep(3)
-            counters = instance_manager.get_pod_counter()
+            counters = instance_manager.get_pod_counter(pod_type="worker")
             if not counters:
                 break
         task_d.recover_tasks.assert_has_calls(
@@ -156,7 +156,7 @@ class InstanceManagerTest(unittest.TestCase):
         max_check_num = 60
         for _ in range(max_check_num):
             time.sleep(1)
-            counters = instance_manager.get_pod_counter()
+            counters = instance_manager.get_pod_counter(pod_type="worker")
             if counters["Running"] + counters["Pending"] > 0:
                 break
         # Note: There is a slight chance of race condition.
@@ -187,7 +187,7 @@ class InstanceManagerTest(unittest.TestCase):
         else:
             self.fail("Failed to find newly launched worker.")
 
-        instance_manager.stop_relaunch_and_remove_workers()
+        instance_manager.stop_relaunch_and_remove_pods(pod_type="worker")
 
     @unittest.skipIf(
         os.environ.get("K8S_TESTS", "True") == "False",
@@ -221,7 +221,7 @@ class InstanceManagerTest(unittest.TestCase):
         max_check_num = 60
         for _ in range(max_check_num):
             time.sleep(1)
-            counters = instance_manager.get_pod_counter(is_worker=False)
+            counters = instance_manager.get_pod_counter(pod_type="ps")
             if counters["Running"] + counters["Pending"] > 0:
                 break
         # Note: There is a slight chance of race condition.
@@ -251,7 +251,7 @@ class InstanceManagerTest(unittest.TestCase):
         else:
             self.fail("Failed to find newly launched ps.")
 
-        instance_manager.stop_relaunch_and_remove_all_ps()
+        instance_manager.stop_relaunch_and_remove_pods(pod_type="ps")
 
 
 if __name__ == "__main__":

--- a/elasticdl/python/tests/k8s_instance_manager_test.py
+++ b/elasticdl/python/tests/k8s_instance_manager_test.py
@@ -49,6 +49,7 @@ class InstanceManagerTest(unittest.TestCase):
                 break
 
         instance_manager._not_created_worker_id = [2]
+        instance_manager._worker_pod_priority[2] = None
         instance_manager._process_worker()
         for _ in range(max_check_num):
             time.sleep(3)

--- a/elasticdl/python/tests/k8s_instance_manager_test.py
+++ b/elasticdl/python/tests/k8s_instance_manager_test.py
@@ -44,7 +44,7 @@ class InstanceManagerTest(unittest.TestCase):
         max_check_num = 20
         for _ in range(max_check_num):
             time.sleep(3)
-            counters = instance_manager.get_worker_counter()
+            counters = instance_manager.get_pod_counter()
             if counters["Succeeded"] == 2:
                 break
 
@@ -53,14 +53,14 @@ class InstanceManagerTest(unittest.TestCase):
         instance_manager._process_worker()
         for _ in range(max_check_num):
             time.sleep(3)
-            counters = instance_manager.get_worker_counter()
+            counters = instance_manager.get_pod_counter()
             if counters["Succeeded"] == 3:
                 break
 
         instance_manager.stop_relaunch_and_remove_workers()
         for _ in range(max_check_num):
             time.sleep(3)
-            counters = instance_manager.get_worker_counter()
+            counters = instance_manager.get_pod_counter()
             if not counters:
                 break
         self.assertFalse(counters)
@@ -86,7 +86,7 @@ class InstanceManagerTest(unittest.TestCase):
         max_check_num = 20
         for _ in range(max_check_num):
             time.sleep(3)
-            counters = instance_manager.get_worker_counter()
+            counters = instance_manager.get_pod_counter()
             if counters["Running"]:
                 worker_addrs = instance_manager._get_alive_worker_addr()
                 self.assertEqual(len(worker_addrs), counters["Running"])
@@ -119,14 +119,14 @@ class InstanceManagerTest(unittest.TestCase):
         max_check_num = 20
         for _ in range(max_check_num):
             time.sleep(3)
-            counters = instance_manager.get_worker_counter()
+            counters = instance_manager.get_pod_counter()
             if counters["Failed"] == 3:
                 break
 
         instance_manager.stop_relaunch_and_remove_workers()
         for _ in range(max_check_num):
             time.sleep(3)
-            counters = instance_manager.get_worker_counter()
+            counters = instance_manager.get_pod_counter()
             if not counters:
                 break
         task_d.recover_tasks.assert_has_calls(
@@ -156,7 +156,7 @@ class InstanceManagerTest(unittest.TestCase):
         max_check_num = 60
         for _ in range(max_check_num):
             time.sleep(1)
-            counters = instance_manager.get_worker_counter()
+            counters = instance_manager.get_pod_counter()
             if counters["Running"] + counters["Pending"] > 0:
                 break
         # Note: There is a slight chance of race condition.
@@ -221,7 +221,7 @@ class InstanceManagerTest(unittest.TestCase):
         max_check_num = 60
         for _ in range(max_check_num):
             time.sleep(1)
-            counters = instance_manager.get_ps_counter()
+            counters = instance_manager.get_pod_counter(is_worker=False)
             if counters["Running"] + counters["Pending"] > 0:
                 break
         # Note: There is a slight chance of race condition.

--- a/elasticdl/python/tests/k8s_instance_manager_test.py
+++ b/elasticdl/python/tests/k8s_instance_manager_test.py
@@ -37,11 +37,19 @@ class InstanceManagerTest(unittest.TestCase):
             worker_command=["/bin/bash"],
             worker_args=["-c", "echo"],
             namespace="default",
-            num_workers=3,
+            num_workers=2,
         )
 
         instance_manager.start_workers()
         max_check_num = 20
+        for _ in range(max_check_num):
+            time.sleep(3)
+            counters = instance_manager.get_worker_counter()
+            if counters["Succeeded"] == 2:
+                break
+
+        instance_manager._not_created_worker_id = [2]
+        instance_manager._process_worker()
         for _ in range(max_check_num):
             time.sleep(3)
             counters = instance_manager.get_worker_counter()
@@ -55,14 +63,6 @@ class InstanceManagerTest(unittest.TestCase):
             if not counters:
                 break
         self.assertFalse(counters)
-
-        instance_manager._not_created_worker_id = [3, 4]
-        instance_manager._process_worker()
-        for _ in range(max_check_num):
-            time.sleep(3)
-            counters = instance_manager.get_worker_counter()
-            if counters["Succeeded"] == 2:
-                break
 
     @unittest.skipIf(
         os.environ.get("K8S_TESTS", "True") == "False",

--- a/elasticdl/python/tests/k8s_instance_manager_test.py
+++ b/elasticdl/python/tests/k8s_instance_manager_test.py
@@ -56,6 +56,14 @@ class InstanceManagerTest(unittest.TestCase):
                 break
         self.assertFalse(counters)
 
+        instance_manager._not_created_worker_id = [3, 4]
+        instance_manager._process_worker()
+        for _ in range(max_check_num):
+            time.sleep(3)
+            counters = instance_manager.get_worker_counter()
+            if counters["Succeeded"] == 2:
+                break
+
     @unittest.skipIf(
         os.environ.get("K8S_TESTS", "True") == "False",
         "No Kubernetes cluster available",

--- a/elasticdl/python/tests/k8s_instance_manager_test.py
+++ b/elasticdl/python/tests/k8s_instance_manager_test.py
@@ -233,6 +233,7 @@ class InstanceManagerTest(unittest.TestCase):
                 all_current_ps.add(k)
                 if phase in ["Running", "Pending"]:
                     all_live_ps.add(k)
+        self.assertTrue(all_current_ps)
         self.assertTrue(all_live_ps)
 
         ps_to_be_removed = all_live_ps.pop()


### PR DESCRIPTION
fix #2303 

For some reasons, such as not enough GPU resources due to quota, pod creations API may fail with a crash.

1. If the master fails to create a worker pod, the master stores the corresponding `worker_id` in a list.
2. A thread periodically check this list, and try to create worker pods if the list is not empty.
3. Since PS pods are not elastic, the master must wait for all PS pods to create.
