### PR TITLE
The API for users to create an elastic allreduce controller.

### DIFF
--- a/elasticdl/python/allreduce/pytorch_controller.py
+++ b/elasticdl/python/allreduce/pytorch_controller.py
@@ -58,7 +58,6 @@ def get_elastic_controller(batch_size):
     ontroller.set_broadcast_optimizer(optimizer)
     model.train()
     for batch_idx, (data, target) in enumerate(data_loader):
-
         # Use the elastic function to wrap the training function with a batch.
         elastic_train_one_batch = allreduce_controller.elastic_run(
             train_one_batch

--- a/elasticdl/python/allreduce/pytorch_controller.py
+++ b/elasticdl/python/allreduce/pytorch_controller.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import time
 import traceback
 
@@ -18,7 +19,10 @@ from elasticdl.python.allreduce.base_controller import (
     DEFAULT_MAX_ALLREDUCE_RETRY_NUM,
     AllReduceController,
 )
+from elasticdl.python.common.grpc_utils import build_channel
 from elasticdl.python.common.log_utils import default_logger as logger
+from elasticdl.python.worker.data_shard_service import DataShardService
+from elasticdl.python.worker.master_client import MasterClient
 
 try:
     import horovod.torch as hvd
@@ -30,6 +34,60 @@ try:
 
 except ImportError:
     hvd = None
+
+
+def get_elastic_controller():
+    """Create an elastic AllReduce controller with data shard service.
+    Users can use the `controller.data_shard_service` to get data
+    shards like:
+    ```python
+    while True:
+        shard = controller.data_shard_service.fetch_shard()
+        for i in range(shard.start, shard.end):
+            yield i
+    ```
+
+    Users also can use the controller to do an elastic training.
+
+    ```python
+    model = ...
+    optimizer = optim.SGD(model.parameters(), lr=0.1)
+    optimizer = hvd.DistributedOptimizer(optimizer)
+
+    controller.set_broadcast_model(model)
+    ontroller.set_broadcast_optimizer(optimizer)
+    model.train()
+    for batch_idx, (data, target) in enumerate(data_loader):
+
+        # Use the elastic function to wrap the training function with a batch.
+        elastic_train_one_batch = allreduce_controller.elastic_run(
+            train_one_batch
+        )
+
+    def train_one_batch(model, optimizer, data, target):
+        optimizer.zero_grad()
+        output = model(data)
+        loss = F.nll_loss(output, target)
+        loss.backward()
+        optimizer.step()
+        return loss
+    ```
+    """
+    master_addr = os.getenv("MASTER_ADDR", " localhost:12345")
+    worker_id = int(os.getenv("WORKER_ID", 0))
+
+    if master_addr and worker_id:
+        master_client = MasterClient(
+            build_channel(master_addr), worker_id
+        )
+        data_shard_service = DataShardService(64)
+
+        master_ip = master_addr.split(":")[0]
+        controller = PyTorchAllReduceController(
+            master_client, master_ip, data_shard_service
+        )
+        controller.init_horovod_locally()
+    return controller
 
 
 class PyTorchAllReduceController(AllReduceController):

--- a/elasticdl/python/allreduce/pytorch_controller.py
+++ b/elasticdl/python/allreduce/pytorch_controller.py
@@ -36,7 +36,7 @@ except ImportError:
     hvd = None
 
 
-def get_elastic_controller():
+def get_elastic_controller(batch_size):
     """Create an elastic AllReduce controller with data shard service.
     Users can use the `controller.data_shard_service` to get data
     shards like:
@@ -76,17 +76,11 @@ def get_elastic_controller():
     master_addr = os.getenv("MASTER_ADDR", " localhost:12345")
     worker_id = int(os.getenv("WORKER_ID", 0))
 
-    if master_addr and worker_id:
-        master_client = MasterClient(
-            build_channel(master_addr), worker_id
-        )
-        data_shard_service = DataShardService(64)
+    master_client = MasterClient(build_channel(master_addr), worker_id)
+    data_shard_service = DataShardService(batch_size, master_client)
 
-        master_ip = master_addr.split(":")[0]
-        controller = PyTorchAllReduceController(
-            master_client, master_ip, data_shard_service
-        )
-        controller.init_horovod_locally()
+    controller = PyTorchAllReduceController(master_client, data_shard_service)
+    controller.init_horovod_locally()
     return controller
 
 

--- a/elasticdl/python/allreduce/pytorch_controller.py
+++ b/elasticdl/python/allreduce/pytorch_controller.py
@@ -36,7 +36,7 @@ except ImportError:
     hvd = None
 
 
-def get_elastic_controller(batch_size):
+def create_elastic_controller(batch_size):
     """Create an elastic AllReduce controller with data shard service.
     Users can use the `controller.data_shard_service` to get data
     shards like:
@@ -72,7 +72,7 @@ def get_elastic_controller(batch_size):
         return loss
     ```
     """
-    master_addr = os.getenv("MASTER_ADDR", " localhost:12345")
+    master_addr = os.getenv("MASTER_ADDR", "localhost:12345")
     worker_id = int(os.getenv("WORKER_ID", 0))
 
     master_client = MasterClient(build_channel(master_addr), worker_id)

--- a/elasticdl/python/tests/allreduce_trainer_test.py
+++ b/elasticdl/python/tests/allreduce_trainer_test.py
@@ -23,7 +23,7 @@ from elasticdl.python.allreduce.base_controller import (
 )
 from elasticdl.python.allreduce.pytorch_controller import (
     PyTorchAllReduceController,
-    get_elastic_controller,
+    create_elastic_controller,
 )
 from elasticdl.python.allreduce.tensorflow_controller import (
     TensorFlowV2AllReduceController,
@@ -169,8 +169,8 @@ class PyTorchReduceControllerTest(unittest.TestCase):
         self.assertIsNotNone(controller._model)
         self.assertIsNotNone(controller._optimizer)
 
-    def test_get_elastic_controller(self):
-        controller = get_elastic_controller(batch_size=64)
+    def test_create_elastic_controller(self):
+        controller = create_elastic_controller(batch_size=64)
         self.assertIsNotNone(controller)
         self.assertIsNotNone(controller.data_shard_service._mc)
         self.assertEqual(controller.data_shard_service._batch_size, 64)

--- a/elasticdl/python/tests/allreduce_trainer_test.py
+++ b/elasticdl/python/tests/allreduce_trainer_test.py
@@ -23,6 +23,7 @@ from elasticdl.python.allreduce.base_controller import (
 )
 from elasticdl.python.allreduce.pytorch_controller import (
     PyTorchAllReduceController,
+    get_elastic_controller,
 )
 from elasticdl.python.allreduce.tensorflow_controller import (
     TensorFlowV2AllReduceController,
@@ -167,6 +168,12 @@ class PyTorchReduceControllerTest(unittest.TestCase):
         self.assertEqual(result, 1)
         self.assertIsNotNone(controller._model)
         self.assertIsNotNone(controller._optimizer)
+
+    def test_get_elastic_controller(self):
+        controller = get_elastic_controller(batch_size=64)
+        self.assertIsNotNone(controller)
+        self.assertIsNotNone(controller.data_shard_service._mc)
+        self.assertEqual(controller.data_shard_service._batch_size, 64)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We can view the example of `create_elastic_controller` in 
https://github.com/sql-machine-learning/elasticdl/blob/9e18cd8142e505b612b1ee66f2fd144690078a90/model_zoo/mnist/pytorch_demo.py#L113-L124