### PR TITLE
Update base image and add more logs in the building process.

### DIFF
--- a/elasticdl/python/master/k8s_instance_manager.py
+++ b/elasticdl/python/master/k8s_instance_manager.py
@@ -30,7 +30,7 @@ _SERVICE_ADDR_SEP = ","
 
 def _get_addrs(num_addrs, addr_get_fn):
     """
-    Get `num_addrs` addresses and then the concatenate
+    Get `num_addrs` addresses and then concatenate
     them to a comma separated string.
     """
     addrs = []

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,12 +39,17 @@ make -f elasticdl/Makefile
 )
 
 # Create elasticdl_preprocessing package
+echo "Building the wheel for elasticdl_preprocessing."
 rm -rf ./build/lib
 python setup_preprocessing.py --quiet bdist_wheel --dist-dir ./build
+
 # Create elasticdl_client package
+echo "Building the wheel for elasticdl_client."
 rm -rf ./build/lib
 python setup_client.py --quiet bdist_wheel --dist-dir ./build
+
 # Create elasticdl package
+echo "Building the wheel for elasticdl."
 mkdir -p ./elasticdl/go/bin
 cp /tmp/elasticdl_ps ./elasticdl/go/bin/
 rm -rf ./build/lib

--- a/scripts/travis/build_images.sh
+++ b/scripts/travis/build_images.sh
@@ -14,7 +14,7 @@
 
 # Pull base image quietly.  We might want to use
 # tensorflow/tensorflow:2.1.0-gpu-py3 for GPU-accelerated deep learning.
-BASE_IMAGE=tensorflow/tensorflow:2.1.0-py3
+BASE_IMAGE=tensorflow/tensorflow:2.1.2
 docker pull --quiet "$BASE_IMAGE"
 
 docker build --target dev -t elasticdl:dev \


### PR DESCRIPTION
At the present, the base image is `tensorflow/tensorflow:2.1.0-py3`, but the requirement of elasticdl is tensorflow.2.1.2, it will cost much time to download and reinstall tensorflow.2.1.2. It would be faster to update the base image.