### PR TITLE
Use the max completed time of task to check timeout tasks.

### DIFF
--- a/elasticdl/python/master/task_manager.py
+++ b/elasticdl/python/master/task_manager.py
@@ -29,7 +29,7 @@ from elasticdl.python.common.save_utils import CheckpointSaver
 from elasticdl.python.data.reader.data_reader_factory import create_data_reader
 
 _MAX_TASK_RETRIES = 3
-_TASK_TIMEOUT_THRESHOLD = 300
+_TASK_TIMEOUT_THRESHOLD_SECS = 300
 
 
 class _Shard(object):
@@ -506,7 +506,7 @@ class TaskManager(object):
                     elasticdl_pb2.EVALUATION,
                 ]:
                     if cur_time - start_time > max(
-                        _TASK_TIMEOUT_THRESHOLD,
+                        _TASK_TIMEOUT_THRESHOLD_SECS,
                         3 * self._max_task_completed_times[task.type],
                     ):
                         logger.info(

--- a/elasticdl/python/master/task_manager.py
+++ b/elasticdl/python/master/task_manager.py
@@ -482,7 +482,7 @@ class TaskManager(object):
 
     def record_task_completed_time(self, task_type, completed_time):
         self._max_task_completed_times[task_type] = max(
-            self._task_completed_times[task_type], completed_time
+            self._max_task_completed_times[task_type], completed_time
         )
 
     def set_task_timeout_callback(self, callback_fn):

--- a/elasticdl/python/tests/task_manager_test.py
+++ b/elasticdl/python/tests/task_manager_test.py
@@ -154,7 +154,7 @@ class TaskManagerTest(unittest.TestCase):
     def test_get_average_task_completed_time(self):
         task_manager = create_task_manager([("f1", 0, 10), ("f2", 0, 10)], [])
         average_task_completed_time = (
-            task_manager._get_average_task_completed_time()
+            task_manager._get_max_task_completed_time()
         )
         self.assertEqual(
             average_task_completed_time,
@@ -163,7 +163,7 @@ class TaskManagerTest(unittest.TestCase):
         task_manager._task_completed_times[elasticdl_pb2.TRAINING] = [10] * 21
         task_manager._task_completed_times[elasticdl_pb2.EVALUATION] = [5] * 21
         average_task_completed_time = (
-            task_manager._get_average_task_completed_time()
+            task_manager._get_max_task_completed_time()
         )
         self.assertEqual(
             average_task_completed_time,

--- a/elasticdl/python/tests/task_manager_test.py
+++ b/elasticdl/python/tests/task_manager_test.py
@@ -151,22 +151,17 @@ class TaskManagerTest(unittest.TestCase):
         time.sleep(1)  # Sleep 1s to reassgin checkout the timeout task
         self.assertEqual(len(task_manager._todo), task_count)
 
-    def test_get_average_task_completed_time(self):
+    def test_get_max_task_completed_time(self):
         task_manager = create_task_manager([("f1", 0, 10), ("f2", 0, 10)], [])
-        average_task_completed_time = (
-            task_manager._get_max_task_completed_time()
-        )
         self.assertEqual(
-            average_task_completed_time,
-            {elasticdl_pb2.TRAINING: 300, elasticdl_pb2.EVALUATION: 300},
+            task_manager._max_task_completed_times,
+            {elasticdl_pb2.TRAINING: 0, elasticdl_pb2.EVALUATION: 0},
         )
-        task_manager._task_completed_times[elasticdl_pb2.TRAINING] = [10] * 21
-        task_manager._task_completed_times[elasticdl_pb2.EVALUATION] = [5] * 21
-        average_task_completed_time = (
-            task_manager._get_max_task_completed_time()
-        )
+        task_manager.record_task_completed_time(elasticdl_pb2.TRAINING, 10)
+        task_manager.record_task_completed_time(elasticdl_pb2.EVALUATION, 5)
+
         self.assertEqual(
-            average_task_completed_time,
+            task_manager._max_task_completed_times,
             {elasticdl_pb2.TRAINING: 10, elasticdl_pb2.EVALUATION: 5},
         )
 


### PR DESCRIPTION
If the completed time of the task is very small, the timeout will happen frequently.