### PR TITLE
Implement the fail fast mechanism of master. (#2480)

### DIFF
--- a/elasticdl/python/tests/master_test.py
+++ b/elasticdl/python/tests/master_test.py
@@ -71,7 +71,8 @@ class MasterTest(unittest.TestCase):
             master.stop()
             self.assertEqual(exit_code, 0)
             master.pod_manager.all_workers_failed = True
-            self.assertRaises(RuntimeError, master.run)
+            exit_code = master.run()
+            self.assertEqual(exit_code, 1)
 
     def test_master_validate(self):
         with tempfile.TemporaryDirectory() as temp_dir_name:


### PR DESCRIPTION
* Add TFV1TrainLoopMonitorCallback.

* Remove the parameter num_workers in TFV1TrainLoopMonitorCallback.is_critical_pod

* Update some comments.

* Merge two if conditions into one.

* Composite TFV1PSStrategyTrainLoopMonitorCallback if _is_tfv1_ps_strategy_training is True.

* Set the exit_code according to the success parameter in Master.request_stop.

* Add message content in request_stop.

* Organize the master exit logic.

* Resolve test failure.

* Resolve typo.