### PR TITLE
Set ENV PYTHONUNBUFFERE=0 in the dockerfile

### DIFF
--- a/elasticdl/docker/Dockerfile
+++ b/elasticdl/docker/Dockerfile
@@ -4,6 +4,10 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as dev
 ARG EXTRA_PYPI_INDEX=https://pypi.org/simple
 
+# Allows for log messages by `print` in Python to be immediately dumped
+# to the stream instead of being buffered.
+ENV PYTHONUNBUFFERED 0
+
 COPY elasticdl/docker/bashrc /etc/bash.bashrc
 RUN chmod a+rx /etc/bash.bashrc
 


### PR DESCRIPTION
Now, the log message will not be dumped in the log of pod if users use `print` in their codes.