### PR TITLE
Relaunch worker on failure

### DIFF
--- a/elasticdl/python/master/pod_manager.py
+++ b/elasticdl/python/master/pod_manager.py
@@ -36,6 +36,7 @@ from elasticdl_client.common.args import parse_envs
 from elasticdl_client.common.constants import (
     BashCommandTemplate,
     ClusterSpecConfig,
+    DistributionStrategy,
 )
 from elasticdl_client.common.k8s_client import (
     ELASTICDL_REPLICA_INDEX_KEY,
@@ -169,6 +170,12 @@ def create_pod_manager(args):
         disable_relaunch = kwargs.get("disable_relaunch", False)
         cluster_spec = get_image_cluster_spec(args.cluster_spec)
 
+        # relaunch on worker failure for PS strategy only
+        if args.distribution_strategy == DistributionStrategy.PARAMETER_SERVER:
+            relaunch_on_worker_failure = args.relaunch_on_worker_failure
+        else:
+            relaunch_on_worker_failure = 0
+
         pod_manager = PodManager(
             job_name=args.job_name,
             image_name=args.worker_image,
@@ -191,7 +198,7 @@ def create_pod_manager(args):
             disable_relaunch=disable_relaunch,
             log_file_path=args.log_file_path,
             need_elasticdl_job_args=args.need_elasticdl_job_service,
-            relaunch_on_worker_failure=args.relaunch_on_worker_failure,
+            relaunch_on_worker_failure=relaunch_on_worker_failure,
         )
 
     return pod_manager

--- a/elasticdl/python/tests/pod_manager_test.py
+++ b/elasticdl/python/tests/pod_manager_test.py
@@ -33,6 +33,7 @@ from elasticdl.python.master.pod_event_callbacks import (
 )
 from elasticdl.python.master.pod_manager import (
     PodManager,
+    WorkerInfo,
     _parse_worker_pod_priority,
     build_environment_variables,
 )
@@ -67,7 +68,9 @@ class PodManagerTest(unittest.TestCase):
                 break
 
         pod_manager._not_created_worker_id = [2]
-        pod_manager._worker_pod_priority_and_original_index[2] = (None, 1)
+        pod_manager._worker_info[2] = WorkerInfo(
+            pod_priority=None, original_index=1, relaunch_count=0
+        )
         pod_manager._process_worker()
         for _ in range(max_check_num):
             time.sleep(3)

--- a/elasticdl_client/common/args.py
+++ b/elasticdl_client/common/args.py
@@ -199,7 +199,8 @@ def add_train_params(parser):
     parser.add_argument(
         "--relaunch_on_worker_failure",
         type=int,
-        help="The number of relaunch tries for a worker failure",
+        help="The number of relaunch tries for a worker failure for "
+        "PS Strategy training",
         default=1,
     )
 

--- a/elasticdl_client/common/args.py
+++ b/elasticdl_client/common/args.py
@@ -196,6 +196,12 @@ def add_train_params(parser):
         help="If true, needs to set TF_CONFIG env for ps/worker. Also "
         "need to use fixed service name for workers",
     )
+    parser.add_argument(
+        "--relaunch_on_worker_failure",
+        type=int,
+        help="The number of relaunch tries for a worker failure",
+        default=1,
+    )
 
 
 def add_evaluate_params(parser):


### PR DESCRIPTION
Sometimes a worker may fail due to some system instability. 
Thus, the master can relaunch a failed worker for at most `relaunch_on_worker_failure` times.
`relaunch_on_worker_failure` default value is 1.
