### PR TITLE
Set the priority of at least 1 worker to high if the priority is a fraction.

### DIFF
--- a/docs/designs/elasticdl_operator.md
+++ b/docs/designs/elasticdl_operator.md
@@ -70,7 +70,7 @@ spec:
       '' --image_name 'elasticdl:test' --job_name 'test-mnist' --master_resource_request
       'cpu=1,memory=1024Mi' --master_resource_limit 'cpu=1,memory=2048Mi' --num_workers
       '8' --worker_resource_request 'cpu=2,gpu=1,memory=2048Mi' --worker_resource_limit
-      'cpu=2,gpu=1,memory=2048Mi' --master_pod_priority '' --worker_pod_priority 'high=0.5' --num_ps_pods
+      'cpu=2,gpu=1,memory=2048Mi' --master_pod_priority '' --worker_pod_priority '0.5' --num_ps_pods
       '1' --ps_resource_request 'cpu=2,memory=1024Mi' --ps_resource_limit 'cpu=2,memory=2048Mi'
       --ps_pod_priority 'high' --volume 'host_path=/data,mount_path=/data' --image_pull_policy
       'Never' --restart_policy 'Never' --envs '' --extra_pypi_index 'https://pypi.org/simple'
@@ -138,7 +138,7 @@ spec:
     resource_request: "cpu=1,memory=1024Mi"
   worker:
     count: 10
-    priority: high=0.5
+    priority: 0.5
     image: elasticdl-worker
     resource_request: "cpu=4,gpu=1,memory=2048Mi"
     volume: "host_path=/host_data,mount_path=/data"

--- a/elasticdl/python/master/pod_manager.py
+++ b/elasticdl/python/master/pod_manager.py
@@ -52,6 +52,8 @@ def _get_addrs(num_addrs, addr_get_fn):
 
 
 def _is_float_str(str_number):
+    if not str_number:
+        return False
     try:
         float(str_number)
         return True

--- a/elasticdl/python/master/pod_manager.py
+++ b/elasticdl/python/master/pod_manager.py
@@ -14,6 +14,7 @@
 
 import copy
 import itertools
+import math
 import os
 import threading
 import time
@@ -65,15 +66,13 @@ def _parse_worker_pod_priority(num_workers, worker_pod_priority):
     res = {}
     if _is_float_str(worker_pod_priority):
         fraction = float(worker_pod_priority)
-        high_count = int(num_workers * fraction)
-        # At least 1 worker has high priority
-        high_count = 1 if high_count < 1 else high_count
+        high_count = math.ceil(num_workers * fraction)
         for i in range(num_workers):
             if i < high_count:
                 res[i] = "high"
             else:
                 res[i] = "low"
-    elif worker_pod_priority in ["", "high", "low"]:
+    elif worker_pod_priority in [None, "", "high", "low"]:
         for i in range(num_workers):
             res[i] = worker_pod_priority
     else:

--- a/elasticdl/python/master/pod_manager.py
+++ b/elasticdl/python/master/pod_manager.py
@@ -57,6 +57,8 @@ def _parse_worker_pod_priority(num_workers, worker_pod_priority):
         try:
             fraction = float(worker_pod_priority.split("=")[1])
             high_count = int(num_workers * fraction)
+            # At least 1 worker has high priority
+            high_count = 1 if high_count < 1 else high_count
             for i in range(num_workers):
                 if i < high_count:
                     res[i] = "high"

--- a/elasticdl/python/tests/pod_manager_test.py
+++ b/elasticdl/python/tests/pod_manager_test.py
@@ -19,7 +19,10 @@ from unittest.mock import MagicMock, call
 
 from elasticdl.python.common.k8s_client import PodType
 from elasticdl.python.master.pod_event_callbacks import TaskRescheduleCallback
-from elasticdl.python.master.pod_manager import PodManager
+from elasticdl.python.master.pod_manager import (
+    PodManager,
+    _parse_worker_pod_priority,
+)
 from elasticdl.python.tests.test_utils import create_task_manager
 
 
@@ -260,6 +263,17 @@ class PodManagerTest(unittest.TestCase):
             self.fail("Failed to find newly launched ps.")
 
         pod_manager.stop_relaunch_and_remove_pods(pod_type=PodType.PS)
+
+    def test_parse_worker_pod_priority(self):
+        worker_priorities = _parse_worker_pod_priority(10, "high=0.5")
+        expected = {}
+        for i in range(5):
+            expected[i] = "high"
+        for i in range(5, 10):
+            expected[i] = "low"
+        self.assertDictEqual(worker_priorities, expected)
+        worker_priorities = _parse_worker_pod_priority(1, "high=0.5")
+        self.assertDictEqual(worker_priorities, {0: "high"})
 
 
 if __name__ == "__main__":

--- a/elasticdl/python/tests/pod_manager_test.py
+++ b/elasticdl/python/tests/pod_manager_test.py
@@ -265,14 +265,14 @@ class PodManagerTest(unittest.TestCase):
         pod_manager.stop_relaunch_and_remove_pods(pod_type=PodType.PS)
 
     def test_parse_worker_pod_priority(self):
-        worker_priorities = _parse_worker_pod_priority(10, "high=0.5")
+        worker_priorities = _parse_worker_pod_priority(10, "0.5")
         expected = {}
         for i in range(5):
             expected[i] = "high"
         for i in range(5, 10):
             expected[i] = "low"
         self.assertDictEqual(worker_priorities, expected)
-        worker_priorities = _parse_worker_pod_priority(1, "high=0.5")
+        worker_priorities = _parse_worker_pod_priority(1, "0.5")
         self.assertDictEqual(worker_priorities, {0: "high"})
 
 

--- a/elasticdl_client/common/args.py
+++ b/elasticdl_client/common/args.py
@@ -270,7 +270,7 @@ def add_common_params(parser):
         "--worker_pod_priority",
         default="",
         help="The requested priority of worker pod, we support following"
-        "configs: high/low/high=0.5. The high=0.5 means that half"
+        "configs: high/low/0.5. The 0.5 means that half"
         "worker pods have high priority, and half worker pods have"
         "low priority. The default value is low",
     )


### PR DESCRIPTION
The master will exit if there is no worker. So we must guarantee at least 1 worker will not be preempted.