### PR TITLE
Do not scale learning rate of optimizer.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
 multi_line_output=3
 line_length=79
-known_third_party = PIL,deepctr,docker,google,grpc,jinja2,kubernetes,matplotlib,numpy,odps,pandas,recordio,requests,setuptools,sklearn,tensorflow,yaml
+known_third_party = PIL,deepctr,docker,google,grpc,horovod,jinja2,kubernetes,matplotlib,numpy,odps,pandas,recordio,requests,setuptools,sklearn,tensorflow,yaml
 include_trailing_comma=True

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
 multi_line_output=3
 line_length=79
-known_third_party = PIL,deepctr,docker,google,grpc,horovod,jinja2,kubernetes,matplotlib,numpy,odps,pandas,recordio,requests,setuptools,sklearn,tensorflow,yaml
+known_third_party = PIL,deepctr,docker,google,grpc,jinja2,kubernetes,matplotlib,numpy,odps,pandas,recordio,requests,setuptools,sklearn,tensorflow,yaml
 include_trailing_comma=True

--- a/elasticdl/python/tests/allreduce_trainer_test.py
+++ b/elasticdl/python/tests/allreduce_trainer_test.py
@@ -35,6 +35,7 @@ class AllReduceTrainerTest(unittest.TestCase):
         self._trainer = AllReduceTrainer(master_client, "", model)
 
     def test_training_process(self):
+        self._trainer.init_horovod_if_needed()
         features = tf.constant([[0.5], [0.6], [0.7]])
         labels = tf.constant([[1.0], [0.0], [1.0]])
         loss = self._trainer._training_process(features, labels)

--- a/elasticdl/python/tests/allreduce_trainer_test.py
+++ b/elasticdl/python/tests/allreduce_trainer_test.py
@@ -14,9 +14,9 @@
 import unittest
 from unittest.mock import MagicMock, Mock
 
+import horovod.tensorflow as hvd
 import tensorflow as tf
 
-import horovod.tensorflow as hvd
 from elasticdl.python.tests.test_module import custom_model, loss, optimizer
 from elasticdl.python.worker.allreduce_trainer import AllReduceTrainer
 

--- a/elasticdl/python/tests/allreduce_trainer_test.py
+++ b/elasticdl/python/tests/allreduce_trainer_test.py
@@ -14,9 +14,9 @@
 import unittest
 from unittest.mock import MagicMock, Mock
 
-import horovod.tensorflow as hvd
 import tensorflow as tf
 
+import horovod.tensorflow as hvd
 from elasticdl.python.tests.test_module import custom_model, loss, optimizer
 from elasticdl.python.worker.allreduce_trainer import AllReduceTrainer
 
@@ -33,6 +33,12 @@ class AllReduceTrainerTest(unittest.TestCase):
         model.optimizer = optimizer()
         model.loss = loss
         self._trainer = AllReduceTrainer(master_client, "", model)
+
+    def test_training_process(self):
+        features = tf.constant([[0.5], [0.6], [0.7]])
+        labels = tf.constant([[1.0], [0.0], [1.0]])
+        loss = self._trainer._training_process(features, labels)
+        self.assertIsNotNone(loss)
 
     def test_train_minibatch(self):
         self._trainer.init_horovod_if_needed()

--- a/elasticdl/python/worker/allreduce_trainer.py
+++ b/elasticdl/python/worker/allreduce_trainer.py
@@ -46,7 +46,6 @@ class AllReduceTrainer(Trainer):
         self._rendezvous_id = None
         self._need_broadcast = True
         self._var_created = False
-        self._world_size = None
         self._optimizer = model.optimizer
         self._set_horovod_env()
 
@@ -130,7 +129,6 @@ class AllReduceTrainer(Trainer):
             hvd.shutdown()
             hvd.init()
             os.environ[HorovodEnv.ELASTIC] = str(1)
-            self._world_size = hvd.size()
             self._rendezvous_id = rank_response.rendezvous_id
             self._need_broadcast = True
 

--- a/elasticdl/python/worker/allreduce_trainer.py
+++ b/elasticdl/python/worker/allreduce_trainer.py
@@ -47,20 +47,8 @@ class AllReduceTrainer(Trainer):
         self._need_broadcast = True
         self._var_created = False
         self._world_size = None
-        self._set_optimizer(model.optimizer)
+        self._optimizer = model.optimizer
         self._set_horovod_env()
-
-    def _set_optimizer(self, optimizer):
-        self._optimizer = optimizer
-        self._lr = optimizer._hyper["learning_rate"]
-        self._optimizer.lr = self._get_learning_rate
-
-    def _get_learning_rate(self):
-        scaler = 1 if self._world_size is None else self._world_size
-        lr = self._lr
-        if callable(lr):
-            lr = lr()
-        return lr * scaler
 
     @tf.function
     def _training_process(self, features, labels):


### PR DESCRIPTION
User can scale the learning rate of the optimizer by defining callbacks in the model definition like:
```python
def callbacks():
    def _schedule(model_version):
        LR = 0.001
        if model_version > 10000:
            lr = LR * 0.01
        elif model_version > 6000:
            lr = LR * 0.1
        elif model_version > 4000:
            lr = LR * 0.2
        elif model_version > 2000:
            lr = LR * 0.5
        else:
            lr = LR
        return lr * hvd.size()

    return [LearningRateScheduler(_schedule)]
```