### PR TITLE
Add num_minibatches_per_shard param in report_training_params (#2473)

### DIFF
--- a/elasticai_api/common/data_shard_service.py
+++ b/elasticai_api/common/data_shard_service.py
@@ -51,6 +51,7 @@ class DataShardService(object):
         shuffle=False,
         shuffle_shards=False,
         task_type=elasticai_api_pb2.TRAINING,
+        num_minibatches_per_shard=0,
     ):
         self._mc = master_client
         self._batch_size = batch_size
@@ -59,6 +60,7 @@ class DataShardService(object):
         self._shuffle = shuffle
         self._shuffle_shards = shuffle_shards
         self._task_type = task_type
+        self._num_minibatches_per_shard = num_minibatches_per_shard
         self._lock = threading.Lock()
         self._failed_record_count = 0
         self._reported_record_count = 0
@@ -74,6 +76,7 @@ class DataShardService(object):
                 dataset_size=self._dataset_size,
                 shuffle=self._shuffle,
                 shuffle_shards=self._shuffle_shards,
+                num_minibatches_per_shard=self._num_minibatches_per_shard,
             )
 
     def get_current_task(self):

--- a/elasticai_api/common/master_client.py
+++ b/elasticai_api/common/master_client.py
@@ -92,12 +92,12 @@ class MasterClient:
           statistics of the task being executed.
         """
 
-        report = elasticai_api_pb2.ReportTaskResultRequest()
-        report.task_id = task_id
-        report.err_message = err_msg
+        request = elasticai_api_pb2.ReportTaskResultRequest()
+        request.task_id = task_id
+        request.err_message = err_msg
         if isinstance(exec_counters, dict):
-            report.exec_counters.update(exec_counters)
-        return self._stub.report_task_result(report)
+            request.exec_counters.update(exec_counters)
+        return self._stub.report_task_result(request)
 
     def get_comm_rank(self):
         req = elasticai_api_pb2.GetCommRankRequest()
@@ -117,13 +117,15 @@ class MasterClient:
         dataset_size=None,
         shuffle=False,
         shuffle_shards=False,
+        num_minibatches_per_shard=0,
     ):
-        report = elasticai_api_pb2.ReportTrainingParamsRequest()
-        report.batch_size = batch_size
-        report.shuffle = shuffle
-        report.shuffle_shards = shuffle_shards
+        request = elasticai_api_pb2.ReportTrainingParamsRequest()
+        request.batch_size = batch_size
+        request.shuffle = shuffle
+        request.shuffle_shards = shuffle_shards
         if num_epochs is not None:
-            report.num_epochs = num_epochs
+            request.num_epochs = num_epochs
         if dataset_size is not None:
-            report.dataset_size = dataset_size
-        return self._stub.report_training_params(report)
+            request.dataset_size = dataset_size
+        request.num_minibatches_per_shard = num_minibatches_per_shard
+        return self._stub.report_training_params(request)

--- a/elasticai_api/proto/elasticai_api.proto
+++ b/elasticai_api/proto/elasticai_api.proto
@@ -59,6 +59,7 @@ message ReportTrainingParamsRequest {
   int32 dataset_size = 3;
   bool shuffle = 4;
   bool shuffle_shards = 5;
+  int32 num_minibatches_per_shard = 6;
 }
 
 message GetTaskRequest {

--- a/elasticdl/python/master/servicer.py
+++ b/elasticdl/python/master/servicer.py
@@ -173,6 +173,7 @@ class MasterServicer(
             request.dataset_size,
             request.shuffle,
             request.shuffle_shards,
+            request.num_minibatches_per_shard,
         )
         return empty_pb2.Empty()
 

--- a/elasticdl/python/tests/task_manager_test.py
+++ b/elasticdl/python/tests/task_manager_test.py
@@ -169,7 +169,7 @@ class TaskManagerTest(unittest.TestCase):
 
     def test_set_training_params(self):
         task_manager = create_task_manager([], [])
-        task_manager.set_training_params(1, 1, 10, False, False)
+        task_manager.set_training_params(1, 1, 10, False, False, 3)
         self.assertEqual(
             task_manager._training_shards,
             [("", 0, 3), ("", 3, 3), ("", 6, 3), ("", 9, 1)],


### PR DESCRIPTION
* Add num_minibatches_per_shard param in report_training_params

* Pass the value of the num_minibatches_per_shard parameter in master.servicer.report_training_params

* Resolve pre-commit failure.

* Fix typo