### PR TITLE
Remove unnecessary Worker param

### DIFF
--- a/elasticdl/python/tests/worker_ps_interaction_test.py
+++ b/elasticdl/python/tests/worker_ps_interaction_test.py
@@ -156,8 +156,6 @@ class WorkerPSInteractionTest(unittest.TestCase):
         model_def = "mnist.mnist_functional_api.custom_model"
         self._create_pserver(model_def, 2)
         arguments = [
-            "--worker_id",
-            0,
             "--job_type",
             elasticai_api_pb2.TRAINING,
             "--minibatch_size",

--- a/elasticdl/python/tests/worker_ps_interaction_test.py
+++ b/elasticdl/python/tests/worker_ps_interaction_test.py
@@ -71,8 +71,6 @@ class WorkerPSInteractionTest(unittest.TestCase):
             tf.keras.backend.clear_session()
             tf.random.set_seed(22)
             arguments = [
-                "--worker_id",
-                i,
                 "--job_type",
                 elasticai_api_pb2.TRAINING,
                 "--minibatch_size",
@@ -208,8 +206,6 @@ class WorkerPSInteractionTest(unittest.TestCase):
         images, labels = get_random_batch(self._batch_size)
         # TODO(yunjian.lmh): test optimizer wrapper
         arguments = [
-            "--worker_id",
-            0,
             "--job_type",
             elasticai_api_pb2.TRAINING,
             "--minibatch_size",
@@ -369,8 +365,6 @@ class WorkerPSInteractionTest(unittest.TestCase):
         for w in range(2):
             self._reset_pserver()
             arguments = [
-                "--worker_id",
-                0,
                 "--job_type",
                 elasticai_api_pb2.TRAINING,
                 "--minibatch_size",


### PR DESCRIPTION
when running test, it will throw warning log. like following. 

`[2021-02-02 18:02:49,547] [WARNING] [args.py:239:parse_worker_args] Unknown arguments: ['--worker_id', '0']`

Actually, worker.py don't use worker_id. it can be removed.