### PR TITLE
Add the DistributedOptimizer for TF1.x for elastic training.

### DIFF
--- a/elasticdl/python/allreduce/tensorflow_optimizer.py
+++ b/elasticdl/python/allreduce/tensorflow_optimizer.py
@@ -1,0 +1,590 @@
+# Copyright 2020 The ElasticDL Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import horovod.tensorflow as hvd
+import tensorflow as tf
+from horovod.tensorflow import _LegacyOptimizer
+
+def complement_value_from_env_if_none(original_value, key, clz):
+    if original_value is not None:
+        return original_value
+
+    if key in os.environ:
+        return clz(os.environ.get(key))
+
+    raise ValueError("Cannot complement the value with key {} from environment".format(key))
+
+class AdjustBackwardPassesPerStepHook(tf.train.SessionRunHook):
+    """
+    Hooks that adjusts `backward_passer_per_step` according to
+    the horovod size dynamically.
+    """
+
+    def __init__(
+        self, backward_passes_per_step_var, global_batch_count_per_step=None
+    ):
+        """
+        Args:
+            backward_passes_per_step_var: A tf.Variable which stands for
+                `backward_passes_per_step` of this process.
+            global_batch_count_per_step: The total batch counts per step
+                of all the workers for this training job.
+        """
+        self._value_placeholder = tf.placeholder(
+            backward_passes_per_step_var.dtype, []
+        )
+        self._update_op = tf.assign(
+            backward_passes_per_step_var, self._value_placeholder
+        )
+
+        self._global_batch_count_per_step = complement_value_from_env_if_none(
+            global_batch_count_per_step,
+            "global_batch_count_per_step",
+            int)
+
+    def before_run(self, run_context):
+        size = hvd.size()
+        rank = hvd.rank()
+        backward_passer_per_step_value = (
+            self._global_batch_count_per_step // size
+            + int(rank < self._global_batch_count_per_step % size)
+        )
+        run_context.session.run(
+            self._update_op,
+            feed_dict={
+                self._value_placeholder: backward_passer_per_step_value
+            },
+        )
+
+
+def apply_op_to_not_none_tensors(tensor_op, tensors, *args):
+    return [
+        tensor_op(tensor, *args) if tensor is not None else tensor
+        for tensor in tensors
+    ]
+
+
+def get_not_none_from_list(tensor_list):
+    return [x for x in tensor_list if x is not None]
+
+
+# Update based on horovod v0.21.0
+# https://github.com/horovod/horovod/blob/7d71874258fc8625ad8952defad0ea5b24531248/horovod/tensorflow/gradient_aggregation.py#L16
+# Make `backward_passes_per_step` a tensorflow variable instead of
+# a primitive python type.
+class LocalGradientAggregationHelper:
+    """
+    LocalGradientAggregationHelper aggregates gradient updates locally,
+    and communicates the updates across machines only once every
+    backward_passes_per_step. Only supports graph mode execution.
+    """
+
+    _OPTIMIZER_TYPE_KERAS = "optimizer_type_keras"
+    _OPTIMIZER_TYPE_LEGACY = "optimizer_type_legacy"
+
+    def __init__(
+            self,
+            backward_passes_per_step,
+            allreduce_func,
+            sparse_as_dense,
+            average_aggregated_gradients,
+            rank,
+            optimizer_type,
+            global_batch_count_per_step,
+            op):
+        self._allreduce_grads = allreduce_func
+
+        # backward_passes_per_step controls how often gradient updates are
+        # synchronized.
+        self.backward_passes_per_step = tf.Variable(
+            initial_value=backward_passes_per_step,
+            trainable=False,
+            dtype=tf.int32,
+        )
+
+        # average_aggregated_gradients controls whether gradient updates that are
+        # aggregated, should be divided by `backward_passes_per_step`.
+        self.average_aggregated_gradients = average_aggregated_gradients
+
+        # This is going to be [N] data structure holding the aggregated gradient updates
+        # N is the number of parameters.
+        self.locally_aggregated_grads = []
+
+        # Used to know when to allreduce and apply gradients. We allreduce when `self.counter`
+        # is equal to `self.backward_passes_per_step`. We apply gradients when `self.counter` is
+        # equal to 0.
+        self.counter = None
+
+        self.sparse_as_dense = sparse_as_dense
+        self.rank = rank
+        self.optimizer_type = optimizer_type
+
+        # Contains the mapping of indexes of grad updates that are not None to their index in
+        # locally_aggregated_grads which only contains not None gradients. When performing
+        # gradient aggregation we have to remove them from the list of grads prior to passing
+        # the list into a tf.cond().
+        self.not_none_indexes = {}
+        self.num_none_grad_updates = 0
+
+        # *ElasticDL Update*: add two more fields for updating
+        # gradient value.
+        self.global_batch_count_per_step = global_batch_count_per_step
+        self.op = op
+
+    def _init_aggregation_vars(self, grads):
+        """
+        Initializes the counter that is used when to communicate and aggregate gradients
+        and the tensorflow variables that store the locally aggregated gradients.
+        """
+        variable_scope_name = "aggregation_variables_" + str(self.rank)
+        with tf.compat.v1.variable_scope(variable_scope_name, reuse=tf.compat.v1.AUTO_REUSE):
+            self.counter = tf.compat.v1.get_variable(
+                "aggregation_counter", shape=(), dtype=tf.int32,
+                trainable=False, initializer=tf.compat.v1.zeros_initializer(),
+                collections=[tf.compat.v1.GraphKeys.LOCAL_VARIABLES],
+            )
+            for idx, grad in enumerate(grads):
+                # Handle IndexedSlices.
+                if self.sparse_as_dense and isinstance(grad, tf.IndexedSlices):
+                    grad = tf.convert_to_tensor(grad)
+                elif isinstance(grad, tf.IndexedSlices):
+                    raise ValueError(
+                        "IndexedSlices are not supported when "
+                        "`backward_passes_per_step` > 1 and "
+                        "`sparse_as_dense` is False."
+                    )
+
+                # Handle grads that are None.
+                if grad is None:
+                    self.num_none_grad_updates += 1
+                    continue
+                self.not_none_indexes[idx] = len(self.locally_aggregated_grads)
+
+                # Create shadow variable.
+                grad_aggregation_variable_name = str(idx)
+                zero_grad = tf.zeros(shape=grad.get_shape().as_list(), dtype=grad.dtype)
+                grad_aggregation_variable = tf.compat.v1.get_variable(
+                    grad_aggregation_variable_name,
+                    trainable=False,
+                    initializer=zero_grad,
+                    collections=[
+                        tf.compat.v1.GraphKeys.LOCAL_VARIABLES,
+                        "aggregating_collection"],
+                )
+                self.locally_aggregated_grads.append(grad_aggregation_variable)
+            assert len(self.locally_aggregated_grads) + \
+                self.num_none_grad_updates == len(grads)
+
+        # We expect to get a `sess` when we need to manually do a `sess.run(...)`
+        # for the variables to be initialized. This is the `tf.keras`
+        # optimizers.
+        if self.optimizer_type == self._OPTIMIZER_TYPE_KERAS:
+            session = tf.compat.v1.keras.backend.get_session(op_input_list=())
+            vars_init_op = tf.compat.v1.variables_initializer(
+                [self.counter, *get_not_none_from_list(self.locally_aggregated_grads)]
+            )
+            session.run(vars_init_op)
+
+    def _clear_grads(self):
+        clear_ops_list = []
+        for idx, grad_aggregator in enumerate(self.locally_aggregated_grads):
+            clear_op = grad_aggregator.assign(grad_aggregator.initial_value)
+            clear_ops_list.append(clear_op)
+        return tf.group(*clear_ops_list)
+
+    def _aggregate_grads(self, grads):
+        aggregation_ops_list = []
+        grads = get_not_none_from_list(grads)
+        assert len(grads) == len(self.locally_aggregated_grads)
+
+        # Apply new gradient updates to the local copy.
+        for idx, grad in enumerate(grads):
+            if self.sparse_as_dense and isinstance(grad, tf.IndexedSlices):
+                grad = tf.convert_to_tensor(grad)
+
+            updated_grad_aggregator = self.locally_aggregated_grads[idx].assign_add(
+                grad)
+            aggregation_ops_list.append(updated_grad_aggregator)
+
+        return aggregation_ops_list
+
+    def _allreduce_grads_helper(self, grads):
+        # Read in latest variables values.
+        aggregated_grads = []
+        aggregation_read_ops_list = []
+        for idx, locally_aggregated_grad in enumerate(
+                self.locally_aggregated_grads):
+            aggregated_grads.append(locally_aggregated_grad.read_value())
+            aggregation_read_ops_list.append(aggregated_grads[idx])
+        aggregation_read_ops = tf.group(*aggregation_read_ops_list)
+
+        with tf.control_dependencies([aggregation_read_ops]):
+            averaged_gradients = self._allreduce_grads(aggregated_grads)
+
+            # Reset counter.
+            with tf.control_dependencies([g.op for g in averaged_gradients if g is not None]):
+                reset_op = self.counter.assign(
+                    tf.constant(0), use_locking=True)
+
+            # *Elastic Update*: If ReduceOP is average,
+            # multiply horovod_size / global_batch_count_per_step
+            with tf.control_dependencies([reset_op]):
+                averaged_gradients = self.update_gradients_for_elastic_workers(averaged_gradients)
+
+                # Divide by backward_passes_per_step if
+                # average_aggregated_gradients is True.
+                with tf.control_dependencies([g.op for g in averaged_gradients if g is not None]):
+                # with tf.control_dependencies([reset_op]):
+                    gradient_divisor = self.backward_passes_per_step if \
+                        self.average_aggregated_gradients else 1
+
+                    averaged_gradients = apply_op_to_not_none_tensors(
+                        tf.divide,
+                        averaged_gradients,
+                        gradient_divisor,
+                    )
+                    return averaged_gradients
+
+    # *ElasticDL Update*: Update the gradient using
+    # global_batch_count_per_step if the ReduceOP is average.
+    def update_gradients_for_elastic_workers(self, grads):
+        if self.op == hvd.Average:
+            valid_grads = get_not_none_from_list(grads)
+            horovod_size = tf.cast(hvd.size_op() if int(os.environ.get("HOROVOD_ELASTIC", 0)) else hvd.size(),
+                                   dtype=valid_grads[0].dtype)
+            gradient_multiplier = horovod_size / self.global_batch_count_per_step
+            return apply_op_to_not_none_tensors(
+                tf.multiply,
+                grads,
+                gradient_multiplier)
+        
+        return grads
+
+    def compute_gradients(self, grads):
+        """
+        Applies the new gradient updates the locally aggregated gradients, and
+        performs cross-machine communication every backward_passes_per_step
+        times it is called.
+        """
+        self._init_aggregation_vars(grads)
+
+        # Clear the locally aggregated gradients when the counter is at zero.
+        clear_op = tf.cond(
+            pred=tf.equal(self.counter, 0),
+            true_fn=lambda: self._clear_grads(),
+            false_fn=tf.no_op
+        )
+
+        # Add new gradients to the locally aggregated gradients.
+        with tf.control_dependencies([clear_op]):
+            aggregation_ops_list = self._aggregate_grads(grads)
+
+        # Increment the counter once new gradients have been applied.
+        aggregation_ops = tf.group(*aggregation_ops_list)
+        with tf.control_dependencies([aggregation_ops]):
+            update_counter = self.counter.assign_add(tf.constant(1))
+
+        with tf.control_dependencies([update_counter]):
+            grads = get_not_none_from_list(grads)
+            assert len(grads) == len(self.locally_aggregated_grads)
+
+            # Allreduce locally aggregated gradients when the counter is equivalent to
+            # `backward_passes_per_step`. This the condition is true, it also resets
+            # the counter back to 0.
+            allreduced_grads = tf.cond(
+                tf.equal(self.counter, self.backward_passes_per_step),
+                lambda: self._allreduce_grads_helper(grads),
+                lambda: grads,
+            )
+
+            # Handle case where there is only one variable.
+            if not isinstance(allreduced_grads, (list, tuple)):
+                allreduced_grads = (allreduced_grads,)
+            assert len(allreduced_grads) == len(self.locally_aggregated_grads)
+
+            # Insert gradients that are None back in.
+            allreduced_grads = [
+                allreduced_grads[self.not_none_indexes[idx]] if idx in self.not_none_indexes else None
+                for idx in range(len(self.locally_aggregated_grads) + self.num_none_grad_updates)
+            ]
+            assert len(allreduced_grads) == len(
+                self.locally_aggregated_grads) + self.num_none_grad_updates
+
+        # If gradients have not been allreduced this batch, we return the gradients
+        # that were submitted as the updates (the input).
+        return allreduced_grads
+
+    def apply_gradients(self, apply_grads_closure, optimizer, *args, **kwargs):
+        """
+        Apply updates every backward_passes_per_step, which lines up with
+        the batches on which we communicated the locally aggregated gradients.
+        """
+        flattended_args0 = [item for tup in args[0] for item in tup]
+
+        # Since we skip applying updates when the counter is not at zero we
+        # still want to increment the global step if it is being tracked
+        # (e.g., Tensorflow Estimators).
+        def increment_global_step_counter():
+            global_step_counter = tf.compat.v1.train.get_global_step()
+            if global_step_counter is None:
+                return tf.no_op()
+            return global_step_counter.assign_add(
+                tf.constant(1, dtype=tf.int64),
+                use_locking=True,
+                read_value=False
+            )
+
+        # Increment global step on iterations where we don't call `apply_gradients()`.
+        cond_increment_global_step_counter = tf.cond(
+            pred=tf.equal(self.counter, 0),
+            true_fn=tf.no_op,
+            false_fn=increment_global_step_counter,
+        )
+        flattended_args0.append(cond_increment_global_step_counter)
+
+        # If optimizer tracks iterations, we increment it on steps where we
+        # are not going to call `apply_gradients()`.
+        def increment_optimizer_iteration():
+            if hasattr(optimizer, "_iterations") and optimizer._iterations is not None:
+                return optimizer._iterations.assign_add(1).op
+            return tf.no_op()
+
+        with tf.control_dependencies([tf.group(*get_not_none_from_list(flattended_args0))]):
+            return tf.cond(
+                pred=tf.equal(self.counter, 0),
+                true_fn=apply_grads_closure,
+                false_fn=increment_optimizer_iteration,
+            )
+
+
+# `_DistributedOptimizer` is updated based on horovod v0.21.0
+# https://github.com/horovod/horovod/blob/7d71874258fc8625ad8952defad0ea5b24531248/horovod/tensorflow/__init__.py#L396
+# Update the __init__ function.
+class _DistributedOptimizer(_LegacyOptimizer):
+    """An optimizer that wraps another tf.Optimizer, using an allreduce to
+    combine gradient values before applying gradients to model weights."""
+
+    def __init__(self, optimizer, name=None, use_locking=False, device_dense='',
+                device_sparse='', compression=hvd.Compression.none,
+                sparse_as_dense=False, op=hvd.Average, gradient_predivide_factor=1.0,
+                backward_passes_per_step=1, average_aggregated_gradients=False,
+                num_groups=0, global_batch_count_per_step=None):
+        if name is None:
+            name = "Distributed{}".format(type(optimizer).__name__)
+        super(_DistributedOptimizer, self).__init__(name=name, use_locking=use_locking)
+
+        self._optimizer = optimizer
+        self._allreduce_grads = hvd._make_allreduce_grads_fn(
+            name, device_dense, device_sparse, compression, sparse_as_dense, op,
+            gradient_predivide_factor, num_groups)
+
+        # *ElasticDL Update*: Always create LocalGradientAggregationHelper
+        # for Elastic training with fixed global batch size.
+        self._agg_helper = LocalGradientAggregationHelper(
+            backward_passes_per_step=backward_passes_per_step,
+            allreduce_func=self._allreduce_grads,
+            sparse_as_dense=sparse_as_dense,
+            average_aggregated_gradients=average_aggregated_gradients,
+            rank=hvd.rank(),
+            optimizer_type=LocalGradientAggregationHelper._OPTIMIZER_TYPE_LEGACY,
+            global_batch_count_per_step=global_batch_count_per_step,
+            op=op,
+        )
+
+    def compute_gradients(self, *args, **kwargs):
+        """Compute gradients of all trainable variables.
+
+        See Optimizer.compute_gradients() for more info.
+
+        In DistributedOptimizer, compute_gradients() is overriden to also
+        allreduce the gradients before returning them.
+        """
+        gradients = self._optimizer.compute_gradients(*args, **kwargs)
+        grads, vars = zip(*gradients)
+        if self._agg_helper:
+            avg_grads = self._agg_helper.compute_gradients(grads)
+        else:
+            avg_grads = self._allreduce_grads(grads)
+        return list(zip(avg_grads, vars))
+
+    def apply_gradients(self, *args, **kwargs):
+        """Calls this same method on the underlying optimizer."""
+        if self._agg_helper:
+            return self._agg_helper.apply_gradients(
+                lambda: self._optimizer.apply_gradients(*args, **kwargs),
+                self._optimizer,
+                *args,
+                **kwargs,
+            )
+
+        return self._optimizer.apply_gradients(*args, **kwargs)
+
+    def get_slot(self, *args, **kwargs):
+        """Calls this same method on the underlying optimizer."""
+        return self._optimizer.get_slot(*args, **kwargs)
+
+    def get_slot_names(self, *args, **kwargs):
+        """Calls this same method on the underlying optimizer."""
+        return self._optimizer.get_slot_names(*args, **kwargs)
+
+    def variables(self, *args, **kwargs):
+        """Calls this same method on the underlying optimizer."""
+        return self._optimizer.variables(*args, **kwargs)
+
+    @property
+    def counter(self):
+        return self._agg_helper.counter
+
+    @property
+    def backward_passes_per_step(self):
+        return self._agg_helper.backward_passes_per_step
+
+
+def DistributedOptimizer(optimizer, name=None, use_locking=False, device_dense='',
+                         device_sparse='', compression=hvd.Compression.none,
+                         sparse_as_dense=False, backward_passes_per_step=1,
+                         op=hvd.Average, gradient_predivide_factor=1.0,
+                         average_aggregated_gradients=False,
+                         num_groups=0,
+                         fixed_global_batch_size=False,
+                         global_batch_count_per_step=None):
+    """Construct a new DistributedOptimizer, which uses another optimizer
+    under the hood for computing single-process gradient values and
+    applying gradient updates after the gradient values have been combined
+    across all the Horovod ranks.
+
+    Args:
+      optimizer:
+        Optimizer to use for computing gradients and applying updates.
+      name:
+        Optional name prefix for the operations created when applying
+        gradients. Defaults to "Distributed" followed by the provided
+        optimizer type.
+      use_locking:
+        Whether to use locking when updating variables.
+        See Optimizer.__init__ for more info.
+      device_dense:
+        Device to be used for dense tensors. Uses GPU by default
+        if Horovod was built with HOROVOD_GPU_OPERATIONS.
+      device_sparse:
+        Device to be used for sparse tensors. Uses GPU by default
+        if Horovod was built with HOROVOD_GPU_OPERATIONS.
+      compression:
+        Compression algorithm used during allreduce to reduce the amount
+        of data sent during each parameter update step.  Defaults to
+        not using compression.
+      sparse_as_dense:
+        Treat all sparse gradients as dense tensors.  This can help improve
+        performance and memory utilization if the original sparse gradient
+        has high density.  Defaults to false.
+      backward_passes_per_step:
+        Number of backward passes to perform before calling hvd.allreduce.
+        This allows accumulating updates over multiple mini-batches before
+        reducing and applying them.
+      op:
+        The reduction operation to use when combining gradients across
+        different ranks.
+      gradient_predivide_factor:
+        If op == Average, gradient_predivide_factor splits the averaging
+        before and after the sum. Gradients are scaled by
+        1.0 / gradient_predivide_factor before the sum and
+        gradient_predivide_factor / size after the sum.
+      average_aggregated_gradients:
+        Whether to average the aggregated gradients that have been accumulated
+        over multiple mini-batches. If true divides gradients updates by
+        backward_passes_per_step. Only applicable for backward_passes_per_step > 1.
+      num_groups:
+        Number of groups to assign gradient allreduce ops to for explicit
+        grouping. Defaults to no explicit groups.
+    fixed_global_batch_size:
+        Whether to keep the global batch size is fixed even though the worker number
+        is changing during elastic execution.
+    global_batch_count_per_step:
+        Total batch number per step of all the workers.
+    """
+
+    # *ElasticDL Update#: If `fixed_global_batch_size` == False,
+    # just fallback to the native horovod DistributedOptimizer.
+    if not fixed_global_batch_size:
+        return hvd.DistributedOptimizer(
+            optimizer=optimizer,
+            name=name,
+            use_locking=use_locking,
+            device_dense=device_dense,
+            device_sparse=device_sparse,
+            compression=compression,
+            sparse_as_dense=sparse_as_dense,
+            backward_passes_per_step=backward_passes_per_step,
+            op=op,
+            gradient_predivide_factor=gradient_predivide_factor,
+            average_aggregated_gradients=average_aggregated_gradients,
+            num_groups=num_groups)
+
+    if gradient_predivide_factor != 1.0:
+        if hvd.rocm_built():
+            raise ValueError('gradient_predivide_factor not supported yet with ROCm')
+        if op != hvd.Average:
+            raise ValueError('gradient_predivide_factor not supported with op != Average')
+
+    if op == hvd.Adasum and average_aggregated_gradients:
+        raise ValueError('Adasum does not support average_aggregated_gradients == True')
+
+
+    if isinstance(optimizer, _LegacyOptimizer):
+        if op == hvd.Adasum:
+            return hvd._DistributedAdasumOptimizer(optimizer, name, use_locking, device_dense,
+                                            device_sparse, compression, backward_passes_per_step)
+
+        # If global_batch_count_per_step is None from the parameter,
+        # try to get the value from environment variable.
+        global_batch_count_per_step = complement_value_from_env_if_none(
+            global_batch_count_per_step,
+            "global_batch_count_per_step",
+            int
+        )
+        return _DistributedOptimizer(
+            optimizer=optimizer,
+            name=name,
+            use_locking=use_locking,
+            device_dense=device_dense,
+            device_sparse=device_sparse,
+            compression=compression,
+            sparse_as_dense=sparse_as_dense,
+            op=op,
+            gradient_predivide_factor=gradient_predivide_factor,
+            backward_passes_per_step=backward_passes_per_step,
+            average_aggregated_gradients=average_aggregated_gradients,
+            num_groups=num_groups,
+            global_batch_count_per_step=global_batch_count_per_step,
+        )
+    elif isinstance(optimizer, tf.keras.optimizers.Optimizer):
+        if op == hvd.Adasum:
+            raise ValueError('op == Adasum is not supported yet with Keras')
+
+        import horovod.tensorflow.keras as hvd_k
+        return hvd_k.DistributedOptimizer(
+            optimizer=optimizer,
+            name=name,
+            device_dense=device_dense,
+            device_sparse=device_sparse,
+            compression=compression,
+            sparse_as_dense=sparse_as_dense,
+            gradient_predivide_factor=gradient_predivide_factor,
+            backward_passes_per_step=backward_passes_per_step,
+            average_aggregated_gradients=average_aggregated_gradients,
+        )
+    else:
+        raise ValueError('Provided optimizer doesn\'t inherit from either legacy '
+                         'TensorFlow or Keras optimizer: %s' % optimizer)


### PR DESCRIPTION
For the TF1.x model trained using AllReduce strategy with horovod, if we want to train them using elastic way. Use this DistributedOptimizer instead of the one from horovod.

The Optimizer is already verified using the following sample model which are updated based on the sample model from horovod repo.
```Python
import argparse
import errno
import os

import horovod.tensorflow as hvd
import numpy as np
import tensorflow as tf
from tensorflow import keras

from elasticdl.python.allreduce.tensorflow_optimizer import (
    AdjustBackwardPassesPerStepHook,
    DistributedOptimizer,
)

layers = tf.layers

tf.logging.set_verbosity(tf.logging.INFO)

# Training settings
parser = argparse.ArgumentParser(description="Tensorflow MNIST Example")
parser.add_argument(
    "--use-adasum",
    action="store_true",
    default=False,
    help="use adasum algorithm to do reduction",
)
parser.add_argument(
    "--gradient-predivide-factor",
    type=float,
    default=1.0,
    help="apply gradient predivide factor in optimizer (default: 1.0)",
)
args = parser.parse_args()


def conv_model(feature, target, mode):
    """2-layer convolution model."""
    # Convert the target to a one-hot tensor of shape (batch_size, 10) and
    # with a on-value of 1 for each one-hot vector of length 10.
    target = tf.one_hot(tf.cast(target, tf.int32), 10, 1, 0)

    # Reshape feature to 4d tensor with 2nd and 3rd dimensions being
    # image width and height final dimension being the number of color
    # channels.
    feature = tf.reshape(feature, [-1, 28, 28, 1])

    # First conv layer will compute 32 features for each 5x5 patch
    with tf.variable_scope("conv_layer1"):
        h_conv1 = layers.conv2d(
            feature,
            32,
            kernel_size=[5, 5],
            activation=tf.nn.relu,
            padding="SAME",
        )
        h_pool1 = tf.nn.max_pool(
            h_conv1, ksize=[1, 2, 2, 1], strides=[1, 2, 2, 1], padding="SAME"
        )

    # Second conv layer will compute 64 features for each 5x5 patch.
    with tf.variable_scope("conv_layer2"):
        h_conv2 = layers.conv2d(
            h_pool1,
            64,
            kernel_size=[5, 5],
            activation=tf.nn.relu,
            padding="SAME",
        )
        h_pool2 = tf.nn.max_pool(
            h_conv2, ksize=[1, 2, 2, 1], strides=[1, 2, 2, 1], padding="SAME"
        )
        # reshape tensor into a batch of vectors
        h_pool2_flat = tf.reshape(h_pool2, [-1, 7 * 7 * 64])

    # Densely connected layer with 1024 neurons.
    h_fc1 = layers.dropout(
        layers.dense(h_pool2_flat, 1024, activation=tf.nn.relu),
        rate=0.5,
        training=mode == tf.estimator.ModeKeys.TRAIN,
    )

    # Compute logits (1 per class) and compute loss.
    logits = layers.dense(h_fc1, 10, activation=None)
    loss = tf.losses.softmax_cross_entropy(target, logits)

    return tf.argmax(logits, 1), loss


def train_input_generator(x_train, y_train, batch_size=64):
    assert len(x_train) == len(y_train)
    while True:
        p = np.random.permutation(len(x_train))
        x_train, y_train = x_train[p], y_train[p]
        index = 0
        while index <= len(x_train) - batch_size:
            yield x_train[
                index : (index + batch_size)  # noqa: ignore=E203
            ], y_train[
                index : (index + batch_size)  # noqa: ignore=E203
            ],
            index += batch_size


def main(_):
    WORKER_NUM = 3

    # Horovod: initialize Horovod.
    hvd.init()

    # Keras automatically creates a cache directory in ~/.keras/datasets for
    # storing the downloaded MNIST data. This creates a race
    # condition among the workers that share the same filesystem. If the
    # directory already exists by the time this worker gets around to creating
    # it, ignore the resulting exception and continue.
    cache_dir = os.path.join(os.path.expanduser("~"), ".keras", "datasets")
    if not os.path.exists(cache_dir):
        try:
            os.mkdir(cache_dir)
        except OSError as e:
            if e.errno == errno.EEXIST and os.path.isdir(cache_dir):
                pass
            else:
                raise

    # Download and load MNIST dataset.
    (x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data(
        "MNIST-data-%d" % hvd.rank()
    )

    # The shape of downloaded data is (-1, 28, 28), hence we need to reshape it
    # into (-1, 784) to feed into our network. Also, need to normalize the
    # features between 0 and 1.
    x_train = np.reshape(x_train, (-1, 784)) / 255.0
    x_test = np.reshape(x_test, (-1, 784)) / 255.0

    # Build model...
    with tf.name_scope("input"):
        image = tf.placeholder(tf.float32, [None, 784], name="image")
        label = tf.placeholder(tf.float32, [None], name="label")
    predict, loss = conv_model(image, label, tf.estimator.ModeKeys.TRAIN)

    lr_scaler = hvd.size()
    # By default, Adasum doesn't need scaling when increasing batch size.
    # If used with NCCL, scale lr by local_size
    if args.use_adasum:
        lr_scaler = hvd.local_size() if hvd.nccl_built() else 1

    # Horovod: adjust learning rate based on lr_scaler.
    opt = tf.train.AdamOptimizer(0.001 * lr_scaler)

    # Use the customized optimizer instead of the DistributedOptimizer
    # from horovod.
    opt = DistributedOptimizer(
        opt,
        op=hvd.Sum,
        backward_passes_per_step=1,
        gradient_predivide_factor=args.gradient_predivide_factor,
        global_batch_count_per_step=WORKER_NUM,
        fixed_global_batch_size=True,
    )

    global_step = tf.train.get_or_create_global_step()
    train_op = opt.minimize(loss, global_step=global_step)

    hooks = [
        # Horovod: BroadcastGlobalVariablesHook broadcasts initial variable
        # states from rank 0 to all other processes. This is necessary to
        # ensure consistent initialization of all workers when training is
        # started with random weights or restored from a checkpoint.
        hvd.BroadcastGlobalVariablesHook(0),
        # Horovod: adjust number of steps based on number of GPUs.
        tf.train.StopAtStepHook(last_step=20000 // hvd.size()),
        tf.train.LoggingTensorHook(
           tensors={"step": global_step, "loss": loss}, every_n_iter=10
        ),
        # Add the hook to update the backward_passes_per_step variable based on
        # the horovod size and the rank of this process.
        AdjustBackwardPassesPerStepHook(
            backward_passes_per_step_var=opt.backward_passes_per_step,
            global_batch_count_per_step=WORKER_NUM,
        ),
    ]

    # Horovod: pin GPU to be used to process local rank (one GPU per process)
    config = tf.ConfigProto()
    config.gpu_options.allow_growth = True
    config.gpu_options.visible_device_list = str(hvd.local_rank())

    # Horovod: save checkpoints only on worker 0 to prevent other workers from
    # corrupting them.
    checkpoint_dir = "./checkpoints" if hvd.rank() == 0 else None
    training_batch_generator = train_input_generator(
        x_train, y_train, batch_size=100
    )
    local_step = 1
    # The MonitoredTrainingSession takes care of session initialization,
    # restoring from a checkpoint, saving to a checkpoint, and closing when
    # done or an error occurs.
    with tf.train.MonitoredTrainingSession(
        checkpoint_dir=checkpoint_dir, hooks=hooks, config=config
    ) as mon_sess:
        while not mon_sess.should_stop():
            # Run a training step synchronously.
            image_, label_ = next(training_batch_generator)
            _, counter_value, backward_passes_per_step_value, global_step_value = mon_sess.run([train_op, opt.counter, opt.backward_passes_per_step, global_step], feed_dict={image: image_, label: label_})
            print("counter_value: {}, backward_passes_per_step_value: {}, global_step_value: {}, local_step: {}".format(counter_value, backward_passes_per_step_value, global_step_value, local_step))
            local_step += 1


if __name__ == "__main__":
    tf.app.run()
```

The sample model definition for elastic training will be submitted in the next PR.