### PR TITLE
Rename method name to better describe its functionality

### DIFF
--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -252,7 +252,7 @@ class Worker(object):
         task_id = task.task_id
         err_msg = ""
         for dataset_batch in eval_dataset:
-            data_err_msg = self._process_minibatch_and_report(
+            data_err_msg = self._safe_process_minibatch(
                 dataset_batch, elasticdl_pb2.EVALUATION, model_version
             )
             if data_err_msg:
@@ -278,7 +278,7 @@ class Worker(object):
         if self._distribution_strategy == DistributionStrategy.ALLREDUCE:
             self._trainer.export_saved_model(self._saved_model_path)
 
-    def _process_minibatch_and_report(
+    def _safe_process_minibatch(
         self,
         dataset_batch,
         task_type,
@@ -364,7 +364,7 @@ class Worker(object):
                 else:
                     train_with_local_model = True
 
-                err_msg = self._process_minibatch_and_report(
+                err_msg = self._safe_process_minibatch(
                     dataset_batch,
                     task.type,
                     task.model_version,
@@ -427,7 +427,7 @@ class Worker(object):
             for dataset_batch in dataset:
                 task = self._task_data_service.get_current_task()
 
-                err_msg = self._process_minibatch_and_report(
+                err_msg = self._safe_process_minibatch(
                     dataset_batch, task.type, task.model_version
                 )
                 self._task_data_service.report_record_done(


### PR DESCRIPTION

Rename method  `_process_minibatch_and_report` to _`safe__process_minibatch` as the method does not report but only process minibatch with exception catching.