### PR TITLE
Set worker number into the env of workers.

### DIFF
--- a/elasticdl/python/master/pod_manager.py
+++ b/elasticdl/python/master/pod_manager.py
@@ -137,6 +137,9 @@ def create_pod_manager(args):
         for key in env_dict:
             env.append(V1EnvVar(name=key, value=env_dict[key]))
         env.append(V1EnvVar(name=WorkerEnv.MASTER_ADDR, value=master_addr))
+        env.append(
+            V1EnvVar(name=WorkerEnv.WORKER_NUM, value=str(args.num_workers))
+        )
 
         kwargs = get_dict_from_params_str(args.aux_params)
         disable_relaunch = kwargs.get("disable_relaunch", False)


### PR DESCRIPTION
`PytorchAllReduceController` needs to get worker number from envs.
https://github.com/sql-machine-learning/elasticdl/blob/ce5945a55675efd15f4c81127dbbbdc52224400f/elasticdl/python/allreduce/pytorch_controller.py#L96