### PR TITLE
Decouple PodManager with TaskManager and RendezvousServer using PodEventCallbacks.

### DIFF
--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -17,6 +17,10 @@ import time
 from elasticdl.python.common.constants import InstanceManagerStatus
 from elasticdl.python.common.log_utils import default_logger as logger
 from elasticdl.python.master.elasticdl_job_service import ElasticdlJobService
+from elasticdl.python.master.pod_event_callbacks import (
+    RendezvousServiceRefreshCallback,
+    TaskRescheduleCallback,
+)
 from elasticdl.python.master.pod_manager import create_pod_manager
 from elasticdl.python.master.rendezvous_server import HorovodRendezvousServer
 from elasticdl.python.master.servicer import create_master_service
@@ -60,6 +64,14 @@ class Master(object):
                 # TODO: Get the Pod arguments from the input
                 # args directly
                 pass
+            if self.task_manager:
+                self.pod_manager.add_pod_event_callback(
+                    TaskRescheduleCallback(self.task_manager)
+                )
+            if self.rendezvous_server:
+                self.pod_manager.add_pod_event_callback(
+                    RendezvousServiceRefreshCallback(self.rendezvous_server)
+                )
 
         # Start the components one by one
         if self.task_manager:

--- a/elasticdl/python/master/master.py
+++ b/elasticdl/python/master/master.py
@@ -64,6 +64,7 @@ class Master(object):
                 # TODO: Get the Pod arguments from the input
                 # args directly
                 pass
+            # Add PodEventCallbacks for the listeners of Pod events.
             if self.task_manager:
                 self.pod_manager.add_pod_event_callback(
                     TaskRescheduleCallback(self.task_manager)
@@ -127,9 +128,7 @@ class Master(object):
 
     def create_pod_manager_if_needed(self, args):
         if args.need_pod_manager:
-            self.pod_manager = create_pod_manager(
-                args, self.task_manager, self.rendezvous_server
-            )
+            self.pod_manager = create_pod_manager(args)
         else:
             self.pod_manager = None
 

--- a/elasticdl/python/master/pod_event_callbacks.py
+++ b/elasticdl/python/master/pod_event_callbacks.py
@@ -75,6 +75,7 @@ class PodEventCallback(metaclass=abc.ABCMeta):
 
 class TaskRescheduleCallback(PodEventCallback):
     def __init__(self, task_manager):
+        super(TaskRescheduleCallback, self).__init__()
         self._task_manager = task_manager
 
     def on_pod_started(self, pod_info, cluster_context):
@@ -84,9 +85,31 @@ class TaskRescheduleCallback(PodEventCallback):
         pass
 
     def on_pod_failed(self, pod_info, cluster_context):
-        # TODO: Call task_manager to reschedule the task
-        # of the failed worker to another worker
-        pass
+        if pod_info.id:
+            self._task_manager.recover_tasks(pod_info.id)
 
     def on_pod_deleted(self, pod_info, cluster_context):
-        pass
+        if pod_info.id:
+            self._task_manager.recover_tasks(pod_info.id)
+
+
+class RendezvousServiceRefreshCallback(PodEventCallback):
+    def __init__(self, rendezvous_server):
+        super(RendezvousServiceRefreshCallback, self).__init__()
+        self._rendezvous_server = rendezvous_server
+
+    def on_pod_started(self, pod_info, cluster_context):
+        self._refresh_rendezvous_service(cluster_context.pod_manager)
+
+    def on_pod_succeeded(self, pod_info, cluster_context):
+        self._refresh_rendezvous_service(cluster_context.pod_manager)
+
+    def on_pod_failed(self, pod_info, cluster_context):
+        self._refresh_rendezvous_service(cluster_context.pod_manager)
+
+    def on_pod_deleted(self, pod_info, cluster_context):
+        self._refresh_rendezvous_service(cluster_context.pod_manager)
+
+    def _refresh_rendezvous_service(self, pod_manager):
+        worker_addrs = pod_manager.get_alive_worker_addr()
+        self._rendezvous_server.set_worker_hosts(worker_addrs)

--- a/elasticdl/python/master/pod_event_callbacks.py
+++ b/elasticdl/python/master/pod_event_callbacks.py
@@ -85,11 +85,11 @@ class TaskRescheduleCallback(PodEventCallback):
         pass
 
     def on_pod_failed(self, pod_info, cluster_context):
-        if pod_info.id:
+        if pod_info.id is not None:
             self._task_manager.recover_tasks(pod_info.id)
 
     def on_pod_deleted(self, pod_info, cluster_context):
-        if pod_info.id:
+        if pod_info.id is not None:
             self._task_manager.recover_tasks(pod_info.id)
 
 

--- a/elasticdl/python/master/pod_manager.py
+++ b/elasticdl/python/master/pod_manager.py
@@ -430,22 +430,6 @@ class PodManager(object):
             if pod_name in self._failed_pods:
                 return
 
-            # Notify each PodEventCallback that PodStarted is fired
-            if evt_type in ["ADDED", "MODIFIED"] and phase == "Running":
-                for callback in self._pod_event_callbacks:
-                    callback.on_pod_started(
-                        PodInfo(type=None, id=None, name=pod_name),
-                        ClusterContext(pod_manager=self),
-                    )
-
-            # Notify each PodEventCallback that PodSucceeded is fired
-            if evt_type == "MODIFIED" and phase == "Succeeded":
-                for callback in self._pod_event_callbacks:
-                    callback.on_pod_succeeded(
-                        PodInfo(type=None, id=None, name=pod_name),
-                        ClusterContext(pod_manager=self),
-                    )
-
             # For the failed worker, reassign the its tasks to others.
             # Check whether to relaunch the worker.
             relaunch_failed_pod = False
@@ -511,6 +495,22 @@ class PodManager(object):
             else:
                 logger.error("Unknown pod name: %s" % pod_name)
                 return
+
+            # Notify each PodEventCallback that PodStarted is fired
+            if evt_type in ["ADDED", "MODIFIED"] and phase == "Running":
+                for callback in self._pod_event_callbacks:
+                    callback.on_pod_started(
+                        PodInfo(type=None, id=None, name=pod_name),
+                        ClusterContext(pod_manager=self),
+                    )
+
+            # Notify each PodEventCallback that PodSucceeded is fired
+            if evt_type == "MODIFIED" and phase == "Succeeded":
+                for callback in self._pod_event_callbacks:
+                    callback.on_pod_succeeded(
+                        PodInfo(type=None, id=None, name=pod_name),
+                        ClusterContext(pod_manager=self),
+                    )
 
         if relaunch_worker and worker_id >= 0:
             logger.info("Relaunching worker.")

--- a/elasticdl/python/master/pod_manager.py
+++ b/elasticdl/python/master/pod_manager.py
@@ -485,7 +485,7 @@ class PodManager(object):
                 return
 
             if self._rendezvous_server:
-                self._worker_addrs = self._get_alive_worker_addr()
+                self._worker_addrs = self.get_alive_worker_addr()
                 self._rendezvous_server.set_worker_hosts(self._worker_addrs)
 
         if relaunch_worker and worker_id >= 0:
@@ -524,7 +524,7 @@ class PodManager(object):
         _, pod_ip, _ = self._worker_pods_ip_phase[worker_id]
         return pod_ip
 
-    def _get_alive_worker_addr(self):
+    def get_alive_worker_addr(self):
         alive_workers = self.get_alive_workers()
         worker_addrs = []
         worker_start_times = []

--- a/elasticdl/python/master/pod_manager.py
+++ b/elasticdl/python/master/pod_manager.py
@@ -435,7 +435,7 @@ class PodManager(object):
             if evt_type in ["ADDED", "MODIFIED"] and phase == "Running":
                 for callback in self._pod_event_callbacks:
                     callback.on_pod_started(
-                        PodInfo(id=None, name=pod_name, ip=pod_ip),
+                        PodInfo(type=None, id=None, name=pod_name),
                         ClusterContext(pod_manager=self),
                     )
 
@@ -448,7 +448,9 @@ class PodManager(object):
                 # Notify each PodEventCallback that PodFailed is fired
                 for callback in self._pod_event_callbacks:
                     callback.on_pod_failed(
-                        PodInfo(id=worker_id, name=pod_name, ip=pod_ip),
+                        PodInfo(
+                            type=PodType.WORKER, id=worker_id, name=pod_name
+                        ),
                         ClusterContext(pod_manager=self),
                     )
 
@@ -488,7 +490,7 @@ class PodManager(object):
                     # Notify each PodEventCallback that PodDeleted is fired
                     for callback in self._pod_event_callbacks:
                         callback.on_pod_deleted(
-                            PodInfo(id=worker_id, name=pod_name, ip=pod_ip),
+                            PodInfo(type=None, id=worker_id, name=pod_name),
                             ClusterContext(pod_manager=self),
                         )
             elif pod_name in self._ps_pod_name_to_id:

--- a/elasticdl/python/master/pod_manager.py
+++ b/elasticdl/python/master/pod_manager.py
@@ -438,6 +438,14 @@ class PodManager(object):
                         ClusterContext(pod_manager=self),
                     )
 
+            # Notify each PodEventCallback that PodSucceeded is fired
+            if evt_type == "MODIFIED" and phase == "Succeeded":
+                for callback in self._pod_event_callbacks:
+                    callback.on_pod_succeeded(
+                        PodInfo(type=None, id=None, name=pod_name),
+                        ClusterContext(pod_manager=self),
+                    )
+
             # For the failed worker, reassign the its tasks to others.
             # Check whether to relaunch the worker.
             relaunch_failed_pod = False

--- a/elasticdl/python/master/task_manager.py
+++ b/elasticdl/python/master/task_manager.py
@@ -448,6 +448,8 @@ class TaskManager(object):
         if not self.support_fault_tolerance:
             return
 
+        logger.info("Recover the tasks assigned to worker %d" % worker_id)
+
         with self._lock:
             ids = [
                 id

--- a/elasticdl/python/tests/pod_manager_test.py
+++ b/elasticdl/python/tests/pod_manager_test.py
@@ -204,7 +204,6 @@ class PodManagerTest(unittest.TestCase):
     def test_relaunch_ps_pod(self):
         num_ps = 3
         pod_manager = PodManager(
-            task_manager=None,
             job_name="test-relaunch-ps-pod-%d-%d"
             % (int(time.time()), random.randint(1, 101)),
             image_name="ubuntu:18.04",

--- a/elasticdl/python/tests/pod_manager_test.py
+++ b/elasticdl/python/tests/pod_manager_test.py
@@ -95,7 +95,7 @@ class PodManagerTest(unittest.TestCase):
             time.sleep(3)
             counters = pod_manager.get_pod_counter(pod_type=PodType.WORKER)
             if counters["Running"]:
-                worker_addrs = pod_manager._get_alive_worker_addr()
+                worker_addrs = pod_manager.get_alive_worker_addr()
                 self.assertEqual(len(worker_addrs), counters["Running"])
 
         pod_manager.stop_relaunch_and_remove_pods(pod_type=PodType.WORKER)

--- a/elasticdl/python/tests/pod_manager_test.py
+++ b/elasticdl/python/tests/pod_manager_test.py
@@ -18,6 +18,7 @@ import unittest
 from unittest.mock import MagicMock, call
 
 from elasticdl.python.common.k8s_client import PodType
+from elasticdl.python.master.pod_event_callbacks import TaskRescheduleCallback
 from elasticdl.python.master.pod_manager import PodManager
 from elasticdl.python.tests.test_utils import create_task_manager
 
@@ -28,10 +29,7 @@ class PodManagerTest(unittest.TestCase):
         "No Kubernetes cluster available",
     )
     def test_create_delete_worker_pod(self):
-        task_d = create_task_manager({"f": (0, 10)}, {})
-        task_d.recover_tasks = MagicMock()
         pod_manager = PodManager(
-            task_d,
             job_name="test-create-worker-pod-%d-%d"
             % (int(time.time()), random.randint(1, 101)),
             image_name="ubuntu:18.04",
@@ -74,9 +72,7 @@ class PodManagerTest(unittest.TestCase):
         "No Kubernetes cluster available",
     )
     def test_get_worker_addrs(self):
-        task_d = create_task_manager({"f": (0, 10)}, {})
         pod_manager = PodManager(
-            task_d,
             job_name="test-create-worker-pod-%d-%d"
             % (int(time.time()), random.randint(1, 101)),
             image_name="ubuntu:18.04",
@@ -109,10 +105,9 @@ class PodManagerTest(unittest.TestCase):
         Start a pod running a python program destined to fail with
         restart_policy="Never" to test failed_worker_count
         """
-        task_d = create_task_manager({"f": (0, 10)}, {})
-        task_d.recover_tasks = MagicMock()
+        task_manager = create_task_manager({"f": (0, 10)}, {})
+        task_manager.recover_tasks = MagicMock()
         pod_manager = PodManager(
-            task_d,
             job_name="test-failed-worker-pod-%d-%d"
             % (int(time.time()), random.randint(1, 101)),
             image_name="ubuntu:18.04",
@@ -123,6 +118,9 @@ class PodManagerTest(unittest.TestCase):
         )
         pod_manager.set_up(
             worker_command=["/bin/bash"], worker_args=["-c", "badcommand"],
+        )
+        pod_manager.add_pod_event_callback(
+            TaskRescheduleCallback(task_manager=task_manager)
         )
         pod_manager.start()
         pod_manager.start_workers()
@@ -139,7 +137,7 @@ class PodManagerTest(unittest.TestCase):
             counters = pod_manager.get_pod_counter(pod_type=PodType.WORKER)
             if not counters:
                 break
-        task_d.recover_tasks.assert_has_calls(
+        task_manager.recover_tasks.assert_has_calls(
             [call(0), call(1), call(2)], any_order=True
         )
 
@@ -149,9 +147,7 @@ class PodManagerTest(unittest.TestCase):
     )
     def test_relaunch_worker_pod(self):
         num_workers = 3
-        task_d = create_task_manager({"f": (0, 10)}, {})
         pod_manager = PodManager(
-            task_d,
             job_name="test-relaunch-worker-pod-%d-%d"
             % (int(time.time()), random.randint(1, 101)),
             image_name="ubuntu:18.04",


### PR DESCRIPTION
- Implement two subclass of PodEventCallback: `TaskRescheduleCallback` and `RendezvousServiceRefreshCallback`
- Inside PodManager._event_cb, we will call PodEventCallback instead of calling TaskManager and RendezvousServer directly
- Remove task_manager and rendezvous_server from the constructor of PodManager.