### PR TITLE
Add the PodStateFlow from PENDING to SUCCEEDED and FAILED.

### DIFF
--- a/elasticdl/python/master/pod_state.py
+++ b/elasticdl/python/master/pod_state.py
@@ -48,6 +48,20 @@ POD_STATE_FLOWS = [
         should_relaunch=False,
     ),
     PodStateFlow(
+        from_status=PodStatus.PENDING,
+        to_status=PodStatus.SUCCEEDED,
+        event_type="MODIFIED",
+        phase="Succeeded",
+        should_relaunch=False,
+    ),
+    PodStateFlow(
+        from_status=PodStatus.PENDING,
+        to_status=PodStatus.FAILED,
+        event_type="MODIFIED",
+        phase="Failed",
+        should_relaunch=True,
+    ),
+    PodStateFlow(
         from_status=PodStatus.RUNNING,
         to_status=PodStatus.SUCCEEDED,
         event_type="MODIFIED",


### PR DESCRIPTION
If the program in the worker pods completes or fails very fast, there will be pending and then succeeded/failed k8s events. And the running event will be missing. For this scenario, we add the pod state transfer logic from pending to succeeded/failed.