### PR TITLE
The worker only create a dataset for an evaluation job

### DIFF
--- a/elasticdl/python/worker/worker.py
+++ b/elasticdl/python/worker/worker.py
@@ -433,10 +433,11 @@ class Worker(object):
         dataset = dataset.batch(self._minibatch_size).prefetch(1)
         while True:
             # The dataset will re-call generator each time when
-            # we call iterator of the dataset.
+            # calling iterator of the dataset.
             evaluated = self._process_evaluation_dataset(dataset)
             if not evaluated:
                 break
+        del dataset
         evaluation_task_executed = True
         return evaluation_task_executed
 


### PR DESCRIPTION
Now, the worker needs to create a dataset for each evaluation task. It will create much overhead and evenly result in OOM. The worker only creates a dataset that can query evaluation tasks.