### PR TITLE
Use a list not a dict to store shards.

### DIFF
--- a/elasticdl/python/data/reader/odps_reader.py
+++ b/elasticdl/python/data/reader/odps_reader.py
@@ -62,25 +62,19 @@ class ODPSDataReader(AbstractDataReader):
 
     def create_shards(self):
         check_required_kwargs(["table", "records_per_task"], self._kwargs)
-        reader = self.get_odps_reader(self._kwargs["table"])
-        shard_name_prefix = self._kwargs["table"] + ":shard_"
+        table_name = self._kwargs["table"]
+        reader = self.get_odps_reader(table_name)
         table_size = reader.get_table_size()
         records_per_task = self._kwargs["records_per_task"]
-        shards = {}
+        shards = []
         num_shards = table_size // records_per_task
         start_ind = 0
         for shard_id in range(num_shards):
-            shards[shard_name_prefix + str(shard_id)] = (
-                start_ind,
-                records_per_task,
-            )
+            shards.append((table_name, start_ind, records_per_task,))
             start_ind += records_per_task
         num_records_left = table_size % records_per_task
         if num_records_left != 0:
-            shards[shard_name_prefix + str(num_shards)] = (
-                start_ind,
-                num_records_left,
-            )
+            shards.append((table_name, start_ind, num_records_left,))
         return shards
 
     @property

--- a/elasticdl/python/data/reader/recordio_reader.py
+++ b/elasticdl/python/data/reader/recordio_reader.py
@@ -48,11 +48,11 @@ class RecordIODataReader(AbstractDataReader):
     def create_shards(self):
         data_dir = self._kwargs["data_dir"]
         start_ind = 0
-        f_records = {}
+        f_records = []
         for f in os.listdir(data_dir):
             p = os.path.join(data_dir, f)
             with closing(recordio.Index(p)) as rio:
-                f_records[p] = (start_ind, rio.num_records())
+                f_records.append((p, start_ind, rio.num_records()))
         return f_records
 
     @property

--- a/elasticdl/python/master/task_manager.py
+++ b/elasticdl/python/master/task_manager.py
@@ -231,8 +231,9 @@ class TaskManager(object):
         # Note that a shard may contain records for multiple tasks.
         for (
             shard_name,
-            (start_ind_this_shard, num_records_this_shard),
-        ) in shards.items():
+            start_ind_this_shard,
+            num_records_this_shard,
+        ) in shards:
             max_ind_this_shard = start_ind_this_shard + num_records_this_shard
             self._job_counters[
                 task_type
@@ -307,8 +308,8 @@ class TaskManager(object):
         shards = self._training_shards
         assert shards is not None
 
-        (shard_name, (start_ind_this_shard, num_records_this_shard)) = next(
-            iter(shards.items())
+        (shard_name, start_ind_this_shard, num_records_this_shard) = next(
+            iter(shards)
         )
         start_ind_this_task = start_ind_this_shard
         end_ind_this_task = start_ind_this_shard + min(

--- a/elasticdl/python/tests/data_reader_test.py
+++ b/elasticdl/python/tests/data_reader_test.py
@@ -50,7 +50,7 @@ class RecordIODataReaderTest(unittest.TestCase):
             )
 
             # Test shards creation
-            expected_shards = {shard_name: (0, num_records)}
+            expected_shards = [(shard_name, 0, num_records)]
             reader = RecordIODataReader(data_dir=temp_dir_name)
             self.assertEqual(expected_shards, reader.create_shards())
 

--- a/elasticdl/python/tests/evaluation_service_test.py
+++ b/elasticdl/python/tests/evaluation_service_test.py
@@ -95,7 +95,7 @@ class EvaluationServiceTest(unittest.TestCase):
 
     def testEvaluationService(self):
         task_d = create_task_manager(
-            {"f1": (0, 10), "f2": (0, 10)}, {"f1": (0, 10), "f2": (0, 10)}
+            [("f1", 0, 10), ("f2", 0, 10)], [("f1", 0, 10), ("f2", 0, 10)]
         )
 
         # Evaluation metrics will not be accepted if no evaluation ongoing
@@ -126,7 +126,7 @@ class EvaluationServiceTest(unittest.TestCase):
         self.assertFalse(evaluation_service.try_to_create_new_job())
 
     def testEvaluationOnly(self):
-        task_d = create_task_manager({}, {"f1": (0, 10), "f2": (0, 10)})
+        task_d = create_task_manager([], [("f1", 0, 10), ("f2", 0, 10)])
         task_d.create_tasks(elasticdl_pb2.EVALUATION)
 
         evaluation_service = EvaluationService(
@@ -150,7 +150,7 @@ class EvaluationServiceTest(unittest.TestCase):
 
     def testNeedEvaluation(self):
         task_d = create_task_manager(
-            {"f1": (0, 10), "f2": (0, 10)}, {"f1": (0, 10), "f2": (0, 10)}
+            [("f1", 0, 10), ("f2", 0, 10)], [("f1", 0, 10), ("f2", 0, 10)]
         )
 
         evaluation_service = EvaluationService(

--- a/elasticdl/python/tests/pod_manager_test.py
+++ b/elasticdl/python/tests/pod_manager_test.py
@@ -105,7 +105,7 @@ class PodManagerTest(unittest.TestCase):
         Start a pod running a python program destined to fail with
         restart_policy="Never" to test failed_worker_count
         """
-        task_manager = create_task_manager({"f": (0, 10)}, {})
+        task_manager = create_task_manager([("f", 0, 10)], [])
         task_manager.recover_tasks = MagicMock()
         pod_manager = PodManager(
             job_name="test-failed-worker-pod-%d-%d"

--- a/elasticdl/python/tests/servicer_test.py
+++ b/elasticdl/python/tests/servicer_test.py
@@ -65,7 +65,7 @@ class ServicerTest(unittest.TestCase):
         self.assertIsNotNone(server)
 
     def test_get_empty_task(self):
-        self.master.task_manager = create_task_manager({}, {})
+        self.master.task_manager = create_task_manager([], [])
         master_servicer = MasterServicer(
             self.master.task_manager, self.master.instance_manager, None, None,
         )
@@ -85,7 +85,7 @@ class ServicerTest(unittest.TestCase):
 
     def test_report_task_result(self):
         self.master.task_manager = create_task_manager(
-            {"shard_1": (0, 10), "shard_2": (0, 9)}, {}, 2
+            [("shard_1", 0, 10), ("shard_2", 0, 9)], [], 2
         )
         master = MasterServicer(
             self.master.task_manager, self.master.instance_manager, None, None,

--- a/elasticdl/python/tests/task_manager_test.py
+++ b/elasticdl/python/tests/task_manager_test.py
@@ -21,7 +21,7 @@ from elasticdl.python.tests.test_utils import create_task_manager
 
 class TaskManagerTest(unittest.TestCase):
     def test_create_tasks_with_zero_start_ind(self):
-        task_d = create_task_manager({"f1": (0, 10), "f2": (0, 10)}, {})
+        task_d = create_task_manager([("f1", 0, 10), ("f2", 0, 10)], [])
 
         all_tasks = [
             ("f1", 0, 3, elasticdl_pb2.TRAINING, -1),
@@ -76,7 +76,7 @@ class TaskManagerTest(unittest.TestCase):
         self.assertTrue(task_d.finished())
 
     def test_create_tasks_with_non_zero_start_ind(self):
-        task_d = create_task_manager({"f1": (0, 10), "f2": (10, 10)}, {})
+        task_d = create_task_manager([("f1", 0, 10), ("f2", 10, 10)], [])
 
         all_tasks = [
             ("f1", 0, 3, elasticdl_pb2.TRAINING, -1),
@@ -99,7 +99,7 @@ class TaskManagerTest(unittest.TestCase):
         self.assertEqual(sorted([v._info() for _, v in got_tasks]), all_tasks)
 
     def test_epoch(self):
-        task_d = create_task_manager({"f1": (0, 10), "f2": (0, 10)}, {}, 2)
+        task_d = create_task_manager([("f1", 0, 10), ("f2", 0, 10)], [], 2)
 
         epoch_tasks = [
             ("f1", 0, 3, elasticdl_pb2.TRAINING, -1),
@@ -125,7 +125,7 @@ class TaskManagerTest(unittest.TestCase):
         )
 
     def test_invoke_train_end_callback(self):
-        task_d = create_task_manager({"f1": (0, 10), "f2": (0, 10)}, {})
+        task_d = create_task_manager([("f1", 0, 10), ("f2", 0, 10)], [])
         task_d._add_deferred_callback_create_train_end_task()
         task_d._todo.clear()
         task_d.invoke_deferred_callback()
@@ -135,7 +135,7 @@ class TaskManagerTest(unittest.TestCase):
         )
 
     def test_check_and_reassign_timeout_tasks(self):
-        task_manager = create_task_manager({"f1": (0, 10), "f2": (0, 10)}, {})
+        task_manager = create_task_manager([("f1", 0, 10), ("f2", 0, 10)], [])
         task_manager.create_tasks(elasticdl_pb2.TRAINING)
         task_count = len(task_manager._todo)
         task_start_time = time.time() - 1000
@@ -152,7 +152,7 @@ class TaskManagerTest(unittest.TestCase):
         self.assertEqual(len(task_manager._todo), task_count)
 
     def test_get_average_task_completed_time(self):
-        task_manager = create_task_manager({"f1": (0, 10), "f2": (0, 10)}, {})
+        task_manager = create_task_manager([("f1", 0, 10), ("f2", 0, 10)], [])
         average_task_completed_time = (
             task_manager._get_average_task_completed_time()
         )

--- a/elasticdl/python/tests/test_utils.py
+++ b/elasticdl/python/tests/test_utils.py
@@ -411,12 +411,13 @@ def distributed_train_and_evaluate(
         record_num = batch_size
     else:
         record_num = 128
-    shards = {
-        create_recordio_file(record_num, dataset_name, feature_shape): (
+    shards = [
+        (
+            create_recordio_file(record_num, dataset_name, feature_shape),
             0,
             record_num,
         )
-    }
+    ]
     task_args = TaskManagerArgs(minibatch_size=2, num_minibatches_per_task=32)
     task_d = TaskManager(task_args)
 
@@ -426,7 +427,7 @@ def distributed_train_and_evaluate(
         task_d.create_tasks(elasticdl_pb2.TRAINING)
         task_d.create_tasks(elasticdl_pb2.EVALUATION)
     else:
-        task_d._training_shards = {}
+        task_d._training_shards = []
         task_d._evaluation_shards = shards
         task_d.create_tasks(elasticdl_pb2.TRAINING)
 


### PR DESCRIPTION
Now, we use a dictionary whose keys are file names. The file name will be the same if all data shards are stored in the same file such as the MaxCompute table. In this case, we must add `shard_{index}` to the file name as the key. It is better to use a list to store the shards which are tuples with 3 elements such as `[(file_name, start_index, num_records)]`.